### PR TITLE
docs(examples): add links to example hiring workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ cp -r skills/hr-{skill-name} ~/.claude/skills/
 
 **claude.ai:** Add the skill's `SKILL.md` to your project knowledge, or paste the content into the conversation.
 
+## Examples
+
+Use the [example workflows](./examples/) to see how the technical hiring skills support end-to-end recruiting scenarios. The examples include sample prompts, generated job descriptions, interview question sets, and scorecards for AI, backend, data, DevOps, frontend, fullstack, mobile, QA, security, and UI/UX roles.
+
 ## Skill structure
 
 Each skill contains:
@@ -43,7 +47,7 @@ bun run lint         # Run Biome checks with auto-fix
 bun run format       # Format files with Biome
 bun run lint:md      # markdownlint + case-police on Markdown files
 bun run lint:md:fix  # markdownlint + case-police with auto-fix
-bun run lint:links   # Check Markdown links in skills/
+bun run lint:links   # Check Markdown links in content, docs, examples, and skills
 bun run knip         # Detect unused files and dependencies
 bun run zip          # Generate distributable skill zip packages
 bun run release      # Bump version, generate changelog, commit, tag, and push

--- a/content/hr-ai/README.md
+++ b/content/hr-ai/README.md
@@ -7,6 +7,8 @@ skill: hr-ai
 
 ## Overview
 
+> Related example: [Senior AI Engineer hiring workflow](../../examples/ai/hiring-a-senior-ai-engineer.md).
+
 Artificial Intelligence (AI) in hiring is no longer limited to automation tools or keyword-based screening systems. In modern organizations, AI spans across machine learning systems, generative AI applications, large language models (LLMs), and production-grade AI infrastructure.
 
 For HR professionals and recruiters, understanding AI is not about becoming engineers. It is about developing the ability to evaluate candidates, interpret technical claims, and make informed hiring decisions in a rapidly evolving technical landscape.

--- a/content/hr-backend/README.md
+++ b/content/hr-backend/README.md
@@ -7,6 +7,8 @@ skill: hr-backend
 
 ## Overview
 
+> Related example: [Senior Backend Engineer hiring workflow](../../examples/backend/hiring-a-senior-backend-engineer.md).
+
 Backend engineering is the foundation of modern software systems. It covers everything that happens behind the user interface — data processing, APIs, authentication, business logic, databases, and infrastructure.
 
 For HR and recruiters, backend understanding is essential to evaluate candidate depth beyond buzzwords and identify real engineering capability in system design and production environments.

--- a/content/hr-data/README.md
+++ b/content/hr-data/README.md
@@ -7,6 +7,8 @@ skill: hr-data
 
 ## Overview
 
+> Related example: [Senior Data Engineer hiring workflow](../../examples/data/hiring-a-senior-data-engineer.md).
+
 Data roles sit at the core of modern digital organizations. They power:
 
 - decision-making

--- a/content/hr-devops/README.md
+++ b/content/hr-devops/README.md
@@ -7,6 +7,8 @@ skill: hr-devops
 
 ## Overview
 
+> Related example: [Senior DevOps Engineer hiring workflow](../../examples/devops/hiring-a-senior-devops-engineer.md).
+
 DevOps sits at the intersection of software engineering and IT operations. It focuses on building systems that enable:
 
 - fast software delivery

--- a/content/hr-frontend/README.md
+++ b/content/hr-frontend/README.md
@@ -7,6 +7,8 @@ skill: hr-frontend
 
 ## Overview
 
+> Related example: [Senior Frontend Engineer hiring workflow](../../examples/frontend/hiring-a-senior-frontend-engineer.md).
+
 Frontend engineering focuses on everything users directly interact with in a web application — interfaces, user experience, performance, and visual behavior.
 
 For HR and recruiters, frontend understanding is critical because frontend quality is highly visible in products and strongly impacts user experience, engagement, and business metrics such as conversion rate and retention.

--- a/content/hr-fullstack/README.md
+++ b/content/hr-fullstack/README.md
@@ -7,6 +7,8 @@ skill: hr-fullstack
 
 ## Overview
 
+> Related example: [Senior Fullstack Engineer hiring workflow](../../examples/fullstack/hiring-a-senior-fullstack-engineer.md).
+
 Fullstack engineering focuses on building complete applications across both frontend and backend systems.
 
 A fullstack engineer typically works across:

--- a/content/hr-mobile/README.md
+++ b/content/hr-mobile/README.md
@@ -7,6 +7,8 @@ skill: hr-mobile
 
 ## Overview
 
+> Related example: [Senior Mobile Engineer hiring workflow](../../examples/mobile/hiring-a-senior-mobile-engineer.md).
+
 Mobile engineering focuses on building applications for mobile devices such as smartphones and tablets across iOS, Android, and cross-platform ecosystems.
 
 Modern mobile engineering is no longer limited to:

--- a/content/hr-qa/README.md
+++ b/content/hr-qa/README.md
@@ -7,6 +7,8 @@ skill: hr-qa
 
 ## Overview
 
+> Related example: [Senior QA Automation Engineer hiring workflow](../../examples/qa/hiring-a-senior-qa-automation-engineer.md).
+
 Quality Assurance (QA) focuses on ensuring software systems are reliable, stable, usable, and safe to release into production.
 
 Modern QA is no longer limited to:

--- a/content/hr-security/README.md
+++ b/content/hr-security/README.md
@@ -7,6 +7,8 @@ skill: hr-security
 
 ## Overview
 
+> Related example: [Senior Cloud Security Engineer hiring workflow](../../examples/security/hiring-senior-cloud-security-engineer.md).
+
 Cybersecurity focuses on protecting systems, applications, infrastructure, data, and organizations from threats, attacks, misuse, and operational risks.
 
 Modern cybersecurity is no longer simply:

--- a/content/hr-uiux/README.md
+++ b/content/hr-uiux/README.md
@@ -7,6 +7,8 @@ skill: hr-uiux
 
 ## Overview
 
+> Related example: [Senior Product Designer hiring workflow](../../examples/uiux/hiring-senior-product-designer.md).
+
 UI/UX and Product Design focus on creating digital experiences that are:
 
 - usable

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"format": "biome format . --write",
 		"lint:md": "markdownlint . && case-police .",
 		"lint:md:fix": "markdownlint . --fix && case-police . --fix",
-		"lint:links": "markdown-link-check -c config.json ./content ./docs ./skills",
+		"lint:links": "markdown-link-check -c config.json ./content ./docs ./examples ./skills",
 		"knip": "knip",
 		"sync": "turbo run sync --filter=hr-skills-build",
 		"catalog": "turbo run catalog --filter=hr-skills-build",


### PR DESCRIPTION
### Motivation

- Surface the repository's example hiring workflows in the top-level docs so users can discover end-to-end technical hiring scenarios quickly. 
- Link domain content pages to the matching example to make it easy to jump from guidance to a full example workflow. 
- Ensure link-checking covers the new `examples/` directory so CI and local checks validate those references.

### Description

- Add an `## Examples` section to the root `README.md` linking to `./examples/` and update the dev commands copy to note examples are included in link checks. 
- Insert a `> Related example: [...]` link in `content/*/README.md` for the following skills: `hr-ai`, `hr-backend`, `hr-data`, `hr-devops`, `hr-frontend`, `hr-fullstack`, `hr-mobile`, `hr-qa`, `hr-security`, and `hr-uiux`. 
- Update the `lint:links` script in `package.json` to include `./examples` in the `markdown-link-check` targets. 
- Commit with the message `docs(examples): add content workflow links` and open the PR.

### Testing

- `bun install` (failed because package downloads returned `403` from the npm registry, leaving CLI tools unavailable). 
- `bun run validate` (failed because `turbo` was not available after dependency install failed). 
- `bun run lint:md` (failed because `markdownlint` was not available after dependency install failed). 
- `bun run lint:links` (failed because `markdown-link-check` was not available after dependency install failed). 
- `bun run check` (failed because `biome` was not available after dependency install failed). 
- Local Python link resolver checked all touched markdown links and reported they resolve successfully. 
- `python3 -m json.tool package.json` reported `package.json` is valid JSON. 
- `git diff --check` passed with no whitespace or merge issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d030206c83279a2ea2089e7670b7)