### PR TITLE
docs(content): add example workflow links

### DIFF
--- a/content/hr-ai/README.md
+++ b/content/hr-ai/README.md
@@ -171,6 +171,10 @@ Hiring AI talent now requires understanding both:
 - software engineering fundamentals
 - and AI system design principles
 
+## Example workflow
+
+See the [senior AI engineer hiring workflow](../../examples/ai/hiring-a-senior-ai-engineer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 For HR and recruiters, the key shift is this:

--- a/content/hr-backend/README.md
+++ b/content/hr-backend/README.md
@@ -334,6 +334,10 @@ Strong resumes typically show:
 - database and API design experience
 - cloud infrastructure exposure
 
+## Example workflow
+
+See the [senior backend engineer hiring workflow](../../examples/backend/hiring-a-senior-backend-engineer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 Backend engineering is fundamentally about building reliable, scalable, and secure systems.

--- a/content/hr-data/README.md
+++ b/content/hr-data/README.md
@@ -333,6 +333,10 @@ Strong candidates show:
 - data modeling experience
 - cloud data ecosystem exposure
 
+## Example workflow
+
+See the [senior data engineer hiring workflow](../../examples/data/hiring-a-senior-data-engineer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 Data roles are evolving into a central infrastructure layer for AI and modern software systems.

--- a/content/hr-devops/README.md
+++ b/content/hr-devops/README.md
@@ -326,6 +326,10 @@ Strong candidates show:
 - ignoring production incident experience
 - mixing DevOps with unrelated roles in job descriptions
 
+## Example workflow
+
+See the [senior DevOps engineer hiring workflow](../../examples/devops/hiring-a-senior-devops-engineer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 DevOps is fundamentally about building reliable and automated systems for software delivery and infrastructure management.

--- a/content/hr-frontend/README.md
+++ b/content/hr-frontend/README.md
@@ -333,6 +333,10 @@ Strong portfolios demonstrate:
 - responsive design across devices
 - thoughtful UI/UX decisions
 
+## Example workflow
+
+See the [senior frontend engineer hiring workflow](../../examples/frontend/hiring-a-senior-frontend-engineer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 Frontend engineering is a multidisciplinary discipline combining UI development, system design, performance engineering, and user experience optimization.

--- a/content/hr-fullstack/README.md
+++ b/content/hr-fullstack/README.md
@@ -360,6 +360,10 @@ Major trends include:
 - monorepo architectures
 - fullstack frameworks with integrated tooling
 
+## Example workflow
+
+See the [senior fullstack engineer hiring workflow](../../examples/fullstack/hiring-a-senior-fullstack-engineer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 Fullstack engineering is fundamentally about building and delivering complete software systems.

--- a/content/hr-mobile/README.md
+++ b/content/hr-mobile/README.md
@@ -434,6 +434,10 @@ Mobile engineering increasingly overlaps with:
 - analytics
 - platform engineering
 
+## Example workflow
+
+See the [senior mobile engineer hiring workflow](../../examples/mobile/hiring-a-senior-mobile-engineer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 Mobile engineering is fundamentally about building performant, reliable, and user-centered applications across highly constrained device ecosystems.

--- a/content/hr-qa/README.md
+++ b/content/hr-qa/README.md
@@ -368,6 +368,10 @@ Major trends include:
 - quality engineering maturity
 - production observability integration
 
+## Example workflow
+
+See the [senior QA automation engineer hiring workflow](../../examples/qa/hiring-a-senior-qa-automation-engineer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 Modern QA is increasingly an engineering discipline focused on reliability, release confidence, and scalable software quality.

--- a/content/hr-security/README.md
+++ b/content/hr-security/README.md
@@ -461,6 +461,10 @@ Key trends include:
 - identity-first security strategies
 - post-quantum security preparation
 
+## Example workflow
+
+See the [senior cloud security engineer hiring workflow](../../examples/security/hiring-senior-cloud-security-engineer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 Modern cybersecurity is a strategic engineering and risk-management discipline focused on resilience, operational security, and secure system design.

--- a/content/hr-uiux/README.md
+++ b/content/hr-uiux/README.md
@@ -482,6 +482,10 @@ Key trends include:
 - motion and interaction systems
 - cross-functional product collaboration
 
+## Example workflow
+
+See the [senior product designer hiring workflow](../../examples/uiux/hiring-senior-product-designer.md) for an example of applying this guide to an end-to-end hiring process.
+
 ## Conclusion
 
 Modern UI/UX and Product Design are strategic disciplines focused on usability, product outcomes, accessibility, and scalable user experiences.


### PR DESCRIPTION
### Motivation

- Improve discoverability by linking content guides to concrete example workflows that demonstrate how to apply the guidance in practice. 
- Add concise `## Example workflow` sections to content guides that have matching example files so readers can follow an end-to-end hiring scenario. 

### Description

- Inserted a `## Example workflow` section immediately before `## Conclusion` in ten content guides: `content/hr-ai/README.md`, `content/hr-backend/README.md`, `content/hr-data/README.md`, `content/hr-devops/README.md`, `content/hr-frontend/README.md`, `content/hr-fullstack/README.md`, `content/hr-mobile/README.md`, `content/hr-qa/README.md`, `content/hr-security/README.md`, and `content/hr-uiux/README.md`. 
- Each new section uses the sentence case heading `## Example workflow` followed by a single concise sentence linking to the corresponding example under `examples/...`. 
- Links point to the relative example files such as `../../examples/ai/hiring-a-senior-ai-engineer.md` and follow the repository markdown conventions required by the content guidelines. 

### Testing

- Ran `git diff --check` which produced no whitespace or diff-check errors and passed. 
- Ran a custom Python verification that confirmed each `## Example workflow` section appears before the `## Conclusion` heading and that each target example file exists, which passed. 
- Attempted `bun run lint:md` but it failed because `markdownlint` was not available in the environment, so markdown linting could not be completed. 
- Attempted dependency install with `bun install` and `bun run validate` but they failed due to missing toolchain and registry access (npm `403` responses and `turbo` not installed), so workspace validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d02e5d7c832797ca2138daa8777c)