### PR TITLE
docs(examples): add HR operations examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,8 @@
 # Examples
 
-Real-world HR hiring workflow examples powered by HR Skills.
+Real-world HR hiring and operations workflow examples powered by HR Skills.
 
-Each example shows an end-to-end hiring scenario with sample prompts, generated outputs, interview question sets, and evaluation scorecards — demonstrating what the corresponding skill can produce in practice.
+Each example shows an end-to-end HR scenario with sample prompts, generated outputs, and adaptation notes — demonstrating what the corresponding skill can produce in practice.
 
 ## Technical hiring examples
 
@@ -19,10 +19,30 @@ Each example shows an end-to-end hiring scenario with sample prompts, generated 
 | [Hiring a Senior Cloud Security Engineer](./security/hiring-senior-cloud-security-engineer.md) | `hr-security` | AppSec, cloud security, SecOps |
 | [Hiring a Senior Product Designer](./uiux/hiring-senior-product-designer.md) | `hr-uiux` | UI/UX, design systems, user research |
 
+## HR operations examples
+
+| Example | Skill | Scenario |
+|---------|-------|---------|
+| [Analyze turnover risk by department](./analytics/turnover-risk-by-department.md) | `hr-analytics` | Turnover analysis, retention actions, executive reporting |
+| [Benchmark compensation for a new role](./compensation-benefits/benchmark-compensation-for-a-new-role.md) | `hr-compensation-benefits` | Salary bands, market inputs, internal equity |
+| [Review a remote work policy](./compliance/review-remote-work-policy.md) | `hr-compliance` | Policy clarity, compliance review, employee FAQs |
+| [Mediate team conflict after a reorganization](./conflict-resolution/mediate-team-conflict-after-reorganization.md) | `hr-conflict-resolution` | Intake conversations, mediation, working agreements |
+| [Audit promotion fairness signals](./diversity-inclusion/audit-promotion-fairness-signals.md) | `hr-diversity-inclusion` | Promotion criteria, calibration, fairness checkpoints |
+| [Design a stay interview campaign](./employee-engagement/design-stay-interview-campaign.md) | `hr-employee-engagement` | Stay interviews, retention themes, engagement actions |
+| [Document an employee relations case](./employee-relations/document-employee-relations-case.md) | `hr-employee-relations` | Case timelines, neutral documentation, escalation guardrails |
+| [Build a first-time manager program](./leadership-development/build-first-time-manager-program.md) | `hr-leadership-development` | Manager capabilities, learning modules, behavior change |
+| [Create a 30-60-90 day onboarding plan](./onboarding/create-30-60-90-day-onboarding-plan.md) | `hr-onboarding` | Role milestones, stakeholder mapping, manager check-ins |
+| [Write a performance improvement plan](./performance-management/write-performance-improvement-plan.md) | `hr-performance-management` | Performance expectations, support plans, progress check-ins |
+| [Plan a structured recruiting process](./recruiting/plan-structured-recruiting-process.md) | `hr-recruiting` | Intake alignment, scorecards, interview stages |
+| [Select an HRIS replacement](./technology/select-hris-replacement.md) | `hr-technology` | Vendor evaluation, integrations, implementation risk |
+| [Create a skills gap training plan](./training-development/create-skills-gap-training-plan.md) | `hr-training-development` | Capability assessment, learning interventions, skill transfer |
+| [Prepare Vietnam employee onboarding checklist](./vietnam-context/prepare-vietnam-employee-onboarding-checklist.md) | `hr-vietnam-context` | Local onboarding, payroll steps, compliance review points |
+| [Model hiring needs for a growth plan](./workforce-planning/model-hiring-needs-for-growth-plan.md) | `hr-workforce-planning` | Headcount assumptions, role timing, workforce options |
+
 ## How to use these examples
 
 1. Install the corresponding skill into Claude.
 2. Replicate the sample prompts from each example in your own conversation.
-3. Adapt the generated job descriptions, interview questions, and scorecards to your company's context.
+3. Adapt the generated plans, templates, questions, and scorecards to your company's context.
 
 See [docs/skills.md](../docs/skills.md) for trigger phrases and coverage details for all 25 skills.

--- a/examples/analytics/turnover-risk-by-department.md
+++ b/examples/analytics/turnover-risk-by-department.md
@@ -1,0 +1,35 @@
+---
+title: Analyze turnover risk by department
+reference: hr-analytics
+---
+
+# Example: Analyze turnover risk by department
+
+## Context
+
+An HR manager needs to explain rising voluntary turnover to the leadership team and prioritize retention actions by department.
+
+## Sample workflow
+
+Use `hr-analytics` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: an HR manager needs to explain rising voluntary turnover to the leadership team and prioritize retention actions by department. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Clean and define the turnover dataset
+- Segment regrettable and non-regrettable exits
+- Identify departments with concentrated risk
+- Draft an executive summary with recommended actions
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/compensation-benefits/benchmark-compensation-for-a-new-role.md
+++ b/examples/compensation-benefits/benchmark-compensation-for-a-new-role.md
@@ -1,0 +1,35 @@
+---
+title: Benchmark compensation for a new role
+reference: hr-compensation-benefits
+---
+
+# Example: Benchmark compensation for a new role
+
+## Context
+
+A people team needs to price a newly created role without creating internal equity issues or unclear offer guidance.
+
+## Sample workflow
+
+Use `hr-compensation-benefits` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a people team needs to price a newly created role without creating internal equity issues or unclear offer guidance. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Define the role level and compensable factors
+- Compare market range inputs with internal peers
+- Recommend a salary band and offer guardrails
+- Prepare a manager-facing explanation
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/compliance/review-remote-work-policy.md
+++ b/examples/compliance/review-remote-work-policy.md
@@ -1,0 +1,35 @@
+---
+title: Review a remote work policy
+reference: hr-compliance
+---
+
+# Example: Review a remote work policy
+
+## Context
+
+An HR manager needs to review a remote work policy for consistency, employee clarity, and compliance escalation points.
+
+## Sample workflow
+
+Use `hr-compliance` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: an HR manager needs to review a remote work policy for consistency, employee clarity, and compliance escalation points. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Identify policy sections that need legal review
+- Clarify eligibility and approval rules
+- Add documentation and data-security expectations
+- Prepare an employee-friendly FAQ
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/conflict-resolution/mediate-team-conflict-after-reorganization.md
+++ b/examples/conflict-resolution/mediate-team-conflict-after-reorganization.md
@@ -1,0 +1,35 @@
+---
+title: Mediate team conflict after a reorganization
+reference: hr-conflict-resolution
+---
+
+# Example: Mediate team conflict after a reorganization
+
+## Context
+
+A manager reports escalating friction between two team leads after a reporting-line change, and HR needs a structured mediation plan.
+
+## Sample workflow
+
+Use `hr-conflict-resolution` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a manager reports escalating friction between two team leads after a reporting-line change, and HR needs a structured mediation plan. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Gather facts without taking sides
+- Plan separate intake conversations
+- Facilitate a joint working agreement
+- Define follow-up checkpoints
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/diversity-inclusion/audit-promotion-fairness-signals.md
+++ b/examples/diversity-inclusion/audit-promotion-fairness-signals.md
@@ -1,0 +1,35 @@
+---
+title: Audit promotion fairness signals
+reference: hr-diversity-inclusion
+---
+
+# Example: Audit promotion fairness signals
+
+## Context
+
+An HR business partner wants to check whether promotion outcomes reflect consistent criteria across employee groups.
+
+## Sample workflow
+
+Use `hr-diversity-inclusion` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: an HR business partner wants to check whether promotion outcomes reflect consistent criteria across employee groups. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Review promotion criteria and calibration notes
+- Compare outcomes by relevant demographics where legally allowed
+- Spot process gaps and manager discretion risks
+- Recommend fairer decision checkpoints
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/employee-engagement/design-stay-interview-campaign.md
+++ b/examples/employee-engagement/design-stay-interview-campaign.md
@@ -1,0 +1,35 @@
+---
+title: Design a stay interview campaign
+reference: hr-employee-engagement
+---
+
+# Example: Design a stay interview campaign
+
+## Context
+
+A company wants to understand why high-performing employees stay and what might cause them to leave.
+
+## Sample workflow
+
+Use `hr-employee-engagement` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a company wants to understand why high-performing employees stay and what might cause them to leave. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Select employee segments and interview goals
+- Draft stay interview questions
+- Create a synthesis plan for themes
+- Turn findings into retention experiments
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/employee-relations/document-employee-relations-case.md
+++ b/examples/employee-relations/document-employee-relations-case.md
@@ -1,0 +1,35 @@
+---
+title: Document an employee relations case
+reference: hr-employee-relations
+---
+
+# Example: Document an employee relations case
+
+## Context
+
+An HR generalist needs to document a sensitive employee relations concern with neutral language and clear next steps.
+
+## Sample workflow
+
+Use `hr-employee-relations` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: an HR generalist needs to document a sensitive employee relations concern with neutral language and clear next steps. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Create a fact-based case timeline
+- Separate observations from conclusions
+- Prepare interview questions
+- Define escalation and confidentiality guardrails
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/leadership-development/build-first-time-manager-program.md
+++ b/examples/leadership-development/build-first-time-manager-program.md
@@ -1,0 +1,35 @@
+---
+title: Build a first-time manager program
+reference: hr-leadership-development
+---
+
+# Example: Build a first-time manager program
+
+## Context
+
+A growing company needs a practical development path for newly promoted managers who have limited people-leadership experience.
+
+## Sample workflow
+
+Use `hr-leadership-development` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a growing company needs a practical development path for newly promoted managers who have limited people-leadership experience. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Define first-time manager capabilities
+- Sequence learning modules and practice assignments
+- Add manager coaching prompts
+- Measure behavior change after the program
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/onboarding/create-30-60-90-day-onboarding-plan.md
+++ b/examples/onboarding/create-30-60-90-day-onboarding-plan.md
@@ -1,0 +1,35 @@
+---
+title: Create a 30-60-90 day onboarding plan
+reference: hr-onboarding
+---
+
+# Example: Create a 30-60-90 day onboarding plan
+
+## Context
+
+A hiring manager needs a structured onboarding plan for a new employee joining a cross-functional role.
+
+## Sample workflow
+
+Use `hr-onboarding` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a hiring manager needs a structured onboarding plan for a new employee joining a cross-functional role. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Clarify role outcomes and stakeholders
+- Map first-week logistics and access needs
+- Set 30, 60, and 90 day milestones
+- Create manager check-in prompts
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/performance-management/write-performance-improvement-plan.md
+++ b/examples/performance-management/write-performance-improvement-plan.md
@@ -1,0 +1,35 @@
+---
+title: Write a performance improvement plan
+reference: hr-performance-management
+---
+
+# Example: Write a performance improvement plan
+
+## Context
+
+A manager needs to address repeated missed deliverables while giving the employee clear expectations and support.
+
+## Sample workflow
+
+Use `hr-performance-management` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a manager needs to address repeated missed deliverables while giving the employee clear expectations and support. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Translate concerns into observable behaviors
+- Define measurable improvement goals
+- Add support resources and check-ins
+- Draft neutral PIP language
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/recruiting/plan-structured-recruiting-process.md
+++ b/examples/recruiting/plan-structured-recruiting-process.md
@@ -1,0 +1,35 @@
+---
+title: Plan a structured recruiting process
+reference: hr-recruiting
+---
+
+# Example: Plan a structured recruiting process
+
+## Context
+
+A recruiter needs a consistent process for a business-critical role before opening the requisition.
+
+## Sample workflow
+
+Use `hr-recruiting` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a recruiter needs a consistent process for a business-critical role before opening the requisition. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Align intake questions with the hiring manager
+- Define scorecard competencies
+- Design interview stages and decision rules
+- Prepare candidate communication templates
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/technology/select-hris-replacement.md
+++ b/examples/technology/select-hris-replacement.md
@@ -1,0 +1,35 @@
+---
+title: Select an HRIS replacement
+reference: hr-technology
+---
+
+# Example: Select an HRIS replacement
+
+## Context
+
+An HR operations lead needs to compare HRIS vendors and reduce implementation risk before making a recommendation.
+
+## Sample workflow
+
+Use `hr-technology` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: an HR operations lead needs to compare HRIS vendors and reduce implementation risk before making a recommendation. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Define functional and integration requirements
+- Build a vendor evaluation scorecard
+- Plan data migration and change management
+- Draft an executive recommendation
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/training-development/create-skills-gap-training-plan.md
+++ b/examples/training-development/create-skills-gap-training-plan.md
@@ -1,0 +1,35 @@
+---
+title: Create a skills gap training plan
+reference: hr-training-development
+---
+
+# Example: Create a skills gap training plan
+
+## Context
+
+A department leader sees inconsistent capability across a team and asks HR to design targeted learning support.
+
+## Sample workflow
+
+Use `hr-training-development` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a department leader sees inconsistent capability across a team and asks HR to design targeted learning support. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Define the required skills and proficiency levels
+- Assess current capability signals
+- Prioritize learning interventions
+- Measure transfer to on-the-job behavior
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/vietnam-context/prepare-vietnam-employee-onboarding-checklist.md
+++ b/examples/vietnam-context/prepare-vietnam-employee-onboarding-checklist.md
@@ -1,0 +1,35 @@
+---
+title: Prepare Vietnam employee onboarding checklist
+reference: hr-vietnam-context
+---
+
+# Example: Prepare Vietnam employee onboarding checklist
+
+## Context
+
+A regional HR team needs a Vietnam-specific onboarding checklist for a local employee while flagging items that require current legal review.
+
+## Sample workflow
+
+Use `hr-vietnam-context` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a regional HR team needs a Vietnam-specific onboarding checklist for a local employee while flagging items that require current legal review. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Collect required employee information
+- Coordinate contract, payroll, tax, and social insurance steps
+- Set local culture and communication expectations
+- Flag compliance items for qualified local review
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.

--- a/examples/workforce-planning/model-hiring-needs-for-growth-plan.md
+++ b/examples/workforce-planning/model-hiring-needs-for-growth-plan.md
@@ -1,0 +1,35 @@
+---
+title: Model hiring needs for a growth plan
+reference: hr-workforce-planning
+---
+
+# Example: Model hiring needs for a growth plan
+
+## Context
+
+A leadership team has approved a growth target, and HR needs to translate it into phased headcount assumptions.
+
+## Sample workflow
+
+Use `hr-workforce-planning` to work through the scenario in stages instead of asking for a single broad output.
+
+**Sample prompt:**
+
+> "Help me with this scenario: a leadership team has approved a growth target, and HR needs to translate it into phased headcount assumptions. Build a practical HR workflow I can adapt for my organization."
+
+**Expected skill support:**
+
+- Connect business goals to workforce demand
+- Model build, buy, borrow, and automate options
+- Identify critical roles and timing risks
+- Create an executive planning narrative
+
+## Follow-up prompts
+
+- "What information should I collect before I act?"
+- "Draft a manager-ready version with clear next steps."
+- "List the risks, assumptions, and review points I should confirm with internal stakeholders."
+
+## Adaptation notes
+
+Replace placeholders with your organization's role names, policies, employee segments, timeline, and review requirements. For legal, payroll, tax, benefits, immigration, or employee relations decisions, use the skill output as preparation for qualified internal or external review.


### PR DESCRIPTION
### Motivation
- Provide concrete HR operations examples to complement the existing technical hiring examples and demonstrate non-technical HR workflows. 
- Ensure `examples/README.md` reflects both hiring and HR operations content and links to the new example files.

### Description
- Add new example files under `examples/analytics/`, `examples/compensation-benefits/`, `examples/compliance/`, `examples/conflict-resolution/`, `examples/diversity-inclusion/`, `examples/employee-engagement/`, `examples/employee-relations/`, `examples/leadership-development/`, `examples/onboarding/`, `examples/performance-management/`, `examples/recruiting/`, `examples/technology/`, `examples/training-development/`, `examples/vietnam-context/`, and `examples/workforce-planning/` that follow the existing example structure. 
- Update `examples/README.md` to add a new `## HR operations examples` section below `## Technical hiring examples` with a markdown table (columns: `Example`, `Skill`, `Scenario`) linking to each new example. 
- Refresh the README overview and usage wording to cover both technical hiring and HR operations examples while leaving the technical hiring table unchanged.

### Testing
- Ran a Python link resolver that verified all local links in `examples/README.md` resolve successfully. 
- Attempted `bun run lint:md` but it could not run because `bun install` failed while fetching dependencies (npm registry 403 errors). 
- Attempted `bun run validate` but it could not run because workspace tooling could not be installed due to the same dependency/network failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d02854bc8327b0b148ed8b7ad76a)