### PR TITLE
docs(examples): add HR operations examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,26 @@ Each example shows an end-to-end hiring scenario with sample prompts, generated 
 | [Hiring a Senior Cloud Security Engineer](./security/hiring-senior-cloud-security-engineer.md) | `hr-security` | AppSec, cloud security, SecOps |
 | [Hiring a Senior Product Designer](./uiux/hiring-senior-product-designer.md) | `hr-uiux` | UI/UX, design systems, user research |
 
+## HR operations examples
+
+| Example | Skill | Scenario |
+|---------|-------|---------|
+| [HR analytics workforce dashboard](./analytics/hr-analytics-workforce-dashboard.md) | `hr-analytics` | Workforce dashboard, attrition, data quality |
+| [Designing a pay equity review](./compensation-benefits/designing-a-pay-equity-review.md) | `hr-compensation-benefits` | Pay equity review and adjustment planning |
+| [Updating a workplace policy](./compliance/updating-a-workplace-policy.md) | `hr-compliance` | Remote work policy update and rollout |
+| [Mediating a team conflict](./conflict-resolution/mediating-a-team-conflict.md) | `hr-conflict-resolution` | Intake, mediation, and working agreements |
+| [Building an inclusive hiring review](./diversity-inclusion/building-an-inclusive-hiring-review.md) | `hr-diversity-inclusion` | Hiring funnel fairness audit |
+| [Running a stay interview program](./employee-engagement/running-a-stay-interview-program.md) | `hr-employee-engagement` | Retention listening and action planning |
+| [Handling an employee relations case](./employee-relations/handling-an-employee-relations-case.md) | `hr-employee-relations` | Complaint triage and case documentation |
+| [Building a manager development plan](./leadership-development/building-a-manager-development-plan.md) | `hr-leadership-development` | First-time manager development journey |
+| [Designing a new hire onboarding plan](./onboarding/designing-a-new-hire-onboarding-plan.md) | `hr-onboarding` | 30-60-90 day onboarding plan |
+| [Writing a performance improvement plan](./performance-management/writing-a-performance-improvement-plan.md) | `hr-performance-management` | Performance plan and progress tracking |
+| [Running an end-to-end hiring process](./recruiting/running-an-end-to-end-hiring-process.md) | `hr-recruiting` | Intake, interviews, debrief, and offer |
+| [Selecting an HRIS platform](./technology/selecting-an-hris-platform.md) | `hr-technology` | Vendor requirements and selection scorecard |
+| [Building a learning program](./training-development/building-a-learning-program.md) | `hr-training-development` | Team lead learning program design |
+| [Managing a Vietnam HR compliance workflow](./vietnam-context/managing-a-vietnam-hr-compliance-workflow.md) | `hr-vietnam-context` | Vietnam contracts, tax, insurance, and permits |
+| [Building a headcount plan](./workforce-planning/building-a-headcount-plan.md) | `hr-workforce-planning` | Annual role prioritization and budget alignment |
+
 ## How to use these examples
 
 1. Install the corresponding skill into Claude.

--- a/examples/analytics/hr-analytics-workforce-dashboard.md
+++ b/examples/analytics/hr-analytics-workforce-dashboard.md
@@ -1,0 +1,96 @@
+---
+title: HR analytics workforce dashboard
+reference: hr-analytics
+---
+
+# Example: HR analytics workforce dashboard
+
+## Context
+
+You are an HR manager at a 700-person software company. The executive team wants a monthly workforce dashboard that explains headcount, attrition, hiring, internal mobility, and engagement risk by department. Your HRIS exports are inconsistent, and leaders need clear insights before the quarterly talent review.
+
+## Step 1 — Define the business questions
+
+**Sample prompt:**
+
+> "Help me turn raw HRIS exports into a workforce dashboard for executives. We need to understand headcount, attrition, hiring progress, and engagement risk by department."
+
+**Expected skill response:**
+
+- Anchor the dashboard on decisions leaders must make, not on every available HR metric.
+- Separate descriptive metrics from risk indicators so executives know what happened and where action is needed.
+- Use consistent definitions for active headcount, regrettable attrition, voluntary attrition, involuntary attrition, open roles, and internal mobility.
+- Add clear data quality notes for missing manager, department, location, or termination reason fields.
+
+## Step 2 — Build the dashboard metric map
+
+**Sample prompt:**
+
+> "Create a metric map for the dashboard with definitions, data fields, owner, update cadence, and action trigger."
+
+**Generated metric map:**
+
+| Metric | Definition | Required fields | Owner | Action trigger |
+|---|---|---|---|---|
+| Active headcount | Employees active on the last day of the reporting month | employee ID, status, department, location | HR operations | More than 5% variance from approved plan |
+| Voluntary attrition | Voluntary exits divided by average headcount for the period | termination date, termination type, department | HR analytics | Two-month increase or top-quartile department rate |
+| Regrettable attrition | Voluntary exits from high performers, critical roles, or flight-risk talent | performance rating, critical role flag, termination reason | HR business partner | Any critical-role loss |
+| Hiring progress | Filled roles compared with approved openings | requisition ID, open date, close date, status | Talent acquisition | Role open more than 60 days |
+| Internal mobility | Employees moving roles, departments, or levels internally | job change date, old role, new role | HR operations | Low movement in priority functions |
+| Engagement risk | Combined signal from survey scores, manager changes, absence, and attrition trend | survey score, manager ID, absence days | People analytics | Red status for two months |
+
+## Step 3 — Create a data quality checklist
+
+**Sample prompt:**
+
+> "Before I show this to executives, create a data quality checklist for the workforce dashboard."
+
+**Generated checklist:**
+
+- [ ] Every active employee has one employee ID.
+- [ ] Department names match the approved organization structure.
+- [ ] Termination reasons are grouped into standard categories.
+- [ ] Contractors, interns, and employees are tagged separately.
+- [ ] Open requisitions have an approved budget owner.
+- [ ] Transfers are not counted as exits and new hires.
+- [ ] Missing values are shown in a visible data quality note.
+
+## Step 4 — Generate the executive summary
+
+**Sample prompt:**
+
+> "Write an executive summary for a dashboard where Engineering attrition rose to 14%, Sales hiring is 30 days behind plan, and Customer Support engagement dropped after a manager change."
+
+**Generated summary:**
+
+```txt
+Monthly workforce dashboard summary
+
+Overall headcount remains within 2% of the approved plan, but three workforce risks need leadership attention this month.
+
+1. Engineering voluntary attrition increased to 14%, with two regrettable exits from critical platform roles. HR should partner with Engineering leadership on stay interviews and workload review within the next two weeks.
+2. Sales hiring is behind plan by an average of 30 days across account executive roles. Talent acquisition needs a sourcing reset and faster interview scheduling with hiring managers.
+3. Customer Support engagement declined after a manager transition. The HR business partner should review team feedback, manager support needs, and short-term staffing pressure.
+
+Recommended next action: Review these three risks in the talent operating meeting and assign owners with due dates before the next dashboard cycle.
+```
+
+## Step 5 — Add a dashboard scorecard
+
+**Sample prompt:**
+
+> "Create a simple scorecard that helps executives read the workforce dashboard without overreacting to one-month changes."
+
+**Generated scorecard:**
+
+| Area | Green | Yellow | Red |
+|---|---|---|---|
+| Headcount plan | Within 3% of plan | 3% to 7% variance | More than 7% variance |
+| Voluntary attrition | Stable or declining | Increase for one month | Increase for two months or above benchmark |
+| Critical role risk | No critical exits | One critical-role exit | Multiple critical-role exits or no successor |
+| Hiring progress | Roles filled on plan | Average delay under 30 days | Average delay over 30 days |
+| Engagement | Stable survey trend | One team below threshold | Repeated low scores plus attrition risk |
+
+## Summary
+
+Use `hr-analytics` to convert messy HR data into an executive-ready dashboard with defined metrics, data quality checks, action triggers, and a short narrative that supports workforce decisions.

--- a/examples/compensation-benefits/designing-a-pay-equity-review.md
+++ b/examples/compensation-benefits/designing-a-pay-equity-review.md
@@ -1,0 +1,101 @@
+---
+title: Designing a pay equity review
+reference: hr-compensation-benefits
+---
+
+# Example: Designing a pay equity review
+
+## Context
+
+You are an HR manager preparing the first structured pay equity review for a 450-person company. Leaders want to identify unexplained pay gaps by role, level, department, gender, race, location, and tenure before the annual compensation cycle.
+
+## Step 1 — Scope the review
+
+**Sample prompt:**
+
+> "Help me design a practical pay equity review for a mid-sized company before annual compensation planning."
+
+**Expected skill response:**
+
+- Define the purpose as identifying unexplained pay differences, not proving intent.
+- Compare employees in similar work groups using role, level, job family, location, and employment type.
+- Include base pay, bonus target, equity value, and total compensation when data quality allows.
+- Involve legal counsel before analysis starts if the review may create privileged findings.
+
+## Step 2 — Build the data request
+
+**Sample prompt:**
+
+> "Create a data request list for compensation, HRIS, and finance teams."
+
+**Generated data request:**
+
+- Employee ID
+- Job title and standardized job family
+- Level or grade
+- Department and manager
+- Work location and pay market
+- Full-time or part-time status
+- Base salary or hourly rate
+- Bonus target and most recent payout
+- Equity grant value, if applicable
+- Hire date and time in role
+- Performance rating history
+- Promotion date
+- Gender, race, ethnicity, and other legally approved demographic fields
+- Leave status and employment status
+
+## Step 3 — Create the review workflow
+
+**Sample prompt:**
+
+> "Give me a step-by-step workflow for running the pay equity review with finance, legal, and HR business partners."
+
+**Generated workflow:**
+
+1. Confirm legal review structure, data access, and confidentiality rules.
+2. Clean job architecture data so employees are compared within valid groups.
+3. Run initial pay comparisons by job family, level, location, and demographic group.
+4. Flag differences that remain after accounting for tenure, performance, location, and role scope.
+5. Review flagged cases with HR business partners for legitimate business context.
+6. Prepare recommended adjustments with cost, timing, and employee impact.
+7. Present aggregate findings to executives without exposing individual demographic details.
+8. Document decisions, owners, and follow-up audits.
+
+## Step 4 — Draft leader talking points
+
+**Sample prompt:**
+
+> "Write talking points for executives explaining why we are doing this review and how we will handle results responsibly."
+
+**Generated talking points:**
+
+```txt
+We are conducting a structured pay equity review to make sure employees doing comparable work are paid fairly and consistently.
+
+The review will compare employees within similar job families, levels, and locations. It will consider relevant business factors such as tenure, performance, role scope, and market differences.
+
+If we find unexplained gaps, we will review them carefully and make appropriate adjustments through the compensation cycle. We will treat employee-level findings as confidential and report executive results in aggregate.
+
+This review supports our compensation philosophy: fair, market-informed, consistent, and transparent where possible.
+```
+
+## Step 5 — Use an adjustment decision checklist
+
+**Sample prompt:**
+
+> "Create a checklist for deciding whether a flagged pay gap needs adjustment."
+
+**Generated checklist:**
+
+- [ ] Employees are in comparable job family, level, and location groups.
+- [ ] Pay difference cannot be explained by documented scope differences.
+- [ ] Performance history supports the current pay position.
+- [ ] Tenure and time in role were reviewed.
+- [ ] Recent promotions or counteroffers were considered but not used as the only explanation.
+- [ ] Proposed adjustment fits salary range and internal equity.
+- [ ] Legal and finance stakeholders approved the recommendation.
+
+## Summary
+
+Use `hr-compensation-benefits` to structure a pay equity review that is data-driven, legally careful, financially realistic, and connected to compensation decisions.

--- a/examples/compliance/updating-a-workplace-policy.md
+++ b/examples/compliance/updating-a-workplace-policy.md
@@ -1,0 +1,97 @@
+---
+title: Updating a workplace policy
+reference: hr-compliance
+---
+
+# Example: Updating a workplace policy
+
+## Context
+
+You are an HR manager updating the company's remote work policy after inconsistent manager decisions created employee complaints. The company has employees in multiple states, and leaders want a clearer policy that balances compliance, fairness, security, and operational needs.
+
+## Step 1 — Diagnose the policy problem
+
+**Sample prompt:**
+
+> "Help me update our remote work policy. Managers are applying it inconsistently, and employees think approvals are unfair."
+
+**Expected skill response:**
+
+- Identify where the policy is vague: eligibility, approval authority, work location, performance expectations, equipment, expenses, and exceptions.
+- Separate business discretion from legally protected accommodation processes.
+- Add documentation standards so managers can explain decisions consistently.
+- Include state-specific review for wage, tax, leave, expense reimbursement, and workplace safety requirements.
+
+## Step 2 — Create the policy outline
+
+**Sample prompt:**
+
+> "Draft a practical outline for a remote work policy that managers can apply consistently."
+
+**Generated outline:**
+
+1. Purpose and scope
+2. Eligibility criteria
+3. Approval process and decision owner
+4. Required work location and schedule expectations
+5. Performance and communication standards
+6. Data security and confidentiality requirements
+7. Equipment, expense, and workspace expectations
+8. Review, renewal, and revocation process
+9. Accommodation and protected leave coordination
+10. Exceptions and escalation path
+
+## Step 3 — Write manager decision criteria
+
+**Sample prompt:**
+
+> "Create manager decision criteria that reduce bias and inconsistent approvals."
+
+**Generated criteria:**
+
+| Criterion | Approve when | Escalate when |
+|---|---|---|
+| Role fit | Core duties can be performed remotely without service or security risk | Role requires regular on-site coverage |
+| Performance | Employee meets current performance expectations | Employee is on a formal performance plan |
+| Team coverage | Schedule supports customer and team needs | Request creates coverage gaps |
+| Location compliance | Work location is approved for payroll and employment compliance | Employee wants to work from a new state or country |
+| Security | Employee can meet workspace and data protection requirements | Role handles highly restricted data |
+| Accommodation | Request is a general flexibility request | Request may relate to disability, pregnancy, medical needs, or protected leave |
+
+## Step 4 — Generate employee-facing policy language
+
+**Sample prompt:**
+
+> "Draft concise employee-facing language for remote work eligibility and approval."
+
+**Generated policy excerpt:**
+
+```txt
+Remote work eligibility depends on the role, business needs, performance expectations, team coverage, data security requirements, and the employee's approved work location.
+
+Employees must submit remote work requests through the standard HR process before changing their regular work arrangement or work location. Managers may not approve work from a new state or country without HR and payroll review.
+
+The company will review remote work arrangements periodically. Approval may be changed if business needs, performance expectations, compliance requirements, or security requirements change.
+
+Requests related to disability, pregnancy, medical restrictions, or protected leave will be reviewed through the applicable accommodation or leave process, not through the general remote work approval process alone.
+```
+
+## Step 5 — Add an implementation checklist
+
+**Sample prompt:**
+
+> "Create an implementation checklist for launching the updated policy."
+
+**Generated checklist:**
+
+- [ ] Legal reviews state-specific requirements.
+- [ ] Payroll confirms approved work locations and tax workflow.
+- [ ] IT confirms security and equipment requirements.
+- [ ] Managers receive decision criteria and sample scenarios.
+- [ ] HR creates a standard request form and approval tracker.
+- [ ] Employees receive the policy, frequently asked questions, and effective date.
+- [ ] HR audits approvals after 60 days for consistency.
+
+## Summary
+
+Use `hr-compliance` to update workplace policies with clear eligibility rules, manager decision criteria, compliance review points, and rollout steps that reduce inconsistent application.

--- a/examples/conflict-resolution/mediating-a-team-conflict.md
+++ b/examples/conflict-resolution/mediating-a-team-conflict.md
@@ -1,0 +1,100 @@
+---
+title: Mediating a team conflict
+reference: hr-conflict-resolution
+---
+
+# Example: Mediating a team conflict
+
+## Context
+
+You are an HR manager supporting a product team where two senior employees are in open conflict. One says the other ignores deadlines and creates rework. The other says decisions are made without input. Their manager wants HR to mediate before the conflict affects retention and delivery.
+
+## Step 1 — Prepare the mediation plan
+
+**Sample prompt:**
+
+> "Help me mediate a conflict between two senior employees who blame each other for missed deadlines and poor collaboration."
+
+**Expected skill response:**
+
+- Clarify whether the issue is interpersonal conflict, role ambiguity, workload pressure, or possible misconduct.
+- Meet each employee separately before any joint conversation.
+- Set ground rules for confidentiality, respectful behavior, and issue-focused discussion.
+- Keep the mediation focused on specific work behaviors and agreements, not personality judgments.
+
+## Step 2 — Run intake conversations
+
+**Sample prompt:**
+
+> "Create questions for separate intake conversations before mediation."
+
+**Generated intake questions:**
+
+1. What specific incidents led you to request support?
+2. What impact has the conflict had on your work, team communication, or deadlines?
+3. What do you believe the other person needs from you to work effectively?
+4. What do you need from the other person to work effectively?
+5. What agreements have been made before, and where did they break down?
+6. What outcome would make the next four weeks workable?
+7. Is there any conduct concern I should assess outside mediation?
+
+## Step 3 — Facilitate the joint conversation
+
+**Sample prompt:**
+
+> "Give me a structure for a 60-minute mediation meeting."
+
+**Generated agenda:**
+
+| Time | Activity | HR role |
+|---|---|---|
+| 0 to 5 minutes | Confirm purpose and ground rules | Set tone and explain process |
+| 5 to 20 minutes | Each person describes the work impact | Keep statements specific and behavior-based |
+| 20 to 35 minutes | Identify shared goals and recurring breakdowns | Translate blame into process issues |
+| 35 to 50 minutes | Agree on working norms | Capture commitments and owners |
+| 50 to 60 minutes | Confirm follow-up plan | Set checkpoints and escalation path |
+
+## Step 4 — Document working agreements
+
+**Sample prompt:**
+
+> "Write a neutral working agreement after mediation."
+
+**Generated agreement:**
+
+```txt
+Working agreement for Product Launch Team
+
+Shared goal:
+Deliver launch milestones with clear decision ownership, timely review, and respectful communication.
+
+Agreements:
+1. Product requirements will be shared at least three business days before technical review when timelines allow.
+2. Engineering concerns that may affect scope, timeline, or risk will be raised in the launch channel within one business day.
+3. Decisions will include an owner, due date, and decision record link.
+4. Disagreements will be escalated to the manager after 24 hours if the employees cannot resolve them directly.
+5. Both employees will avoid side conversations that exclude required decision makers.
+
+Follow-up:
+HR and the manager will check progress in two weeks and again after the launch retrospective.
+```
+
+## Step 5 — Use a mediation quality checklist
+
+**Sample prompt:**
+
+> "Create a checklist to make sure I handled this mediation appropriately."
+
+**Generated checklist:**
+
+- [ ] I met each employee separately before the joint session.
+- [ ] I screened for harassment, discrimination, retaliation, or safety concerns.
+- [ ] I kept the discussion focused on work behaviors and impact.
+- [ ] I avoided taking sides or diagnosing intent.
+- [ ] I captured specific commitments, owners, and dates.
+- [ ] I involved the manager where role clarity or prioritization was needed.
+- [ ] I scheduled follow-up before closing the process.
+
+## Summary
+
+Use `hr-conflict-resolution` to move team conflict from blame to specific working agreements, while screening for issues that need formal HR investigation instead of mediation.

--- a/examples/diversity-inclusion/building-an-inclusive-hiring-review.md
+++ b/examples/diversity-inclusion/building-an-inclusive-hiring-review.md
@@ -1,0 +1,105 @@
+---
+title: Building an inclusive hiring review
+reference: hr-diversity-inclusion
+---
+
+# Example: Building an inclusive hiring review
+
+## Context
+
+You are an HR manager reviewing the hiring process for a growing operations team. Candidate feedback shows inconsistent interview experiences, and hiring data suggests underrepresented candidates are dropping out after the first interview. Leaders want a practical review that improves fairness without slowing hiring.
+
+## Step 1 — Define the review scope
+
+**Sample prompt:**
+
+> "Help me review our hiring process for inclusion and fairness. Underrepresented candidates are dropping after the first interview."
+
+**Expected skill response:**
+
+- Review each stage of the funnel, not only sourcing.
+- Compare pass-through rates by stage, role, location, recruiter, and interviewer panel.
+- Audit job descriptions, screening criteria, interview questions, candidate communication, and scorecard use.
+- Look for process barriers before assuming pipeline availability is the only issue.
+
+## Step 2 — Create a funnel audit plan
+
+**Sample prompt:**
+
+> "Create an inclusive hiring audit plan with data, artifacts, and stakeholder interviews."
+
+**Generated audit plan:**
+
+| Area | What to review | Inclusion risk |
+|---|---|---|
+| Job description | Required criteria, language, salary visibility, work model | Inflated requirements or unclear flexibility |
+| Sourcing | Channel mix, outreach language, referral share | Narrow networks or overreliance on referrals |
+| Screening | Resume rubric, knockout questions, recruiter notes | Subjective fit language or inconsistent standards |
+| Interviews | Questions, interviewer training, panel diversity | Unstructured interviews and uneven candidate experience |
+| Scorecards | Rating anchors, evidence quality, final decision notes | Vague feedback or culture fit bias |
+| Offer | Compensation range, negotiation patterns, acceptance data | Unequal outcomes after offer |
+
+## Step 3 — Rewrite screening criteria
+
+**Sample prompt:**
+
+> "Turn vague screening criteria for an Operations Lead into inclusive, job-related criteria."
+
+**Generated criteria:**
+
+```txt
+Replace:
+"Must be a fast-paced culture fit with strong presence."
+
+Use:
+"Has led shift planning or operational coordination in a high-volume environment, can explain how they prioritize competing requests, and can communicate clearly with frontline employees and cross-functional partners."
+
+Replace:
+"Needs 8 years in a top-tier company."
+
+Use:
+"Has demonstrated ownership of operational metrics, process improvement, and team coordination in a comparable environment. Years of experience are a guide, not a strict screen."
+```
+
+## Step 4 — Build an interviewer calibration checklist
+
+**Sample prompt:**
+
+> "Create a calibration checklist for interviewers before we restart hiring."
+
+**Generated checklist:**
+
+- [ ] Interviewers understand the role outcomes and must-have skills.
+- [ ] Every candidate receives the same core questions for the same interview stage.
+- [ ] Interviewers rate evidence from answers, not style, accent, school, or personal similarity.
+- [ ] Scorecards include examples that justify each rating.
+- [ ] Debriefs start with written scores before group discussion.
+- [ ] Culture add is tied to team needs, not personal preference.
+- [ ] Concerns about communication are linked to job-relevant examples.
+
+## Step 5 — Summarize findings for leaders
+
+**Sample prompt:**
+
+> "Write an executive summary of findings where drop-off is highest after recruiter screen and scorecards show vague culture fit concerns."
+
+**Generated summary:**
+
+```txt
+Inclusive hiring review summary
+
+The largest fairness risk appears after recruiter screen, where pass-through differences are wider than at later stages. Scorecard notes often reference "culture fit" without evidence tied to job outcomes.
+
+Recommended actions:
+1. Replace subjective screening notes with a structured rubric tied to role outcomes.
+2. Train recruiters and hiring managers on evidence-based screening.
+3. Standardize interview questions and rating anchors for each stage.
+4. Review pass-through rates monthly for the next two hiring cycles.
+5. Require written evidence before final debrief discussions.
+
+The goal is not to lower standards. The goal is to make standards clear, job-related, and consistently applied.
+```
+
+## Summary
+
+Use `hr-diversity-inclusion` to audit hiring equity across the funnel, replace subjective criteria with job-related evidence, and create practical controls for fairer decisions.

--- a/examples/employee-engagement/running-a-stay-interview-program.md
+++ b/examples/employee-engagement/running-a-stay-interview-program.md
@@ -1,0 +1,100 @@
+---
+title: Running a stay interview program
+reference: hr-employee-engagement
+---
+
+# Example: Running a stay interview program
+
+## Context
+
+You are an HR manager at a 300-person company with rising regrettable attrition in customer success and engineering. Leaders want to understand why employees stay, what may cause them to leave, and which actions managers can take within 30 days.
+
+## Step 1 — Design the program
+
+**Sample prompt:**
+
+> "Help me create a stay interview program for teams with rising regrettable attrition."
+
+**Expected skill response:**
+
+- Use stay interviews before exit risk becomes urgent.
+- Start with high-risk teams and critical roles, then expand.
+- Position the program as listening for practical improvements, not as a promise that every issue will be solved.
+- Train managers to listen, document themes, and follow through on realistic actions.
+
+## Step 2 — Select participants and timing
+
+**Sample prompt:**
+
+> "Create a rollout plan for stay interviews across customer success and engineering."
+
+**Generated rollout plan:**
+
+| Week | Activity | Owner |
+|---|---|---|
+| 1 | Confirm target teams, employee list, and manager briefing | HR business partner |
+| 2 | Train managers and provide question guide | HR manager |
+| 3 to 4 | Conduct stay interviews with selected employees | People managers |
+| 5 | Summarize themes and quick actions | HR business partner |
+| 6 | Share action plan with employees | Department leaders |
+| 10 | Review progress and attrition signals | HR analytics |
+
+## Step 3 — Create stay interview questions
+
+**Sample prompt:**
+
+> "Write stay interview questions that uncover retention risks without sounding like an exit interview."
+
+**Generated questions:**
+
+1. What part of your work gives you the most energy right now?
+2. What part of your work drains energy or creates avoidable friction?
+3. What keeps you here today?
+4. What might make you consider leaving in the next year?
+5. Do you feel your skills are being used well? Why or why not?
+6. What support from your manager would make the biggest difference?
+7. What is one change we could make in the next 30 days that would improve your experience?
+
+## Step 4 — Summarize themes and actions
+
+**Sample prompt:**
+
+> "Summarize stay interview themes for Customer Success where employees mention workload, unclear career paths, and inconsistent manager feedback."
+
+**Generated output:**
+
+```txt
+Stay interview theme summary: Customer Success
+
+Primary retention risks:
+1. Workload pressure during renewal periods is creating fatigue and lower confidence in service quality.
+2. Employees do not see a clear path from specialist to senior specialist or manager roles.
+3. Manager feedback is inconsistent across teams, which creates uncertainty about expectations.
+
+Recommended 30-day actions:
+- Publish a renewal-period staffing and escalation plan before the next cycle.
+- Draft a simple career path guide for specialist, senior specialist, and team lead roles.
+- Ask managers to hold monthly expectation and feedback conversations using the same template.
+
+What to avoid:
+Do not run another survey without visible follow-up. Employees need to see that the interviews led to practical action.
+```
+
+## Step 5 — Track program health
+
+**Sample prompt:**
+
+> "Create a checklist to measure whether the stay interview program is working."
+
+**Generated checklist:**
+
+- [ ] At least 85% of selected employees complete interviews.
+- [ ] Managers submit themes without naming employees in broad reports.
+- [ ] Each team has no more than three priority actions.
+- [ ] Leaders share what will change and what cannot change now.
+- [ ] Follow-up happens within 30 days.
+- [ ] Regrettable attrition, internal mobility, and engagement pulse results are reviewed together.
+
+## Summary
+
+Use `hr-employee-engagement` to run stay interviews that produce focused retention insights, manager-owned actions, and visible follow-up for high-risk teams.

--- a/examples/employee-relations/handling-an-employee-relations-case.md
+++ b/examples/employee-relations/handling-an-employee-relations-case.md
@@ -1,0 +1,103 @@
+---
+title: Handling an employee relations case
+reference: hr-employee-relations
+---
+
+# Example: Handling an employee relations case
+
+## Context
+
+You are an HR manager receiving a complaint that an employee's manager yelled during a team meeting, assigned undesirable work after the employee raised concerns, and excluded the employee from project updates. You need to assess the issue, document it, and guide the manager without jumping to conclusions.
+
+## Step 1 — Triage the complaint
+
+**Sample prompt:**
+
+> "Help me triage an employee relations complaint involving yelling, possible retaliation, and exclusion from team updates."
+
+**Expected skill response:**
+
+- Separate conduct issues from performance, communication, and possible retaliation concerns.
+- Identify urgent risks, including safety, protected activity, discrimination, harassment, or repeated retaliation.
+- Preserve neutrality in notes and avoid conclusions before fact-finding.
+- Define what must be investigated, who should be interviewed, and what documents are needed.
+
+## Step 2 — Create an intake plan
+
+**Sample prompt:**
+
+> "Create an intake conversation guide for the employee who raised the complaint."
+
+**Generated intake guide:**
+
+1. Thank the employee for raising the concern and explain the process.
+2. Ask what happened, when it happened, where it happened, and who was present.
+3. Ask what the manager said or did, using the employee's words where possible.
+4. Ask what concerns the employee raised before the alleged change in treatment.
+5. Ask what work assignments or project access changed after the concern.
+6. Ask whether there are documents, messages, meeting notes, or witnesses.
+7. Explain confidentiality limits and expected next steps.
+
+## Step 3 — Build the case plan
+
+**Sample prompt:**
+
+> "Create a case plan that shows allegations, evidence needed, and interview sequence."
+
+**Generated case plan:**
+
+| Allegation | Evidence needed | Interview sequence |
+|---|---|---|
+| Manager yelled in meeting | Calendar invite, attendee list, chat messages, witness accounts | Complainant, witnesses, manager |
+| Undesirable work assigned after concern | Assignment history, project tracker, manager notes | Complainant, manager, project lead |
+| Exclusion from updates | Email lists, channel access, meeting invites | Complainant, project coordinator, manager |
+| Possible retaliation | Timeline of protected or good-faith concern and later actions | Complainant, manager, relevant witnesses |
+
+## Step 4 — Draft neutral documentation
+
+**Sample prompt:**
+
+> "Write a neutral case note after the intake conversation."
+
+**Generated case note:**
+
+```txt
+Employee relations case note
+
+Date opened: [date]
+Employee: [name]
+Manager: [name]
+HR owner: [name]
+
+Summary of concern:
+Employee reported that their manager raised their voice during a team meeting on [date], changed work assignments after the employee raised concerns about project timelines, and excluded the employee from project update channels.
+
+Initial assessment:
+The concern includes possible inappropriate workplace conduct, communication breakdown, and potential retaliation. No findings have been made. HR will gather relevant documents and interview identified witnesses before determining next steps.
+
+Immediate actions:
+- Preserve meeting records, project assignment history, and relevant messages.
+- Remind involved parties that retaliation is prohibited.
+- Schedule witness interviews.
+```
+
+## Step 5 — Use a closure checklist
+
+**Sample prompt:**
+
+> "Create a closure checklist for this employee relations case."
+
+**Generated checklist:**
+
+- [ ] Allegations were clearly defined.
+- [ ] Relevant witnesses were interviewed.
+- [ ] Documents and messages were reviewed.
+- [ ] Findings were based on evidence, not assumptions.
+- [ ] Retaliation risk was assessed and addressed.
+- [ ] Manager coaching, corrective action, or team reset steps were documented.
+- [ ] The employee received an appropriate process closure update.
+- [ ] Follow-up date was scheduled.
+
+## Summary
+
+Use `hr-employee-relations` to triage complaints, structure fact-finding, document neutrally, and close cases with evidence-based actions and retaliation safeguards.

--- a/examples/leadership-development/building-a-manager-development-plan.md
+++ b/examples/leadership-development/building-a-manager-development-plan.md
@@ -1,0 +1,105 @@
+---
+title: Building a manager development plan
+reference: hr-leadership-development
+---
+
+# Example: Building a manager development plan
+
+## Context
+
+You are an HR manager supporting 18 first-time managers promoted during rapid growth. Engagement survey comments show inconsistent feedback, unclear priorities, and uneven coaching. Leaders want a manager development plan that builds practical habits instead of a one-time training event.
+
+## Step 1 — Define manager capability gaps
+
+**Sample prompt:**
+
+> "Help me build a development plan for first-time managers who need stronger feedback, prioritization, and coaching habits."
+
+**Expected skill response:**
+
+- Connect the plan to observable manager behaviors, not abstract leadership traits.
+- Prioritize a few capabilities that managers can practice immediately.
+- Combine workshops, peer practice, manager tools, and accountability check-ins.
+- Measure behavior change through employee feedback, one-on-one quality, and manager follow-through.
+
+## Step 2 — Build the capability map
+
+**Sample prompt:**
+
+> "Create a capability map for first-time managers with behaviors and practice activities."
+
+**Generated capability map:**
+
+| Capability | Observable behavior | Practice activity |
+|---|---|---|
+| Set priorities | Translates team goals into weekly priorities and trade-offs | Priority-setting simulation |
+| Give feedback | Gives timely, specific, behavior-based feedback | Feedback role play using real scenarios |
+| Coach employees | Asks questions before giving solutions | Coaching conversation practice |
+| Run one-on-ones | Uses recurring agenda and follows up on commitments | One-on-one audit and peer review |
+| Handle conflict | Addresses tension early and neutrally | Conflict scenario discussion |
+| Manage performance | Documents expectations, support, and consequences | Performance conversation script practice |
+
+## Step 3 — Create the 90-day development journey
+
+**Sample prompt:**
+
+> "Design a 90-day manager development journey with learning, practice, and measurement."
+
+**Generated plan:**
+
+1. Week 1: Manager expectations briefing with executives.
+2. Week 2: Workshop on priorities, role clarity, and one-on-one structure.
+3. Week 4: Feedback and coaching practice lab.
+4. Week 6: Peer circle to discuss real manager challenges.
+5. Week 8: Performance and conflict conversation practice.
+6. Week 10: Employee pulse on manager communication and support.
+7. Week 12: Manager reflection, action plan, and leader review.
+
+## Step 4 — Generate manager tools
+
+**Sample prompt:**
+
+> "Create a one-on-one template managers can use immediately."
+
+**Generated template:**
+
+```txt
+Manager one-on-one template
+
+1. Employee priorities
+- What are your top priorities this week?
+- Where do you need a decision, context, or removal of a blocker?
+
+2. Feedback and recognition
+- What went well since our last conversation?
+- What is one behavior or outcome we should adjust?
+
+3. Growth
+- What skill or responsibility do you want to build next?
+- What support or opportunity would help?
+
+4. Follow-up
+- Employee commitments:
+- Manager commitments:
+- Date for follow-up:
+```
+
+## Step 5 — Evaluate program impact
+
+**Sample prompt:**
+
+> "Create a scorecard for measuring whether manager development is improving employee experience."
+
+**Generated scorecard:**
+
+| Measure | Strong signal | Concern signal |
+|---|---|---|
+| One-on-one consistency | Employees report regular useful conversations | One-on-ones are canceled or status-only |
+| Feedback quality | Feedback is timely, specific, and actionable | Employees are surprised by performance concerns |
+| Priority clarity | Employees can name top priorities and trade-offs | Teams report frequent priority confusion |
+| Coaching habit | Managers ask questions and support ownership | Managers solve everything or avoid coaching |
+| Follow-through | Manager commitments are tracked and completed | Employees report repeated unkept promises |
+
+## Summary
+
+Use `hr-leadership-development` to turn manager development into a structured behavior-change program with practice, tools, peer support, and measurable follow-through.

--- a/examples/onboarding/designing-a-new-hire-onboarding-plan.md
+++ b/examples/onboarding/designing-a-new-hire-onboarding-plan.md
@@ -1,0 +1,110 @@
+---
+title: Designing a new hire onboarding plan
+reference: hr-onboarding
+---
+
+# Example: Designing a new hire onboarding plan
+
+## Context
+
+You are an HR manager preparing onboarding for a cohort of 12 new hires across Sales, Engineering, and Customer Support. Past feedback says onboarding is welcoming but chaotic, with late equipment, unclear role expectations, and no structured manager follow-up.
+
+## Step 1 — Define onboarding outcomes
+
+**Sample prompt:**
+
+> "Help me design a 30-60-90 day onboarding plan for new hires across several departments."
+
+**Expected skill response:**
+
+- Separate company onboarding, role onboarding, team onboarding, and manager check-ins.
+- Define what the new hire should know, do, and feel by day 30, day 60, and day 90.
+- Assign owners for equipment, system access, compliance tasks, role training, and manager expectations.
+- Add feedback points so HR can fix onboarding issues quickly.
+
+## Step 2 — Build the onboarding timeline
+
+**Sample prompt:**
+
+> "Create a practical onboarding timeline from preboarding through day 90."
+
+**Generated timeline:**
+
+| Phase | New hire outcome | Owner |
+|---|---|---|
+| Preboarding | Receives welcome message, schedule, equipment plan, and required documents | HR operations |
+| Day 1 | Understands company mission, people resources, tools, and first-week plan | HR and manager |
+| Week 1 | Meets team, completes access setup, understands role expectations | Manager |
+| Day 30 | Can explain priorities, stakeholders, and success measures | Manager and buddy |
+| Day 60 | Owns core tasks with support and receives structured feedback | Manager |
+| Day 90 | Demonstrates role readiness and has a development plan | Manager and HR business partner |
+
+## Step 3 — Create a manager checklist
+
+**Sample prompt:**
+
+> "Create a manager checklist for onboarding a new hire in the first 30 days."
+
+**Generated checklist:**
+
+- [ ] Send a welcome note before the start date.
+- [ ] Confirm equipment, systems, and workspace readiness.
+- [ ] Share the first-week calendar.
+- [ ] Assign an onboarding buddy.
+- [ ] Explain role outcomes, not only tasks.
+- [ ] Schedule weekly one-on-ones for the first month.
+- [ ] Introduce key stakeholders with context.
+- [ ] Hold a day-30 check-in using a standard template.
+
+## Step 4 — Generate a day-30 check-in template
+
+**Sample prompt:**
+
+> "Write a day-30 onboarding check-in template for managers."
+
+**Generated template:**
+
+```txt
+Day-30 onboarding check-in
+
+Role clarity:
+- What parts of your role feel clear?
+- What still feels unclear?
+
+Support and tools:
+- Do you have the access, tools, and context needed to do your work?
+- Where are you blocked?
+
+Team connection:
+- Which relationships are helping you ramp up?
+- Who else should you meet?
+
+Feedback:
+- What has gone well in your first month?
+- What should we adjust for the next 30 days?
+
+Agreements:
+- New hire next steps:
+- Manager next steps:
+- Follow-up date:
+```
+
+## Step 5 — Review onboarding quality
+
+**Sample prompt:**
+
+> "Create a scorecard for checking whether onboarding is consistent across departments."
+
+**Generated scorecard:**
+
+| Area | Green | Yellow | Red |
+|---|---|---|---|
+| Equipment and access | Ready before day 1 | Ready during week 1 | Missing after week 1 |
+| Role clarity | Outcomes and priorities documented | Tasks shared but outcomes unclear | New hire cannot explain success measures |
+| Manager check-ins | Weekly and structured | Occasional or informal | No planned check-ins |
+| Buddy support | Buddy assigned and active | Buddy assigned but unclear role | No buddy |
+| Feedback loop | Day-30 feedback collected | Feedback collected late | No feedback collected |
+
+## Summary
+
+Use `hr-onboarding` to design onboarding that gives every new hire clear expectations, working tools, manager support, and measured progress through day 90.

--- a/examples/performance-management/writing-a-performance-improvement-plan.md
+++ b/examples/performance-management/writing-a-performance-improvement-plan.md
@@ -1,0 +1,112 @@
+---
+title: Writing a performance improvement plan
+reference: hr-performance-management
+---
+
+# Example: Writing a performance improvement plan
+
+## Context
+
+You are an HR manager helping a department leader write a performance improvement plan for an employee who has missed project deadlines, delivered incomplete work, and responded defensively to feedback. The manager has informal notes but no structured documentation.
+
+## Step 1 — Confirm whether a plan is appropriate
+
+**Sample prompt:**
+
+> "Help me decide whether a performance improvement plan is appropriate for an employee with missed deadlines and incomplete work."
+
+**Expected skill response:**
+
+- Check whether expectations were clear, recent, job-related, and documented.
+- Confirm the employee received feedback and had a reasonable opportunity to improve.
+- Review whether barriers such as workload, leave, accommodation needs, training gaps, or unclear priorities are involved.
+- Use the plan to define required improvement, support, timeline, and consequences.
+
+## Step 2 — Gather documentation
+
+**Sample prompt:**
+
+> "Create a documentation checklist before drafting the plan."
+
+**Generated checklist:**
+
+- [ ] Current job description and role expectations.
+- [ ] Specific missed deadlines with dates and impact.
+- [ ] Examples of incomplete or inaccurate work.
+- [ ] Previous feedback conversations and employee responses.
+- [ ] Support already provided by the manager.
+- [ ] Any workload, training, leave, or accommodation considerations.
+- [ ] Business impact of continued performance issues.
+
+## Step 3 — Draft the plan
+
+**Sample prompt:**
+
+> "Draft a concise performance improvement plan for a project coordinator with deadline and work quality issues."
+
+**Generated plan excerpt:**
+
+```txt
+Performance improvement plan
+
+Employee: [name]
+Role: Project Coordinator
+Manager: [name]
+Plan period: 45 days
+
+Performance concerns:
+1. Project deadline management
+The employee missed the [project] milestone due on [date], which delayed stakeholder review by five business days.
+
+2. Work quality and completeness
+The employee submitted [deliverable] on [date] with missing status updates, incomplete risk tracking, and unresolved owner assignments.
+
+Required improvement:
+- Submit assigned project updates by the agreed deadline each week.
+- Use the project tracker to document owners, due dates, risks, and status before stakeholder review.
+- Raise blockers to the manager at least two business days before a deadline is at risk.
+
+Support:
+- Manager will review priorities every Monday for the first four weeks.
+- Employee will receive a project tracker template and one working session on expected documentation standards.
+
+Consequences:
+Failure to meet the required improvement may result in further corrective action, up to and including termination of employment.
+```
+
+## Step 4 — Prepare the manager conversation
+
+**Sample prompt:**
+
+> "Write a manager script for delivering the plan clearly and respectfully."
+
+**Generated script:**
+
+```txt
+I want to discuss a formal performance improvement plan. The goal is to make expectations clear, provide support, and give you a defined opportunity to improve.
+
+The concerns are about deadlines, completeness of project updates, and timely escalation of blockers. We will focus on specific work outcomes during the next 45 days.
+
+I will walk through the plan, answer questions, and confirm the support we will provide. After this meeting, we will meet weekly to review progress against the written expectations.
+```
+
+## Step 5 — Track progress fairly
+
+**Sample prompt:**
+
+> "Create a weekly tracking template for the plan."
+
+**Generated template:**
+
+| Week | Requirement reviewed | Evidence | Status | Follow-up |
+|---|---|---|---|---|
+| 1 | Weekly project update submitted on time | Tracker link and timestamp | Met or not met | Manager notes |
+| 2 | Risks and blockers escalated early | Email or meeting note | Met or not met | Manager notes |
+| 3 | Deliverables complete before review | Deliverable link | Met or not met | Manager notes |
+| 4 | Stakeholder changes incorporated | Feedback log | Met or not met | Manager notes |
+| 5 | Sustained improvement | Summary evidence | Met or not met | Manager notes |
+| 6 | Final review | Plan outcome | Met or not met | Decision |
+
+## Summary
+
+Use `hr-performance-management` to write performance improvement plans that are specific, documented, supportive, and fair, while avoiding vague criticism or surprise consequences.

--- a/examples/recruiting/running-an-end-to-end-hiring-process.md
+++ b/examples/recruiting/running-an-end-to-end-hiring-process.md
@@ -1,0 +1,100 @@
+---
+title: Running an end-to-end hiring process
+reference: hr-recruiting
+---
+
+# Example: Running an end-to-end hiring process
+
+## Context
+
+You are a recruiter opening a Customer Success Manager role for a fast-growing B2B SaaS company. The hiring manager wants speed, but past roles had unclear requirements, inconsistent interviews, and late compensation alignment. You need to run a structured hiring process from intake to offer.
+
+## Step 1 — Run the intake meeting
+
+**Sample prompt:**
+
+> "Help me run a hiring intake meeting for a Customer Success Manager role so we avoid unclear requirements later."
+
+**Expected skill response:**
+
+- Clarify business need, role outcomes, must-have skills, nice-to-have skills, compensation range, location, and interview process.
+- Push the hiring manager to define success in the first six months.
+- Confirm who can make trade-off decisions during the search.
+- Document decision criteria before sourcing starts.
+
+## Step 2 — Create the hiring plan
+
+**Sample prompt:**
+
+> "Create an end-to-end hiring plan for this Customer Success Manager role."
+
+**Generated hiring plan:**
+
+| Stage | Purpose | Owner | Decision output |
+|---|---|---|---|
+| Intake | Confirm role outcomes and criteria | Recruiter and hiring manager | Approved role brief |
+| Sourcing | Build qualified pipeline | Recruiter | Target list and outreach |
+| Recruiter screen | Validate motivation, basics, and compensation range | Recruiter | Advance or decline |
+| Hiring manager interview | Assess customer success experience and role fit | Hiring manager | Advance or decline |
+| Panel interview | Assess account management, problem solving, and cross-functional work | Interview panel | Scorecards |
+| Final debrief | Make evidence-based decision | Hiring team | Hire or no hire |
+| Offer | Align compensation, start date, and close plan | Recruiter | Accepted offer |
+
+## Step 3 — Write the role brief
+
+**Sample prompt:**
+
+> "Draft a role brief for a Customer Success Manager who will manage mid-market SaaS accounts."
+
+**Generated role brief excerpt:**
+
+```txt
+Role outcomes for first six months
+
+1. Own a portfolio of mid-market customers and maintain accurate account health plans.
+2. Lead renewal preparation with Sales, Support, and Product partners.
+3. Identify expansion opportunities based on customer goals and product usage.
+4. Reduce preventable churn by escalating risks early and documenting action plans.
+
+Must-have criteria
+- Has managed B2B SaaS customer relationships after implementation.
+- Can explain renewal, adoption, and customer health workflows.
+- Uses data to prioritize accounts and identify risk.
+- Communicates clearly with customers and internal stakeholders.
+```
+
+## Step 4 — Build interview scorecards
+
+**Sample prompt:**
+
+> "Create a scorecard for the hiring manager interview and panel interview."
+
+**Generated scorecard:**
+
+| Competency | Strong evidence | Concern signal |
+|---|---|---|
+| Customer discovery | Asks structured questions and connects customer goals to product value | Focuses only on relationship warmth |
+| Account prioritization | Uses health data, renewal timing, and risk signals | Treats every account the same |
+| Churn risk management | Gives examples of early escalation and recovery plans | Notices risk only after customer complaint |
+| Cross-functional influence | Works with Sales, Product, and Support with clear ownership | Blames other teams without action |
+| Communication | Explains complex issues clearly and professionally | Gives vague or overly scripted answers |
+
+## Step 5 — Prepare the debrief
+
+**Sample prompt:**
+
+> "Create a final debrief agenda that prevents groupthink and keeps the decision evidence-based."
+
+**Generated agenda:**
+
+1. Confirm each interviewer submitted a scorecard before discussion.
+2. Review must-have criteria one by one.
+3. Ask each interviewer to share evidence, not impressions.
+4. Identify any unresolved risks and whether they can be addressed.
+5. Compare candidate strengths against role outcomes.
+6. Make a hire, no-hire, or hold decision.
+7. Assign offer owner or candidate communication owner.
+
+## Summary
+
+Use `hr-recruiting` to manage the full hiring process with a clear intake, role brief, structured interviews, evidence-based scorecards, and a disciplined debrief.

--- a/examples/technology/selecting-an-hris-platform.md
+++ b/examples/technology/selecting-an-hris-platform.md
@@ -1,0 +1,104 @@
+---
+title: Selecting an HRIS platform
+reference: hr-technology
+---
+
+# Example: Selecting an HRIS platform
+
+## Context
+
+You are an HR leader at a 250-person company outgrowing spreadsheets and disconnected payroll, benefits, and onboarding tools. The executive team approved an HRIS evaluation, but HR, Finance, IT, and managers have different priorities.
+
+## Step 1 — Define selection goals
+
+**Sample prompt:**
+
+> "Help me select an HRIS platform for a 250-person company moving away from spreadsheets and disconnected tools."
+
+**Expected skill response:**
+
+- Start with business outcomes, not vendor demos.
+- Define must-have workflows for employee records, payroll integration, onboarding, reporting, permissions, and compliance.
+- Include stakeholders from HR, Finance, IT, legal, managers, and employees.
+- Evaluate implementation effort, data migration, support model, security, and total cost.
+
+## Step 2 — Create requirements
+
+**Sample prompt:**
+
+> "Create a practical HRIS requirements checklist for vendor evaluation."
+
+**Generated checklist:**
+
+- [ ] Central employee profile with audit history.
+- [ ] Role-based permissions for HR, managers, employees, and Finance.
+- [ ] Payroll, benefits, and time-off integration.
+- [ ] Configurable onboarding workflows.
+- [ ] Organization charts and reporting lines.
+- [ ] Standard reports for headcount, turnover, compensation, and compliance.
+- [ ] Data import and export options.
+- [ ] Security controls, single sign-on, and access logs.
+- [ ] Implementation support and customer service commitments.
+- [ ] Clear pricing for modules, users, support, and implementation.
+
+## Step 3 — Build a vendor scorecard
+
+**Sample prompt:**
+
+> "Create a weighted scorecard for comparing three HRIS vendors."
+
+**Generated scorecard:**
+
+| Category | Weight | What to assess |
+|---|---:|---|
+| Core HR workflows | 25% | Employee records, job changes, time off, approvals |
+| Payroll and benefits fit | 20% | Integration depth, error handling, ownership model |
+| Reporting and analytics | 15% | Standard reports, custom fields, export quality |
+| Employee and manager experience | 15% | Ease of use, mobile access, self-service |
+| Security and compliance | 10% | Permissions, audit logs, data retention, vendor controls |
+| Implementation effort | 10% | Timeline, migration support, internal workload |
+| Total cost | 5% | Subscription, modules, implementation, support |
+
+## Step 4 — Prepare demo scenarios
+
+**Sample prompt:**
+
+> "Write demo scenarios vendors must show instead of generic product tours."
+
+**Generated demo scenarios:**
+
+1. Hire a new employee, trigger onboarding tasks, and sync required data to payroll.
+2. Process a manager change and show how permissions update.
+3. Approve a compensation change with HR and Finance visibility.
+4. Run a headcount and turnover report by department and location.
+5. Correct a data error and show the audit trail.
+6. Terminate an employee and show offboarding, payroll, and access steps.
+
+## Step 5 — Summarize the recommendation
+
+**Sample prompt:**
+
+> "Write an executive recommendation summary after Vendor B scores highest because implementation risk is lower and reporting is stronger."
+
+**Generated summary:**
+
+```txt
+HRIS recommendation summary
+
+Recommendation: Select Vendor B.
+
+Vendor B scored highest overall because it meets the required HR workflows, has stronger reporting, and presents lower implementation risk than the other options. While Vendor A has a slightly better employee interface, Vendor B provides better payroll integration, cleaner permission controls, and stronger migration support.
+
+Key trade-off:
+Vendor B is not the lowest-cost option, but it reduces manual HR work, improves data reliability, and lowers the risk of implementation delays.
+
+Next steps:
+1. Complete security and legal review.
+2. Confirm final pricing and implementation scope.
+3. Create data migration plan.
+4. Assign internal HRIS owner before contract signature.
+```
+
+## Summary
+
+Use `hr-technology` to select HR systems through business requirements, stakeholder alignment, demo scenarios, weighted scorecards, and implementation risk review.

--- a/examples/training-development/building-a-learning-program.md
+++ b/examples/training-development/building-a-learning-program.md
@@ -1,0 +1,96 @@
+---
+title: Building a learning program
+reference: hr-training-development
+---
+
+# Example: Building a learning program
+
+## Context
+
+You are an HR manager building a learning program for support team leads who need stronger coaching, escalation handling, and quality review skills. Leaders want measurable improvement in customer experience and team consistency, not a generic training calendar.
+
+## Step 1 — Define the performance need
+
+**Sample prompt:**
+
+> "Help me build a learning program for support team leads who need better coaching and escalation handling."
+
+**Expected skill response:**
+
+- Start with the performance gap and business outcome.
+- Define the specific behaviors team leads must practice.
+- Use blended learning: short instruction, scenario practice, job aids, manager reinforcement, and measurement.
+- Avoid treating training as the only solution if process, staffing, or role clarity is the real issue.
+
+## Step 2 — Build the learning objectives
+
+**Sample prompt:**
+
+> "Write practical learning objectives for support team lead training."
+
+**Generated learning objectives:**
+
+By the end of the program, team leads will be able to:
+
+1. Coach support representatives using call evidence and behavior-based feedback.
+2. Identify escalation risk before customer frustration increases.
+3. Apply a standard quality review rubric across tickets.
+4. Document follow-up actions after coaching conversations.
+5. Communicate recurring support issues to Product and Operations with clear examples.
+
+## Step 3 — Design the program journey
+
+**Sample prompt:**
+
+> "Create a six-week learning journey with practice and reinforcement."
+
+**Generated journey:**
+
+| Week | Focus | Activity | Reinforcement |
+|---|---|---|---|
+| 1 | Expectations and quality standards | Kickoff workshop | Manager reviews quality rubric |
+| 2 | Coaching basics | Feedback practice with ticket examples | Peer observation |
+| 3 | Escalation handling | Scenario simulation | Escalation checklist |
+| 4 | Quality calibration | Group review of anonymized tickets | Calibration notes |
+| 5 | Cross-functional communication | Write issue summaries for Product | Leader feedback |
+| 6 | Application review | Present coaching improvement plan | 30-day follow-up |
+
+## Step 4 — Create a practice scenario
+
+**Sample prompt:**
+
+> "Create a realistic practice scenario for coaching a support representative."
+
+**Generated scenario:**
+
+```txt
+Scenario: Coaching after an incomplete escalation
+
+A support representative closed a customer ticket after sending a generic troubleshooting article. The customer replied twice, became frustrated, and asked to speak to a manager. The ticket notes did not include product version, attempted fixes, or the customer's business impact.
+
+Team lead task:
+1. Identify what the representative did well.
+2. Explain the specific quality gap using the rubric.
+3. Coach the representative on what to do in a similar case.
+4. Document the follow-up action and review date.
+```
+
+## Step 5 — Measure learning transfer
+
+**Sample prompt:**
+
+> "Create a measurement plan that shows whether the learning program changed behavior."
+
+**Generated measurement plan:**
+
+| Measure | Before program | After program |
+|---|---|---|
+| Quality review consistency | Audit 20 tickets per lead | Compare rubric variance after week 6 |
+| Coaching frequency | Review calendar and documentation | Confirm monthly coaching completed |
+| Escalation quality | Count incomplete escalation notes | Track reduction in missing fields |
+| Customer experience | Review satisfaction trend for escalated tickets | Compare 60 days after program |
+| Team lead confidence | Pre-program pulse | Post-program pulse and manager observation |
+
+## Summary
+
+Use `hr-training-development` to build learning programs that connect skills to measurable job behavior, practice real scenarios, and reinforce learning after the workshop ends.

--- a/examples/vietnam-context/managing-a-vietnam-hr-compliance-workflow.md
+++ b/examples/vietnam-context/managing-a-vietnam-hr-compliance-workflow.md
@@ -1,0 +1,95 @@
+---
+title: Managing a Vietnam HR compliance workflow
+reference: hr-vietnam-context
+---
+
+# Example: Managing a Vietnam HR compliance workflow
+
+## Context
+
+You are an HR manager setting up a compliance workflow for a Vietnam-based team of 80 employees and three foreign specialists. You need a practical process for employment contracts, social insurance coordination, personal income tax registration, work permit tracking, and policy communication.
+
+## Step 1 — Map the compliance areas
+
+**Sample prompt:**
+
+> "Help me create a Vietnam HR compliance workflow for contracts, social insurance, personal income tax, and work permits."
+
+**Expected skill response:**
+
+- Treat Vietnam-specific compliance as an operating workflow, not a one-time checklist.
+- Coordinate HR, payroll, accounting, legal counsel, and department managers.
+- Track deadlines, document ownership, and employee communication.
+- Confirm legal details with qualified local counsel because laws and administrative guidance can change.
+
+## Step 2 — Build the compliance tracker
+
+**Sample prompt:**
+
+> "Create a tracker for core Vietnam HR compliance tasks and owners."
+
+**Generated tracker:**
+
+| Area | Task | Owner | Evidence |
+|---|---|---|---|
+| Employment contract | Confirm contract type, role, salary, work location, and probation terms | HR | Signed contract and appendix |
+| Social insurance | Register eligible employee and update salary basis | Payroll | Registration confirmation |
+| Personal income tax | Register tax code or confirm existing code | Accounting | Tax registration record |
+| Work permit | Track eligibility, application, renewal, or exemption for foreign worker | HR and legal counsel | Permit or exemption record |
+| Internal labor rules | Keep policy acknowledgment records | HR operations | Employee acknowledgment |
+| Trade union obligations | Track required coordination and contributions if applicable | HR and Finance | Payment and communication records |
+
+## Step 3 — Create the onboarding compliance workflow
+
+**Sample prompt:**
+
+> "Create an onboarding workflow for a new employee in Vietnam."
+
+**Generated workflow:**
+
+1. Confirm offer details, work location, probation terms, and start date.
+2. Prepare employment contract and required employee documents.
+3. Collect identity, bank, tax, dependent, and insurance information.
+4. Register or update personal income tax information.
+5. Coordinate social insurance registration when eligible.
+6. Provide required policies and collect acknowledgments.
+7. Confirm payroll setup before first pay cycle.
+8. Store documents securely with access limited to authorized HR and payroll staff.
+
+## Step 4 — Draft employee communication
+
+**Sample prompt:**
+
+> "Write a clear message to new Vietnam employees explaining required onboarding documents."
+
+**Generated message:**
+
+```txt
+Welcome to [Company]. To complete your onboarding and payroll setup in Vietnam, please provide the required documents listed in your onboarding checklist by [date].
+
+These documents help us prepare your employment contract, payroll profile, personal income tax registration, and applicable social insurance records.
+
+If any document is unavailable or the information needs correction, contact HR before your start date so we can guide the next step.
+
+Your personal information will be used only for employment, payroll, benefits, tax, and compliance purposes, and access will be limited to authorized teams.
+```
+
+## Step 5 — Add monthly controls
+
+**Sample prompt:**
+
+> "Create monthly controls so we do not miss Vietnam HR compliance tasks."
+
+**Generated checklist:**
+
+- [ ] New hires have signed contracts and complete payroll records.
+- [ ] Employee changes are reflected in payroll, social insurance, and tax records.
+- [ ] Work permit renewal dates are reviewed at least 90 days in advance.
+- [ ] Terminations have final pay, return of property, and document retention steps tracked.
+- [ ] Policy acknowledgments are current for active employees.
+- [ ] HR, payroll, and accounting reconcile employee lists before payroll close.
+- [ ] Legal counsel reviews changes when policy, labor rule, or foreign worker questions arise.
+
+## Summary
+
+Use `hr-vietnam-context` to manage Vietnam HR compliance as a recurring workflow with clear owners, document evidence, employee communication, and local legal review where needed.

--- a/examples/workforce-planning/building-a-headcount-plan.md
+++ b/examples/workforce-planning/building-a-headcount-plan.md
@@ -1,0 +1,109 @@
+---
+title: Building a headcount plan
+reference: hr-workforce-planning
+---
+
+# Example: Building a headcount plan
+
+## Context
+
+You are an HR manager supporting annual planning for a 500-person company. Finance needs a headcount plan by department, executives want growth roles prioritized, and managers submitted requests that exceed budget by 25%. You need a structured plan that links roles to business outcomes.
+
+## Step 1 — Clarify planning assumptions
+
+**Sample prompt:**
+
+> "Help me build an annual headcount plan when manager requests exceed budget by 25%."
+
+**Expected skill response:**
+
+- Start with business goals, revenue assumptions, productivity needs, and budget constraints.
+- Separate replacement hiring, approved growth hiring, critical capability gaps, and speculative requests.
+- Use prioritization criteria so leaders can make trade-offs transparently.
+- Align timing with recruiting capacity, onboarding capacity, and payroll forecast.
+
+## Step 2 — Create the request template
+
+**Sample prompt:**
+
+> "Create a headcount request template managers must complete before leadership review."
+
+**Generated template:**
+
+```txt
+Headcount request template
+
+Role title:
+Department:
+Hiring manager:
+Replacement or growth role:
+Target start quarter:
+Estimated compensation range:
+
+Business outcome supported:
+Critical work this role will own:
+Impact if not approved:
+Alternatives considered:
+Required skills and level:
+Dependencies with other teams:
+Ramp time:
+Budget owner:
+```
+
+## Step 3 — Prioritize requests
+
+**Sample prompt:**
+
+> "Create a prioritization scorecard for headcount requests."
+
+**Generated scorecard:**
+
+| Criterion | 1 point | 3 points | 5 points |
+|---|---|---|---|
+| Business impact | Helpful but not tied to a committed goal | Supports department goal | Required for company priority |
+| Urgency | Can wait more than two quarters | Needed within two quarters | Needed this quarter |
+| Risk if delayed | Minor inconvenience | Slower delivery or manager overload | Revenue, compliance, customer, or retention risk |
+| Alternatives | Contractor, automation, or reprioritization likely works | Partial alternative exists | No credible alternative |
+| Budget fit | Not funded | Partially funded | Fully funded or offset identified |
+
+## Step 4 — Build the leadership summary
+
+**Sample prompt:**
+
+> "Write a leadership summary for a plan that approves 30 of 42 requested roles and defers lower-priority roles to midyear review."
+
+**Generated summary:**
+
+```txt
+Annual headcount plan summary
+
+Managers requested 42 roles for the planning year. Based on budget, business priority, and recruiting capacity, the recommended plan approves 30 roles and defers 12 roles to midyear review.
+
+Approved roles are concentrated in customer retention, product delivery, and compliance-critical operations. Deferred roles are important but have lower urgency, partial alternatives, or unclear timing.
+
+Planning trade-offs:
+1. Prioritize roles tied to committed revenue retention and product milestones.
+2. Protect compliance and operational resilience roles.
+3. Defer roles without clear start-quarter need or funded budget.
+4. Reassess deferred roles at midyear based on business performance and attrition.
+```
+
+## Step 5 — Track execution
+
+**Sample prompt:**
+
+> "Create a monthly headcount plan review checklist."
+
+**Generated checklist:**
+
+- [ ] Approved roles match budget and workforce plan version.
+- [ ] Open requisitions are assigned to recruiters.
+- [ ] Start dates are reflected in payroll forecast.
+- [ ] Backfills are separated from growth hiring.
+- [ ] Deferred roles have documented review criteria.
+- [ ] Attrition and internal mobility changes are reflected in the plan.
+- [ ] Leaders review hiring capacity and onboarding constraints.
+
+## Summary
+
+Use `hr-workforce-planning` to convert competing role requests into a budget-aligned headcount plan with clear assumptions, prioritization, leadership trade-offs, and monthly tracking.


### PR DESCRIPTION
### Motivation

- Fill gaps in the examples directory by providing practical, HR-specific scenario examples for non-technical skills used by the agent set. 
- Give HR teams concrete sample prompts, expected outputs, checklists, scorecards, and short workflows they can reuse for common HR operations.

### Description

- Add 15 new example markdown files under `examples/` for the following skills: `hr-analytics`, `hr-compensation-benefits`, `hr-compliance`, `hr-conflict-resolution`, `hr-diversity-inclusion`, `hr-employee-engagement`, `hr-employee-relations`, `hr-leadership-development`, `hr-onboarding`, `hr-performance-management`, `hr-recruiting`, `hr-technology`, `hr-training-development`, `hr-vietnam-context`, and `hr-workforce-planning` (files listed in the commit). 
- Update `examples/README.md` with a new "HR operations examples" table linking each new scenario. 
- Commit with the message `docs(examples): add HR skill examples`.

### Testing

- Ran `git diff --check` which returned clean results. (success)
- Executed a custom Python structure check that verified all 15 files exist, include YAML frontmatter, `## Context`, `**Sample prompt:**`, and `## Summary`. (success)
- Searched new example files and the updated README for forbidden shorthand (`e.g.`, `i.e.`, `etc.`, `&`) which returned no matches. (success)
- `bun run lint:md` could not run because `markdownlint` was not available in the environment. (could not complete)
- `bun install` failed due to registry download errors (HTTP 403) so dependency-based tasks could not be executed. (could not complete)
- `bun run validate` (which depends on `turbo`) could not run because dependencies were not installed. (could not complete)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d02678388327a53ae6a185f30535)