### PR TITLE
fix(hr-skills-build): support CRLF in skill parsing regex

### DIFF
--- a/packages/hr-skills-build/src/utils.ts
+++ b/packages/hr-skills-build/src/utils.ts
@@ -10,22 +10,22 @@
 // -----------------------------------------------------------------------------
 
 /** Matches the full YAML frontmatter block including delimiters. */
-export const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---/;
+export const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
 
 /** Matches `name: <value>` in frontmatter. */
-export const NAME_REGEX = /^name:[ \t]*(.+)$/m;
+export const NAME_REGEX = /^name:[ \t]*(.+)\r?$/m;
 
 /** Matches `description: <value>` in frontmatter. */
-export const DESCRIPTION_REGEX = /^description:[ \t]*(.+)$/m;
+export const DESCRIPTION_REGEX = /^description:[ \t]*(.+)\r?$/m;
 
 /** Matches `  author: <value>` (indented) in frontmatter. */
-export const AUTHOR_REGEX = /^[ \t]+author:[ \t]*(.+)$/m;
+export const AUTHOR_REGEX = /^[ \t]+author:[ \t]*(.+)\r?$/m;
 
 /** Matches `  version: <value>` (indented, optionally quoted) in frontmatter. */
-export const VERSION_REGEX = /^[ \t]+version:[ \t]*"?(.+?)"?$/m;
+export const VERSION_REGEX = /^[ \t]+version:[ \t]*"?(.+?)"?\r?$/m;
 
 /** Matches the `## Supported tasks` block content. */
-export const TASKS_REGEX = /## Supported tasks\n\n([\s\S]*?)(?=\n##|$)/;
+export const TASKS_REGEX = /## Supported tasks\r?\n\r?\n([\s\S]*?)(?=\r?\n##|$)/;
 
 // -----------------------------------------------------------------------------
 // Helpers

--- a/packages/hr-skills-build/test/utils.test.ts
+++ b/packages/hr-skills-build/test/utils.test.ts
@@ -24,6 +24,8 @@ metadata:
 - Doing another useful thing
 `;
 
+const SAMPLE_FRONTMATTER_CRLF = SAMPLE_FRONTMATTER.replaceAll('\n', '\r\n');
+
 describe('extractMatch', () => {
 	it('returns the first capture group when regex matches', () => {
 		const result = extractMatch(/^name:[ \t]*(.+)$/m, 'name: hr-test');
@@ -60,6 +62,13 @@ describe('FRONTMATTER_REGEX', () => {
 
 		expect(result).toBeNull();
 	});
+
+	it('matches valid frontmatter block with CRLF line endings', () => {
+		const match = extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER_CRLF);
+
+		expect(match).not.toBeNull();
+		expect(match).toContain('name: hr-test');
+	});
 });
 
 describe('NAME_REGEX', () => {
@@ -72,11 +81,27 @@ describe('NAME_REGEX', () => {
 	it('returns null when name field is absent', () => {
 		expect(extractMatch(NAME_REGEX, 'description: something')).toBeNull();
 	});
+
+	it('extracts skill name from CRLF frontmatter', () => {
+		const frontmatter =
+			extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER_CRLF) ?? '';
+
+		expect(extractMatch(NAME_REGEX, frontmatter)).toBe('hr-test');
+	});
 });
 
 describe('DESCRIPTION_REGEX', () => {
 	it('extracts description from frontmatter', () => {
 		const frontmatter = extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER) ?? '';
+
+		expect(extractMatch(DESCRIPTION_REGEX, frontmatter)).toBe(
+			'A test HR skill for validation purposes',
+		);
+	});
+
+	it('extracts description from CRLF frontmatter', () => {
+		const frontmatter =
+			extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER_CRLF) ?? '';
 
 		expect(extractMatch(DESCRIPTION_REGEX, frontmatter)).toBe(
 			'A test HR skill for validation purposes',
@@ -94,6 +119,13 @@ describe('AUTHOR_REGEX', () => {
 	it('returns null when author is not present', () => {
 		expect(extractMatch(AUTHOR_REGEX, 'name: hr-test\ndescription: desc')).toBeNull();
 	});
+
+	it('extracts indented author value from CRLF frontmatter', () => {
+		const frontmatter =
+			extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER_CRLF) ?? '';
+
+		expect(extractMatch(AUTHOR_REGEX, frontmatter)).toBe('Tuan Duc Tran');
+	});
 });
 
 describe('VERSION_REGEX', () => {
@@ -109,6 +141,13 @@ describe('VERSION_REGEX', () => {
 
 		expect(extractMatch(VERSION_REGEX, frontmatter)).toBe('2.0.0');
 	});
+
+	it('extracts version from CRLF frontmatter', () => {
+		const frontmatter =
+			extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER_CRLF) ?? '';
+
+		expect(extractMatch(VERSION_REGEX, frontmatter)).toBe('1.0.0');
+	});
 });
 
 describe('TASKS_REGEX', () => {
@@ -123,5 +162,12 @@ describe('TASKS_REGEX', () => {
 		const result = extractMatch(TASKS_REGEX, '## Key prompts\n\nSome content\n');
 
 		expect(result).toBeNull();
+	});
+
+	it('extracts supported tasks block with CRLF line endings', () => {
+		const result = extractMatch(TASKS_REGEX, SAMPLE_FRONTMATTER_CRLF);
+
+		expect(result).not.toBeNull();
+		expect(result).toContain('Doing something useful');
 	});
 });


### PR DESCRIPTION
### Motivation

- Skill parsing currently assumed LF (`\n`) line endings which fails on CRLF (`\r\n`) files produced on Windows.  
- Frontmatter and section extraction must be robust to both line ending styles to avoid false negatives during validation and cataloging.  

### Description

- Update `FRONTMATTER_REGEX` in `packages/hr-skills-build/src/utils.ts` to allow `\r?\n` around the frontmatter delimiters.  
- Update `TASKS_REGEX` to accept either `\n` or `\r\n` between the header and block and when looking ahead to the next section.  
- Make line-anchored field regexes `NAME_REGEX`, `DESCRIPTION_REGEX`, `AUTHOR_REGEX`, and `VERSION_REGEX` tolerate an optional `\r` before end-of-line.  
- Add CRLF-focused test cases in `packages/hr-skills-build/test/utils.test.ts` that exercise `FRONTMATTER_REGEX`, `NAME_REGEX`, `DESCRIPTION_REGEX`, `AUTHOR_REGEX`, `VERSION_REGEX`, and `TASKS_REGEX` using a CRLF fixture.  

### Testing

- Ran `bun test packages/hr-skills-build/test/utils.test.ts` and all tests passed.  
- Ran `bun run validate` and the validation completed successfully with all HR skills reported valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15867bc2488327879cf21a1a36d5eb)