### PR TITLE
fix(hr-skills-build): fail sync on table marker drift

### DIFF
--- a/packages/hr-skills-build/src/sync.ts
+++ b/packages/hr-skills-build/src/sync.ts
@@ -167,10 +167,32 @@ async function syncMarketplace(metas: SkillMeta[]): Promise<boolean> {
 // AGENTS.md sync
 // -----------------------------------------------------------------------------
 
+function assertTemplateMarkerExists(
+	content: string,
+	regex: RegExp,
+	filePath: string,
+	markerName: string,
+): void {
+	if (regex.test(content)) {
+		return;
+	}
+
+	throw new Error(
+		`Template drift detected in ${filePath}: missing ${markerName} marker table. Restore the expected table header in ${filePath} before running bun run sync.`,
+	);
+}
+
 async function syncAgentsTable(metas: SkillMeta[]): Promise<boolean> {
 	const path = join(ROOT, 'AGENTS.md');
 
 	const original = await Bun.file(path).text();
+
+	assertTemplateMarkerExists(
+		original,
+		AGENTS_TABLE_REGEX,
+		'AGENTS.md',
+		'AGENTS_TABLE_REGEX',
+	);
 
 	const tableHeader = '| Skill | Scope |\n|-------|-------|';
 
@@ -199,6 +221,13 @@ async function syncInstallationTable(metas: SkillMeta[]): Promise<boolean> {
 	const path = join(ROOT, 'docs/installation.md');
 
 	const original = await Bun.file(path).text();
+
+	assertTemplateMarkerExists(
+		original,
+		INSTALLATION_TABLE_REGEX,
+		'docs/installation.md',
+		'INSTALLATION_TABLE_REGEX',
+	);
 
 	const tableHeader = '| Skill | What it covers |\n|----------------|--------|';
 
@@ -317,4 +346,8 @@ async function sync(): Promise<void> {
 	consola.success('Sync complete');
 }
 
-void sync();
+if (import.meta.main) {
+	void sync();
+}
+
+export { assertTemplateMarkerExists };

--- a/packages/hr-skills-build/test/sync.test.ts
+++ b/packages/hr-skills-build/test/sync.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test';
+
+import { assertTemplateMarkerExists } from '../src/sync.js';
+
+describe('assertTemplateMarkerExists', () => {
+	it('does not throw when AGENTS table marker matches', () => {
+		const content = [
+			'# AGENTS',
+			'',
+			'| Skill | Scope |',
+			'|-------|-------|',
+			'| **hr-ai** | Scope. |',
+			'',
+			'## Next section',
+		].join('\n');
+
+		expect(() =>
+			assertTemplateMarkerExists(
+				content,
+				/\| Skill \| Scope \|\n\|[-|]+\|\n[\s\S]*?(?=\n## )/,
+				'AGENTS.md',
+				'AGENTS_TABLE_REGEX',
+			),
+		).not.toThrow();
+	});
+
+	it('throws actionable error when AGENTS marker drifts', () => {
+		const content = [
+			'# AGENTS',
+			'',
+			'| Skill name | Scope |',
+			'|------------|-------|',
+			'| **hr-ai** | Scope. |',
+			'',
+			'## Next section',
+		].join('\n');
+
+		expect(() =>
+			assertTemplateMarkerExists(
+				content,
+				/\| Skill \| Scope \|\n\|[-|]+\|\n[\s\S]*?(?=\n## )/,
+				'AGENTS.md',
+				'AGENTS_TABLE_REGEX',
+			),
+		).toThrow(
+			'Template drift detected in AGENTS.md: missing AGENTS_TABLE_REGEX marker table. Restore the expected table header in AGENTS.md before running bun run sync.',
+		);
+	});
+
+	it('throws actionable error when installation marker drifts', () => {
+		const content = [
+			'# Installation',
+			'',
+			'| Skill | Coverage |',
+			'|-------|----------|',
+			'| `hr-ai` | Summary |',
+			'',
+			'See [skills.md](./skills.md)',
+		].join('\n');
+
+		expect(() =>
+			assertTemplateMarkerExists(
+				content,
+				/\| Skill \| What it covers \|\n\|[-|]+\|\n[\s\S]*?(?=\nSee \[skills\.md\])/,
+				'docs/installation.md',
+				'INSTALLATION_TABLE_REGEX',
+			),
+		).toThrow(
+			'Template drift detected in docs/installation.md: missing INSTALLATION_TABLE_REGEX marker table. Restore the expected table header in docs/installation.md before running bun run sync.',
+		);
+	});
+});


### PR DESCRIPTION
### Motivation

- Prevent the `bun run sync` script from silently doing nothing when the expected table markers in documentation drift. 
- Provide actionable errors so maintainers can restore the expected table headers before running the sync. 
- Make importing `sync` safe for tests by preventing side effects when the module is imported.

### Description

- Add `assertTemplateMarkerExists(content, regex, filePath, markerName)` in `packages/hr-skills-build/src/sync.ts` to validate marker presence and throw an actionable error on mismatch. 
- Invoke the assertion before replacing content in both `syncAgentsTable` (checks `AGENTS_TABLE_REGEX`) and `syncInstallationTable` (checks `INSTALLATION_TABLE_REGEX`), and export the helper for testing. 
- Run `sync()` only when the script is executed as the main module via `if (import.meta.main) { void sync(); }`, and add unit tests in `packages/hr-skills-build/test/sync.test.ts` that cover matching markers and template-drift failures.

### Testing

- Ran `bun test packages/hr-skills-build/test/sync.test.ts` which executed 3 tests and all passed (`3 pass`, `0 fail`).
- Ran `bun run check` which ran `biome check` and reported no fixes applied.
- The new tests exercise `assertTemplateMarkerExists` for both AGENTS and installation table regexes and validate the thrown actionable error messages when markers are missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1586adb3b8832796eda12622aaddf3)