### PR TITLE
docs(readme): clarify repository maturity and skill coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Built by [Tuan Duc Tran](https://linkedin.com/in/tuanductran) for members of the
 
 Skills follow the [Agent Skills](https://agentskills.io/) format.
 
+> ⚠️ **HR Skills is actively maintained and evolves continuously.** The repository is fully usable, but not every skill has the same level of coverage or supporting resources. Some skills intentionally consist of only a `SKILL.md`, while others also include examples, prompts, reference content, or additional tooling. This variation is intentional and reflects the needs of each skill. Repository conventions, validation rules, and supporting resources may evolve between releases. [Issues](https://github.com/tuanductran/hr-skills/issues), pull requests, and community feedback are always welcome.
+
 ## Coverage
 
 HR Skills covers the full employee lifecycle and modern HR practice, including:


### PR DESCRIPTION
# What changed?

Added a repository status notice to the README to clarify that HR Skills is actively maintained, that skill coverage intentionally varies between skills, and that community feedback and contributions are welcome.

## Content Type

- [ ] Skill definition
- [ ] Competency framework
- [ ] Interview questions
- [ ] Assessment criteria
- [ ] Recruiting workflow
- [ ] AI prompt
- [x] Documentation
- [ ] Tooling / Configuration

## Why?

Clarifies the repository's development status and prevents contributors and AI assistants from assuming that every skill must have identical structure or supporting resources. This reduces confusion around intentionally different levels of skill coverage.

## Related Issue

N/A

## Validation

- [x] Content reviewed for accuracy
- [ ] No duplicate information exists
- [x] Links and references verified
- [x] Formatting follows repository standards
- [x] CI checks pass

## Commit Convention

- [x] Commits follow Conventional Commits
