### PR TITLE
fix(hr-skills-build): remove trigger placeholder from docs sync

### DIFF
--- a/packages/hr-skills-build/src/sync.ts
+++ b/packages/hr-skills-build/src/sync.ts
@@ -56,7 +56,7 @@ const TASK_ITEM_REGEX = /^- /;
 // Types
 // -----------------------------------------------------------------------------
 
-interface SkillMeta {
+export interface SkillMeta {
 	name: string;
 	description: string;
 	coverage: string;
@@ -223,7 +223,30 @@ async function syncInstallationTable(metas: SkillMeta[]): Promise<boolean> {
 // docs/skills.md sync
 // -----------------------------------------------------------------------------
 
-async function syncSkillsDocs(metas: SkillMeta[]): Promise<boolean> {
+export function buildSkillDocsSection(meta: SkillMeta): string | null {
+	if (meta.triggerPhrases.length === 0) {
+		return null;
+	}
+
+	const triggerList = meta.triggerPhrases.map((phrase) => `- "${phrase}"`).join('\n');
+
+	const heading = `## ${meta.name}`;
+
+	return [
+		'',
+		'---',
+		'',
+		heading,
+		'',
+		`**What it covers:** ${meta.coverage}.`,
+		'',
+		'**Use when you say:**',
+		'',
+		triggerList,
+	].join('\n');
+}
+
+export async function syncSkillsDocs(metas: SkillMeta[]): Promise<boolean> {
 	const path = join(ROOT, 'docs/skills.md');
 
 	let content = await Bun.file(path).text();
@@ -237,23 +260,14 @@ async function syncSkillsDocs(metas: SkillMeta[]): Promise<boolean> {
 			continue;
 		}
 
-		const triggerList =
-			meta.triggerPhrases.length > 0
-				? meta.triggerPhrases.map((phrase) => `- "${phrase}"`).join('\n')
-				: '- [Add trigger phrases here]';
+		const section = buildSkillDocsSection(meta);
 
-		const section = [
-			'',
-			'---',
-			'',
-			heading,
-			'',
-			`**What it covers:** ${meta.coverage}.`,
-			'',
-			'**Use when you say:**',
-			'',
-			triggerList,
-		].join('\n');
+		if (!section) {
+			consola.warn(
+				`Skipping docs/skills.md section for ${meta.name}: no trigger phrases found in SKILL.md`,
+			);
+			continue;
+		}
 
 		content = `${content.trimEnd()}${section}\n`;
 
@@ -273,7 +287,7 @@ async function syncSkillsDocs(metas: SkillMeta[]): Promise<boolean> {
 // Main
 // -----------------------------------------------------------------------------
 
-async function sync(): Promise<void> {
+export async function sync(): Promise<void> {
 	consola.start('Syncing HR skills project...');
 
 	const skillNames = await getHrSkills();
@@ -317,4 +331,6 @@ async function sync(): Promise<void> {
 	consola.success('Sync complete');
 }
 
-void sync();
+if (import.meta.main) {
+	void sync();
+}

--- a/packages/hr-skills-build/test/sync.test.ts
+++ b/packages/hr-skills-build/test/sync.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+import { buildSkillDocsSection } from '../src/sync.js';
+
+const baseMeta = {
+	name: 'hr-test',
+	description: 'desc',
+	coverage: 'help hr teams with testing sync behavior',
+	shortSummary: 'summary',
+	scopeSentence: 'Help hr teams with testing sync behavior.',
+	supportedTasks: ['Task 1'],
+};
+
+describe('buildSkillDocsSection', () => {
+	it('skips section when no trigger phrases are available', () => {
+		const section = buildSkillDocsSection({
+			...baseMeta,
+			triggerPhrases: [],
+		});
+
+		expect(section).toBeNull();
+	});
+
+	it('never emits the legacy placeholder trigger line', () => {
+		const section = buildSkillDocsSection({
+			...baseMeta,
+			triggerPhrases: ['Write a PIP for [employee_name]'],
+		});
+
+		expect(section).not.toBeNull();
+		expect(section).not.toContain('- [Add trigger phrases here]');
+		expect(section).toContain('- "Write a PIP for [employee_name]"');
+	});
+});


### PR DESCRIPTION
### Motivation

- Prevent `docs/skills.md` from being populated with the legacy placeholder `- [Add trigger phrases here]` so published docs never include a filler item. 
- Prefer failing noisily or forcing authors to update `SKILL.md` content; the implemented strategy skips creating a section and logs a clear warning for skills that lack trigger phrases. 
- Add a regression test to ensure the placeholder cannot reappear after running the sync logic. 

### Description

- Add a new helper `buildSkillDocsSection(meta: SkillMeta): string | null` that returns `null` when `meta.triggerPhrases` is empty and otherwise builds the docs section. 
- Update `syncSkillsDocs` to call `buildSkillDocsSection` and to `consola.warn` and skip the section when the helper returns `null`, removing the previous `- [Add trigger phrases here]` fallback. 
- Export `SkillMeta`, `buildSkillDocsSection`, `syncSkillsDocs`, and `sync` and guard `sync()` execution with `if (import.meta.main)` to make the logic testable. 
- Add regression tests in `packages/hr-skills-build/test/sync.test.ts` that assert sections are skipped when no triggers exist and that the legacy placeholder is never emitted. 

### Testing

- Ran `bun test packages/hr-skills-build/test/sync.test.ts` and the two new tests passed. 
- Ran `bun test packages/hr-skills-build/test` and the full suite passed with no failures. 
- All assertions in the updated test suite succeeded (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15869df2c08327b23704864aa01f26)