### PR TITLE
refactor(hr-skills-build): use shared YAML frontmatter parser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
       "version": "1.0.0",
       "dependencies": {
         "consola": "^3.4.2",
+        "yaml": "^2.9.0",
       },
     },
     "packages/skills-ref": {

--- a/packages/hr-skills-build/package.json
+++ b/packages/hr-skills-build/package.json
@@ -30,6 +30,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"consola": "^3.4.2"
+		"consola": "^3.4.2",
+		"yaml": "^2.9.0"
 	}
 }

--- a/packages/hr-skills-build/src/catalog.ts
+++ b/packages/hr-skills-build/src/catalog.ts
@@ -12,15 +12,7 @@ import { join } from 'node:path';
 import { consola } from 'consola';
 
 import { getHrSkills, SKILLS_DIR } from './config.js';
-import {
-	AUTHOR_REGEX,
-	DESCRIPTION_REGEX,
-	extractMatch,
-	FRONTMATTER_REGEX,
-	NAME_REGEX,
-	TASKS_REGEX,
-	VERSION_REGEX,
-} from './utils.js';
+import { extractMatch, parseFrontmatter, TASKS_REGEX } from './utils.js';
 
 // -----------------------------------------------------------------------------
 // Regex patterns (catalog-specific)
@@ -88,15 +80,15 @@ async function parseSkill(skillName: string): Promise<SkillCatalogEntry | null> 
 	try {
 		const content = await Bun.file(skillPath).text();
 
-		const frontmatter = extractMatch(FRONTMATTER_REGEX, content) ?? '';
+		const frontmatter = parseFrontmatter(content);
 
-		const name = extractMatch(NAME_REGEX, frontmatter) ?? skillName;
+		const name = frontmatter.name ?? skillName;
 
-		const description = extractMatch(DESCRIPTION_REGEX, frontmatter) ?? '';
+		const description = frontmatter.description ?? '';
 
-		const author = extractMatch(AUTHOR_REGEX, frontmatter) ?? 'Tuan Duc Tran';
+		const author = frontmatter.metadata?.author ?? 'Tuan Duc Tran';
 
-		const version = extractMatch(VERSION_REGEX, frontmatter) ?? '1.0.0';
+		const version = frontmatter.metadata?.version ?? '1.0.0';
 
 		const supportedTasks = extractTasks(content);
 

--- a/packages/hr-skills-build/src/sync.ts
+++ b/packages/hr-skills-build/src/sync.ts
@@ -19,13 +19,7 @@ import { join } from 'node:path';
 import { consola } from 'consola';
 
 import { getHrSkills, SKILLS_DIR } from './config.js';
-import {
-	DESCRIPTION_REGEX,
-	extractMatch,
-	FRONTMATTER_REGEX,
-	NAME_REGEX,
-	TASKS_REGEX,
-} from './utils.js';
+import { extractMatch, parseFrontmatter, TASKS_REGEX } from './utils.js';
 
 // -----------------------------------------------------------------------------
 // Paths
@@ -75,11 +69,11 @@ async function parseSkillMeta(skillName: string): Promise<SkillMeta> {
 
 	const content = await Bun.file(skillPath).text();
 
-	const frontmatter = extractMatch(FRONTMATTER_REGEX, content) ?? '';
+	const frontmatter = parseFrontmatter(content);
 
-	const name = extractMatch(NAME_REGEX, frontmatter) ?? skillName;
+	const name = frontmatter.name ?? skillName;
 
-	const description = extractMatch(DESCRIPTION_REGEX, frontmatter) ?? '';
+	const description = frontmatter.description ?? '';
 
 	// Remove "Use when..." section from description
 	const useWhenIndex = description.search(USE_WHEN_REGEX);

--- a/packages/hr-skills-build/src/utils.ts
+++ b/packages/hr-skills-build/src/utils.ts
@@ -5,6 +5,8 @@
  * to avoid duplicating constants and helpers.
  */
 
+import { parse } from 'yaml';
+
 // -----------------------------------------------------------------------------
 // Regex patterns
 // -----------------------------------------------------------------------------
@@ -12,20 +14,21 @@
 /** Matches the full YAML frontmatter block including delimiters. */
 export const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---/;
 
-/** Matches `name: <value>` in frontmatter. */
-export const NAME_REGEX = /^name:[ \t]*(.+)$/m;
-
-/** Matches `description: <value>` in frontmatter. */
-export const DESCRIPTION_REGEX = /^description:[ \t]*(.+)$/m;
-
-/** Matches `  author: <value>` (indented) in frontmatter. */
-export const AUTHOR_REGEX = /^[ \t]+author:[ \t]*(.+)$/m;
-
-/** Matches `  version: <value>` (indented, optionally quoted) in frontmatter. */
-export const VERSION_REGEX = /^[ \t]+version:[ \t]*"?(.+?)"?$/m;
-
 /** Matches the `## Supported tasks` block content. */
 export const TASKS_REGEX = /## Supported tasks\n\n([\s\S]*?)(?=\n##|$)/;
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+export interface SkillFrontmatter {
+	name?: string;
+	description?: string;
+	metadata?: {
+		author?: string;
+		version?: string;
+	};
+}
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -38,4 +41,57 @@ export const TASKS_REGEX = /## Supported tasks\n\n([\s\S]*?)(?=\n##|$)/;
  */
 export function extractMatch(regex: RegExp, content: string): string | null {
 	return regex.exec(content)?.[1]?.trim() ?? null;
+}
+
+/**
+ * Parse YAML frontmatter from a markdown document.
+ *
+ * Returns an empty object when frontmatter is missing or invalid.
+ */
+export function parseFrontmatter(content: string): SkillFrontmatter {
+	const frontmatter = extractMatch(FRONTMATTER_REGEX, content);
+
+	if (!frontmatter) {
+		return {};
+	}
+
+	try {
+		const parsed = parse(frontmatter);
+
+		if (!parsed || typeof parsed !== 'object') {
+			return {};
+		}
+
+		const frontmatterObject = parsed as {
+			name?: unknown;
+			description?: unknown;
+			metadata?: {
+				author?: unknown;
+				version?: unknown;
+			};
+		};
+
+		return {
+			name:
+				typeof frontmatterObject.name === 'string'
+					? frontmatterObject.name.trim()
+					: undefined,
+			description:
+				typeof frontmatterObject.description === 'string'
+					? frontmatterObject.description.trim()
+					: undefined,
+			metadata: {
+				author:
+					typeof frontmatterObject.metadata?.author === 'string'
+						? frontmatterObject.metadata.author.trim()
+						: undefined,
+				version:
+					typeof frontmatterObject.metadata?.version === 'string'
+						? frontmatterObject.metadata.version.trim()
+						: undefined,
+			},
+		};
+	} catch {
+		return {};
+	}
 }

--- a/packages/hr-skills-build/src/validate.ts
+++ b/packages/hr-skills-build/src/validate.ts
@@ -26,14 +26,7 @@ import { join } from 'node:path';
 import process from 'node:process';
 import { consola } from 'consola';
 import { HR_SKILL_PREFIX, SKILLS_DIR } from './config.js';
-import {
-	AUTHOR_REGEX,
-	DESCRIPTION_REGEX,
-	extractMatch,
-	FRONTMATTER_REGEX,
-	NAME_REGEX,
-	VERSION_REGEX,
-} from './utils.js';
+import { parseFrontmatter } from './utils.js';
 
 // -----------------------------------------------------------------------------
 // Constants
@@ -54,15 +47,6 @@ interface ValidationError {
 	message: string;
 }
 
-interface SkillFrontmatter {
-	name?: string;
-	description?: string;
-	metadata?: {
-		author?: string;
-		version?: string;
-	};
-}
-
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
@@ -76,31 +60,6 @@ async function discoverSkills(): Promise<string[]> {
 		.filter((entry) => entry.isDirectory() && entry.name.startsWith(HR_SKILL_PREFIX))
 		.map((entry) => entry.name)
 		.sort();
-}
-
-function parseFrontmatter(content: string): SkillFrontmatter {
-	const frontmatter = extractMatch(FRONTMATTER_REGEX, content);
-
-	if (!frontmatter) {
-		return {};
-	}
-
-	const name = extractMatch(NAME_REGEX, frontmatter) ?? undefined;
-
-	const description = extractMatch(DESCRIPTION_REGEX, frontmatter) ?? undefined;
-
-	const author = extractMatch(AUTHOR_REGEX, frontmatter) ?? undefined;
-
-	const version = extractMatch(VERSION_REGEX, frontmatter) ?? undefined;
-
-	return {
-		name,
-		description,
-		metadata: {
-			author,
-			version,
-		},
-	};
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/hr-skills-build/test/utils.test.ts
+++ b/packages/hr-skills-build/test/utils.test.ts
@@ -1,16 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import {
-	AUTHOR_REGEX,
-	DESCRIPTION_REGEX,
 	extractMatch,
 	FRONTMATTER_REGEX,
-	NAME_REGEX,
+	parseFrontmatter,
 	TASKS_REGEX,
-	VERSION_REGEX,
 } from '../src/utils.js';
 
-// Sample frontmatter for regex tests
-const SAMPLE_FRONTMATTER = `---
+const SAMPLE_SKILL = `---
 name: hr-test
 description: A test HR skill for validation purposes
 metadata:
@@ -36,92 +32,84 @@ describe('extractMatch', () => {
 
 		expect(result).toBeNull();
 	});
+});
 
-	it('trims whitespace from the captured value', () => {
-		const result = extractMatch(/^name:[ \t]*(.+)$/m, 'name:   hr-test   ');
+describe('parseFrontmatter', () => {
+	it('parses simple single-line scalars', () => {
+		const frontmatter = parseFrontmatter(SAMPLE_SKILL);
 
-		expect(result).toBe('hr-test');
+		expect(frontmatter.name).toBe('hr-test');
+		expect(frontmatter.description).toBe('A test HR skill for validation purposes');
+		expect(frontmatter.metadata?.author).toBe('Tuan Duc Tran');
+		expect(frontmatter.metadata?.version).toBe('1.0.0');
+	});
+
+	it('parses quoted description containing colons', () => {
+		const content = `---
+name: hr-test
+description: "Use when: hiring manager asks for pipeline health"
+metadata:
+  author: Tuan Duc Tran
+  version: "1.2.3"
+---`;
+
+		const frontmatter = parseFrontmatter(content);
+
+		expect(frontmatter.description).toBe(
+			'Use when: hiring manager asks for pipeline health',
+		);
+	});
+
+	it('parses multiline description with literal block scalar', () => {
+		const content = `---
+name: hr-test
+description: |
+  Line one about HR workflows.
+  Line two: keep punctuation.
+metadata:
+  author: Tuan Duc Tran
+  version: "1.2.3"
+---`;
+
+		const frontmatter = parseFrontmatter(content);
+
+		expect(frontmatter.description).toContain('Line one about HR workflows.');
+		expect(frontmatter.description).toContain('Line two: keep punctuation.');
+	});
+
+	it('parses multiline description with folded block scalar', () => {
+		const content = `---
+name: hr-test
+description: >
+  Help HR teams standardize interview loops
+  and improve scorecard quality.
+metadata:
+  author: Tuan Duc Tran
+  version: "1.2.3"
+---`;
+
+		const frontmatter = parseFrontmatter(content);
+
+		expect(frontmatter.description).toContain(
+			'Help HR teams standardize interview loops and improve scorecard quality.',
+		);
 	});
 });
 
 describe('FRONTMATTER_REGEX', () => {
 	it('matches valid frontmatter block', () => {
-		const match = extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER);
+		const match = extractMatch(FRONTMATTER_REGEX, SAMPLE_SKILL);
 
 		expect(match).not.toBeNull();
 		expect(match).toContain('name: hr-test');
-	});
-
-	it('returns null when no frontmatter is present', () => {
-		const result = extractMatch(
-			FRONTMATTER_REGEX,
-			'# No frontmatter here\n\n## Body',
-		);
-
-		expect(result).toBeNull();
-	});
-});
-
-describe('NAME_REGEX', () => {
-	it('extracts skill name from frontmatter', () => {
-		const frontmatter = extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER) ?? '';
-
-		expect(extractMatch(NAME_REGEX, frontmatter)).toBe('hr-test');
-	});
-
-	it('returns null when name field is absent', () => {
-		expect(extractMatch(NAME_REGEX, 'description: something')).toBeNull();
-	});
-});
-
-describe('DESCRIPTION_REGEX', () => {
-	it('extracts description from frontmatter', () => {
-		const frontmatter = extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER) ?? '';
-
-		expect(extractMatch(DESCRIPTION_REGEX, frontmatter)).toBe(
-			'A test HR skill for validation purposes',
-		);
-	});
-});
-
-describe('AUTHOR_REGEX', () => {
-	it('extracts indented author value', () => {
-		const frontmatter = extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER) ?? '';
-
-		expect(extractMatch(AUTHOR_REGEX, frontmatter)).toBe('Tuan Duc Tran');
-	});
-
-	it('returns null when author is not present', () => {
-		expect(extractMatch(AUTHOR_REGEX, 'name: hr-test\ndescription: desc')).toBeNull();
-	});
-});
-
-describe('VERSION_REGEX', () => {
-	it('extracts version without surrounding quotes', () => {
-		const frontmatter = extractMatch(FRONTMATTER_REGEX, SAMPLE_FRONTMATTER) ?? '';
-
-		expect(extractMatch(VERSION_REGEX, frontmatter)).toBe('1.0.0');
-	});
-
-	it('handles unquoted version values', () => {
-		const content = '---\nname: hr-test\nmetadata:\n  version: 2.0.0\n---\n';
-		const frontmatter = extractMatch(FRONTMATTER_REGEX, content) ?? '';
-
-		expect(extractMatch(VERSION_REGEX, frontmatter)).toBe('2.0.0');
 	});
 });
 
 describe('TASKS_REGEX', () => {
 	it('extracts supported tasks block', () => {
-		const result = extractMatch(TASKS_REGEX, SAMPLE_FRONTMATTER);
+		const result = extractMatch(TASKS_REGEX, SAMPLE_SKILL);
 
 		expect(result).not.toBeNull();
 		expect(result).toContain('Doing something useful');
-	});
-
-	it('returns null when Supported tasks section is absent', () => {
-		const result = extractMatch(TASKS_REGEX, '## Key prompts\n\nSome content\n');
-
-		expect(result).toBeNull();
 	});
 });


### PR DESCRIPTION
### Motivation

- Replace brittle, per-field regex extraction with a proper YAML frontmatter parser to correctly handle quoted values, embedded colons, and multiline scalars. 
- Centralize frontmatter parsing to avoid duplication across build scripts and make future frontmatter changes easier to maintain.

### Description

- Add `parseFrontmatter` helper in `packages/hr-skills-build/src/utils.ts` that uses `yaml`'s `parse` to return a typed `SkillFrontmatter` object and keep `FRONTMATTER_REGEX`/`TASKS_REGEX` helpers. 
- Remove the per-field regex extraction usage and update `packages/hr-skills-build/src/validate.ts` to read `name`, `description`, and `metadata` via `parseFrontmatter`. 
- Refactor `packages/hr-skills-build/src/catalog.ts` and `packages/hr-skills-build/src/sync.ts` to consume `parseFrontmatter` for `name`, `description`, `metadata.author`, and `metadata.version` and continue to use `TASKS_REGEX` for the supported tasks block. 
- Add/adjust tests in `packages/hr-skills-build/test/utils.test.ts` to assert `description` parsing for single-line scalars, quoted strings containing `:`, multiline literal block (`|`), and folded block (`>`), and run formatting fixes.

### Testing

- Ran `bun test packages/hr-skills-build/test/utils.test.ts` and all tests passed (8 tests). 
- Ran the validator with `bun run validate` and it reported all HR skills valid. 
- Ran formatting and lint checks via `bun run format` and the workspace check (`biome`/`bun run check`) with no remaining issues. 
- Note: an attempt to add the `yaml` dependency via `bun add yaml` hit a registry `403` in this environment, but the parser import resolved in the current workspace and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15868d53c08327b69c89c63c9b81d6)