### PR TITLE
docs: align agent guidance with project tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,34 +63,50 @@ build(skills-ref): switch build target to bun
 ci: add Biome job to hr-skills-ci workflow
 ```
 
-After completing any task, validate skills and run the linter:
+Use these project commands from the repository root. After completing any task, validate the affected area and run the relevant lint checks:
 
 ```bash
 bun install          # Install all dependencies (run once, or after package changes)
-bun run sync         # Sync skill references across all docs (run after adding/removing a skill)
+bun run sync         # Sync generated skill references after adding/removing a skill
 bun run validate     # Validate all skill SKILL.md files
+bun run catalog      # Regenerate skills/CATALOG.md
+bun run zip          # Generate cross-platform distributable skill zip packages
+bun run test         # Run tests across workspace packages
+bun run typecheck    # Run type-checking across workspace packages
+bun run build        # Run all workspace build tasks through Turborepo
 bun run check        # Run Biome checks without writing changes
 bun run lint         # Run Biome checks with auto-fix
 bun run format       # Format files with Biome formatter
 bun run lint:md      # markdownlint + case-police on Markdown files
 bun run lint:md:fix  # Markdown lint with auto-fix
-bun run typecheck    # Run type-checking across workspace packages
-bun run build        # Run all workspace build tasks through Turborepo
-bun run catalog      # Regenerate the generated skills catalog
-bun run zip          # Generate cross-platform distributable skill zip packages
+bun run lint:links   # Check Markdown links in content, docs, and skills
+bun run knip         # Detect unused files and dependencies
+bun run release      # Release only: bump version, generate changelog, commit, tag, and push
 ```
 
-Build, test, and typecheck tasks are orchestrated through Turborepo.
+Build, test, typecheck, validate, catalog, and sync tasks are orchestrated through Turborepo.
 
-Tasks may run in parallel and use local caching based on `turbo.json`.
+Tasks may run in parallel and use local caching based on `turbo.jsonc`.
 
-When you add a new skill directory (for example `skills/hr-new-skill/SKILL.md`), run `bun run sync` first. It auto-updates `config.ts`, all documentation tables, `marketplace.json`, and skill counts across the project — no manual edits needed. Then run `bun run catalog` and `bun run zip` to regenerate the zip packages.
+When you add a new skill directory (for example `skills/hr-new-skill/SKILL.md`), run `bun run sync` first. It auto-discovers `hr-*` skill directories from `skills/`, then updates `AGENTS.md`, `docs/installation.md`, `docs/skills.md`, and `.claude-plugin/marketplace.json` — no manual table edits needed. Then run `bun run catalog` and `bun run zip` to regenerate `skills/CATALOG.md` and the distributable zip packages.
+
+## Project structure
+
+| Path | Purpose |
+|------|---------|
+| `skills/hr-*/SKILL.md` | Source skill definitions consumed by Claude Code and claude.ai |
+| `content/hr-*/README.md` | Human-readable companion guidance for each HR skill domain |
+| `docs/` | Installation, contributing, skill format, and generated skill reference documentation |
+| `.claude-plugin/marketplace.json` | Generated marketplace metadata synced from skill frontmatter |
+| `scripts/zip.ts` | Packaging script that creates distributable skill zip files under `skills/` |
+| `packages/hr-skills-build` | Build and maintenance tooling for validation, sync, catalog generation, and packaging support |
+| `packages/skills-ref` | TypeScript library and CLI for reading, validating, and generating prompts from skill files |
 
 ## Packages
 
 This repository uses Bun workspaces with Turborepo task orchestration. All packages are located in `packages/*`.
 
-Generated files and package build outputs are cached through Turborepo based on the task configuration in `turbo.json`.
+Generated files and package build outputs are cached through Turborepo based on the task configuration in `turbo.jsonc`.
 
 | Package | Description |
 |---------|-------------|
@@ -152,9 +168,9 @@ All documentation and skill content follows [Atlassian's content design guidelin
 
 ## Common pitfalls and best practices
 
-- **Blank line before lists:** Always leave a blank line between a heading or paragraph and the list that follows. Missing blank lines cause markdownlint (`MD032`) and rendering errors.
+- **Blank line before lists:** Always leave a blank line between a heading or paragraph and the list that follows. Missing blank lines can cause rendering issues and the skill validator enforces this rule for `SKILL.md` files.
 
-  **For AI tools specifically:** every time you write a heading (`##`, `###`) or a bold label (`**Label:**`) that is immediately followed by a list, you MUST insert a blank line in between. This applies to every file in the project — `AGENTS.md`, `README.md`, `SKILL.md`, `docs/*.md`, and generated files. Run `bun run lint:md` to catch violations before committing.
+  **For AI tools specifically:** every time you write a heading (`##`, `###`) or a bold label (`**Label:**`) that is immediately followed by a list, you MUST insert a blank line in between. This applies to every file in the project — `AGENTS.md`, `README.md`, `SKILL.md`, `docs/*.md`, and generated files. Run `bun run validate` and `bun run lint:md` before committing when Markdown or skills change.
 - **HR-domain only:** Prompts and guidance must cover HR-specific patterns and best practices, not generic management or business advice.
 - **No obvious content:** Avoid widely-known basics. Focus on nuanced guidance that HR professionals actually need AI assistance with.
 - **Required structure:** Each `SKILL.md` needs frontmatter (`name`, `description`, `metadata`), `## Supported tasks`, `## Key prompts` (grouped by subtopic), and `## Tips`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,7 +50,7 @@ Use this template:
 name: hr-your-skill-name
 description: One-sentence description. Include trigger phrases like "Write a ...", "Conduct a ...", or "Analyze ...".
 metadata:
-  author: Your Name
+  author: Tuan Duc Tran
   version: "1.0.0"
 ---
 
@@ -122,7 +122,7 @@ bun run lint:md
 
 The TypeScript workspace packages and build tooling live in `packages/`.
 
-Workspace build outputs are cached through Turborepo based on the task configuration in `turbo.json`.
+Workspace build outputs are cached through Turborepo based on the task configuration in `turbo.jsonc`.
 
 Changes there should:
 

--- a/docs/skill-format.md
+++ b/docs/skill-format.md
@@ -16,7 +16,7 @@ This repository uses a Bun + Turborepo workspace structure. Skill content lives 
 │   └── skills-ref/
 ├── docs/
 ├── scripts/
-└── turbo.json
+└── turbo.jsonc
 ```
 
 The skill directory name must match the `name` field in the frontmatter exactly.

--- a/packages/hr-skills-build/README.md
+++ b/packages/hr-skills-build/README.md
@@ -1,6 +1,6 @@
 # hr-skills-build
 
-Build tooling for the HR Skills collection — validates SKILL.md files and generates the skills catalog.
+Build tooling for the HR Skills collection — validates `SKILL.md` files, syncs generated references, and generates the skills catalog.
 
 ## Scripts
 
@@ -11,7 +11,10 @@ bun run validate
 # Generate skills/CATALOG.md
 bun run catalog
 
-# Run both validate + catalog
+# Sync generated references
+bun run sync
+
+# Run validate + catalog through the package build
 bun run build
 
 # Watch mode — re-validates on file changes
@@ -22,6 +25,7 @@ Or run from the monorepo root:
 
 ```bash
 bun run validate      # delegates to hr-skills-build
+bun run sync          # delegates to hr-skills-build
 bun run catalog       # delegates to hr-skills-build
 bun run build         # runs all package builds
 ```
@@ -35,8 +39,13 @@ Checks every `skills/hr-*/SKILL.md` for:
 - Required frontmatter fields: `name`, `description`, `metadata.author`, `metadata.version`
 - `name` matches directory name
 - `description` is at least 50 characters
-- Required sections: `## Supported Tasks`, `## Key Prompts`, `## Tips`
+- Required sections: `## Supported tasks`, `## Key prompts`, `## Tips`
 - Minimum content length of 1 000 characters
+- `SKILL.md` body length under 500 lines
+- `metadata.author` exactly set to `Tuan Duc Tran`
+- 8–12 supported task items
+- 4–6 tip items
+- Blank lines before lists for MD032 compliance
 
 ```text
 Validating HR Skills...
@@ -53,11 +62,15 @@ Validating HR Skills...
 
 Reads all `SKILL.md` files and writes `skills/CATALOG.md` — a single reference document listing every skill with its name, description, supported tasks, and a link to its source file.
 
+### `sync`
+
+Discovers all `skills/hr-*` directories and rebuilds generated references in `AGENTS.md`, `docs/installation.md`, `docs/skills.md`, and `.claude-plugin/marketplace.json`.
+
 ## Source
 
 | File | Purpose |
 |------|---------|
-| `src/config.ts` | `HR_SKILLS` list and `SKILLS_DIR` path |
+| `src/config.ts` | `SKILLS_DIR` path, `hr-` prefix, and skill discovery helper |
 | `src/validate.ts` | Validates frontmatter and required sections |
 | `src/catalog.ts` | Generates `skills/CATALOG.md` |
 


### PR DESCRIPTION
### Motivation

- Bring `AGENTS.md` into alignment with the repository's actual scripts, sync/validate tooling, and generated artifacts so guidance is accurate for contributors. 
- Make documentation consistent with build tooling behavior (sync targets, `turbo.jsonc`, and validator rules) to avoid template drift and contributor confusion.

### Description

- Updated `AGENTS.md` to list the current root commands (`bun run sync`, `bun run validate`, `bun run catalog`, `bun run zip`, etc.), clarify `turbo.jsonc` usage, and add a new `## Project structure` table describing `skills/`, `content/`, `docs/`, `.claude-plugin/`, `scripts/`, and `packages/` layout. 
- Adjusted blank-line/list guidance to reflect that the skill validator enforces list spacing for `SKILL.md` and recommended `bun run validate` plus `bun run lint:md` for Markdown checks. 
- Fixed the new-skill template `metadata.author` to `Tuan Duc Tran` and normalized checklist labels (`## Supported tasks` and `## Key prompts`) to match validator expectations. 
- Extended `packages/hr-skills-build/README.md` to document `sync` behavior, include `bun run sync` in scripts, and enumerate current validation constraints (line limits, author requirement, task/tip item counts, MD032 blank-line rule).

### Testing

- Ran `git diff --check` which passed with no whitespace or conflict markers reported. 
- Ran custom Python consistency checks that verified every `bun run` command cited in `AGENTS.md` exists in `package.json` and that the `AGENTS.md` skill table matches the discovered `skills/hr-*` directories, both of which succeeded. 
- Ran a custom scan for stale `turbo.json` references and a simple heading→list blank-line scan on touched Markdown files, both of which passed. 
- Attempted `bun install`, `bun run sync`, `bun run validate`, and `bun run lint:md` but these could not complete in this environment because package downloads returned HTTP 403 and local binaries (`turbo`, `markdownlint`) were not available, so those checks are marked as not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1865411da08327bc4205101621ae4c)