### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hr-skills-ci.yml
+++ b/.github/workflows/hr-skills-ci.yml
@@ -1,5 +1,8 @@
 name: HR Skills CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, dev]


### PR DESCRIPTION
Potential fix for [https://github.com/tuanductran/hr-skills/security/code-scanning/1](https://github.com/tuanductran/hr-skills/security/code-scanning/1)

In general, the fix is to explicitly define a minimal `permissions` block for the workflow or for each job, instead of relying on implicit repository/organization defaults. Since none of the jobs perform any write operations against the GitHub API and only need to read the repository contents, we can safely set `contents: read` as the global default permissions for the workflow.

The best fix without changing existing functionality is to add a top-level `permissions` section right after the `name` (or before `jobs`) in `.github/workflows/hr-skills-ci.yml`:

```yaml
permissions:
  contents: read
```

This will apply to all jobs (`validate`, `lint-markdown`, `lint`, `typecheck`) because none of them define their own `permissions`. No other lines need to change, and no additional imports or methods are required, since this is purely a YAML configuration adjustment within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
