### PR TITLE
feat(skills): expand HR skills catalog and refresh marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,6 +3,14 @@
   "description": "A collection of AI skills for HR managers covering recruiting, performance management, compensation, compliance, and all major HR domains. Built by Tuan Duc Tran for the Zalo HR/TA Job Onsite/Hybrid/Remote community.",
   "plugins": [
     {
+      "name": "hr-accessibility-accommodation",
+      "source": "./",
+      "description": "Help HR and people ops teams design and manage workplace accessibility and disability accommodation as a first-class, proactive practice, not just an ADA compliance checklist. Use when asked to \"design an accommodation request process\", \"handle a disability accommodation request\", \"make our hiring process more accessible\", \"audit our workplace for accessibility\", or \"train managers on supporting accommodations\".",
+      "skills": [
+        "./skills/hr-accessibility-accommodation"
+      ]
+    },
+    {
       "name": "hr-agentic-ai",
       "source": "./",
       "description": "Help HR leaders, HR technology teams, and People Ops professionals understand, evaluate, and govern agentic AI systems deployed in HR contexts, including autonomous HR agents, multi-agent workflows, and AI-driven HR process automation. Use when asked to \"use AI agents for HR\", \"build an HR automation agent\", \"govern agentic AI in HR\", \"design multi-agent HR workflows\", or \"evaluate autonomous AI for HR processes\".",
@@ -125,7 +133,7 @@
     {
       "name": "hr-candidate-assessment",
       "source": "./",
-      "description": "Help recruiters and hiring managers design and run structured candidate assessments beyond interviews — skills tests, work samples, assessment centers, and scoring rubrics. Use when asked to \"design a candidate assessment\", \"build a skills test for [role]\", \"create an assessment center\", \"build a scoring rubric\", or \"choose the right assessment method for this role\".",
+      "description": "Help recruiters and hiring managers design and run structured candidate assessments beyond interviews \u2014 skills tests, work samples, assessment centers, and scoring rubrics. Use when asked to \"design a candidate assessment\", \"build a skills test for [role]\", \"create an assessment center\", \"build a scoring rubric\", or \"choose the right assessment method for this role\".",
       "skills": [
         "./skills/hr-candidate-assessment"
       ]
@@ -168,6 +176,14 @@
       "description": "Help HR leaders, change managers, and business partners design, lead, and sustain organizational change initiatives. Use when asked to \"design a change management plan\", \"advise leadership on change communication\", \"build a stakeholder engagement strategy\", \"create a change readiness assessment\", \"design training and enablement for change adoption\", \"measure change success\", or any task where HR needs to guide leaders and employees through organizational change.",
       "skills": [
         "./skills/hr-change-management"
+      ]
+    },
+    {
+      "name": "hr-chatbot-design",
+      "source": "./",
+      "description": "Help HR technology teams design HR service-delivery chatbots and conversational tools for platforms like Slack and Microsoft Teams. Use when asked to \"design an HR chatbot\", \"build a Slack bot for HR questions\", \"plan a Teams HR assistant\", \"write conversation flows for an HR bot\", or \"decide what an HR bot should and shouldn't handle\".",
+      "skills": [
+        "./skills/hr-chatbot-design"
       ]
     },
     {
@@ -237,7 +253,7 @@
     {
       "name": "hr-crisis-management",
       "source": "./",
-      "description": "Help HR and business leaders plan for and respond to workforce crises — layoffs handled poorly, safety incidents, natural disasters, leadership scandals, or sudden business disruption. Use when asked to \"build a crisis response plan for HR\", \"respond to a workplace incident\", \"communicate during a crisis\", \"plan for business continuity from an HR perspective\", or \"handle a sudden leadership departure crisis\".",
+      "description": "Help HR and business leaders plan for and respond to workforce crises \u2014 layoffs handled poorly, safety incidents, natural disasters, leadership scandals, or sudden business disruption. Use when asked to \"build a crisis response plan for HR\", \"respond to a workplace incident\", \"communicate during a crisis\", \"plan for business continuity from an HR perspective\", or \"handle a sudden leadership departure crisis\".",
       "skills": [
         "./skills/hr-crisis-management"
       ]
@@ -579,6 +595,14 @@
       ]
     },
     {
+      "name": "hr-ma-integration-by-country",
+      "source": "./",
+      "description": "Help HR and integration leaders navigate country-specific labor law and cultural considerations when integrating an acquired workforce in major markets like the US, EU, and India. Use when asked to \"what labor law applies to this M&A integration in [country]\", \"compare works council requirements across our merger markets\", \"plan country-specific integration steps for [US/EU/India]\", or \"identify country-level people risks in this cross-border deal\".",
+      "skills": [
+        "./skills/hr-ma-integration-by-country"
+      ]
+    },
+    {
       "name": "hr-manager-effectiveness",
       "source": "./",
       "description": "Help HR teams measure, improve, and develop manager effectiveness across the organization. Use when asked to \"assess manager effectiveness\", \"improve manager quality\", \"build a manager effectiveness program\", \"measure people manager performance\", \"run a manager 360\", \"identify underperforming managers\", or \"develop our management population\".",
@@ -597,7 +621,7 @@
     {
       "name": "hr-mergers-acquisitions",
       "source": "./",
-      "description": "Help HR leaders manage the people dimensions of M&A transactions — due diligence, deal structuring input, and pre-close workforce planning. Use when asked to \"conduct HR due diligence for an acquisition\", \"assess culture fit before a merger\", \"plan workforce implications of a deal\", \"build an M&A HR integration plan\", or \"identify people risks in this transaction\".",
+      "description": "Help HR leaders manage the people dimensions of M&A transactions \u2014 due diligence, deal structuring input, and pre-close workforce planning. Use when asked to \"conduct HR due diligence for an acquisition\", \"assess culture fit before a merger\", \"plan workforce implications of a deal\", \"build an M&A HR integration plan\", or \"identify people risks in this transaction\".",
       "skills": [
         "./skills/hr-mergers-acquisitions"
       ]
@@ -621,7 +645,7 @@
     {
       "name": "hr-offer-management",
       "source": "./",
-      "description": "Help recruiters and hiring managers manage the offer process from approval through acceptance — offer construction, approval workflows, negotiation, and counteroffer handling. Use when asked to \"build an offer package\", \"manage the offer approval process\", \"handle a counteroffer\", \"negotiate salary with a candidate\", or \"track offer status across open roles\".",
+      "description": "Help recruiters and hiring managers manage the offer process from approval through acceptance \u2014 offer construction, approval workflows, negotiation, and counteroffer handling. Use when asked to \"build an offer package\", \"manage the offer approval process\", \"handle a counteroffer\", \"negotiate salary with a candidate\", or \"track offer status across open roles\".",
       "skills": [
         "./skills/hr-offer-management"
       ]
@@ -691,6 +715,14 @@
       ]
     },
     {
+      "name": "hr-people-budgeting",
+      "source": "./",
+      "description": "Help HR leaders and people finance partners own the people budget \u2014 headcount cost-center modeling, budget planning cycles, and variance tracking. Use when asked to \"build the people budget\", \"model headcount by cost center\", \"explain budget variance to finance\", \"plan the HR budget for next fiscal year\", or \"reconcile actual headcount spend against plan\".",
+      "skills": [
+        "./skills/hr-people-budgeting"
+      ]
+    },
+    {
       "name": "hr-people-leadership",
       "source": "./",
       "description": "Help HR teams, managers, and people leaders build strong people leadership capabilities including team leadership, coaching, feedback, accountability, psychological safety, and inclusive leadership. Use when asked to develop people leadership skills, coach a manager, improve team leadership, build a leadership culture, give feedback to a manager, or assess people leadership effectiveness., or coach or develop an individual people leader",
@@ -733,7 +765,7 @@
     {
       "name": "hr-post-merger-integration",
       "source": "./",
-      "description": "Help HR and integration leaders manage the people side of post-close M&A integration — org design harmonization, culture integration, systems consolidation, and retention through the transition. Use when asked to \"plan post-merger HR integration\", \"harmonize two organizations after a merger\", \"integrate compensation and benefits post-close\", \"manage culture integration after an acquisition\", or \"retain talent through post-merger transition\".",
+      "description": "Help HR and integration leaders manage the people side of post-close M&A integration \u2014 org design harmonization, culture integration, systems consolidation, and retention through the transition. Use when asked to \"plan post-merger HR integration\", \"harmonize two organizations after a merger\", \"integrate compensation and benefits post-close\", \"manage culture integration after an acquisition\", or \"retain talent through post-merger transition\".",
       "skills": [
         "./skills/hr-post-merger-integration"
       ]
@@ -805,7 +837,7 @@
     {
       "name": "hr-recruitment-operations",
       "source": "./",
-      "description": "Help TA operations leaders design and run the operational backbone of recruiting — requisition workflows, ATS process design, recruiting SLAs, and reporting cadence. Use when asked to \"design our requisition approval workflow\", \"build recruiting SLAs\", \"set up ATS stages and workflows\", \"audit our recruiting process for bottlenecks\", or \"build a recruiting operations dashboard\".",
+      "description": "Help TA operations leaders design and run the operational backbone of recruiting \u2014 requisition workflows, ATS process design, recruiting SLAs, and reporting cadence. Use when asked to \"design our requisition approval workflow\", \"build recruiting SLAs\", \"set up ATS stages and workflows\", \"audit our recruiting process for bottlenecks\", or \"build a recruiting operations dashboard\".",
       "skills": [
         "./skills/hr-recruitment-operations"
       ]
@@ -821,9 +853,17 @@
     {
       "name": "hr-retained-search",
       "source": "./",
-      "description": "Help executive search consultants and internal TA leaders run retained search engagements — client agreements, milestone-based delivery, confidential search process, and candidate slates. Use when asked to \"structure a retained search engagement\", \"write a retained search agreement\", \"build a candidate slate for a retained search\", or \"manage a retained search timeline\".",
+      "description": "Help executive search consultants and internal TA leaders run retained search engagements \u2014 client agreements, milestone-based delivery, confidential search process, and candidate slates. Use when asked to \"structure a retained search engagement\", \"write a retained search agreement\", \"build a candidate slate for a retained search\", or \"manage a retained search timeline\".",
       "skills": [
         "./skills/hr-retained-search"
+      ]
+    },
+    {
+      "name": "hr-retirement-benefits",
+      "source": "./",
+      "description": "Help compensation and benefits teams design, communicate, and administer retirement and pension benefits. Use when asked to \"design our retirement benefit offering\", \"explain 401(k)/pension options to employees\", \"compare retirement plan providers\", \"communicate a retirement plan change\", or \"help an employee understand their retirement benefits\".",
+      "skills": [
+        "./skills/hr-retirement-benefits"
       ]
     },
     {
@@ -845,7 +885,7 @@
     {
       "name": "hr-search-strategy",
       "source": "./",
-      "description": "Help recruiters, sourcers, and search consultants design the overall strategy for a search assignment before sourcing begins — target companies, channels, timeline, and positioning. Use when asked to \"build a search strategy for [role]\", \"plan a search before we start sourcing\", \"define the search brief\", or \"decide which channels to prioritize for this search\".",
+      "description": "Help recruiters, sourcers, and search consultants design the overall strategy for a search assignment before sourcing begins \u2014 target companies, channels, timeline, and positioning. Use when asked to \"build a search strategy for [role]\", \"plan a search before we start sourcing\", \"define the search brief\", or \"decide which channels to prioritize for this search\".",
       "skills": [
         "./skills/hr-search-strategy"
       ]
@@ -877,7 +917,7 @@
     {
       "name": "hr-skills-intelligence",
       "source": "./",
-      "description": "Help workforce planners and L&D leaders turn skills data into decision-ready intelligence — skills inventories, emerging skill trend analysis, and skills-gap forecasting at scale. Use when asked to \"analyze our skills data\", \"identify emerging skills we're missing\", \"build a skills intelligence dashboard\", \"forecast future skill demand\", or \"benchmark our skills against the market\".",
+      "description": "Help workforce planners and L&D leaders turn skills data into decision-ready intelligence \u2014 skills inventories, emerging skill trend analysis, and skills-gap forecasting at scale. Use when asked to \"analyze our skills data\", \"identify emerging skills we're missing\", \"build a skills intelligence dashboard\", \"forecast future skill demand\", or \"benchmark our skills against the market\".",
       "skills": [
         "./skills/hr-skills-intelligence"
       ]
@@ -925,7 +965,7 @@
     {
       "name": "hr-strategic-workforce-planning",
       "source": "./",
-      "description": "Help CHROs and workforce planners connect long-range business strategy to workforce implications — future role needs, capability shifts, and multi-year workforce roadmaps. Use when asked to \"build a strategic workforce plan\", \"translate our 5-year business strategy into workforce needs\", \"identify future critical roles\", or \"align workforce planning with business strategy\".",
+      "description": "Help CHROs and workforce planners connect long-range business strategy to workforce implications \u2014 future role needs, capability shifts, and multi-year workforce roadmaps. Use when asked to \"build a strategic workforce plan\", \"translate our 5-year business strategy into workforce needs\", \"identify future critical roles\", or \"align workforce planning with business strategy\".",
       "skills": [
         "./skills/hr-strategic-workforce-planning"
       ]
@@ -1045,7 +1085,7 @@
     {
       "name": "hr-vendor-management",
       "source": "./",
-      "description": "Help HR operations and procurement teams select, contract, and manage HR vendors — from ATS and HRIS providers to staffing agencies, benefits brokers, and background check vendors. Use when asked to \"select an HR vendor\", \"evaluate vendors for [HR tool/service]\", \"manage our HR vendor relationships\", \"negotiate an HR vendor contract\", or \"consolidate our HR vendor stack\".",
+      "description": "Help HR operations and procurement teams select, contract, and manage HR vendors \u2014 from ATS and HRIS providers to staffing agencies, benefits brokers, and background check vendors. Use when asked to \"select an HR vendor\", \"evaluate vendors for [HR tool/service]\", \"manage our HR vendor relationships\", \"negotiate an HR vendor contract\", or \"consolidate our HR vendor stack\".",
       "skills": [
         "./skills/hr-vendor-management"
       ]
@@ -1077,7 +1117,7 @@
     {
       "name": "hr-workforce-economics",
       "source": "./",
-      "description": "Help HR and finance leaders model the financial dimensions of workforce decisions — labor cost structure, productivity economics, and the ROI of workforce investments. Use when asked to \"model the cost of this workforce decision\", \"calculate fully loaded labor cost\", \"build a business case for headcount\", \"analyze workforce productivity economics\", or \"compare the cost of hiring vs. contracting\".",
+      "description": "Help HR and finance leaders model the financial dimensions of workforce decisions \u2014 labor cost structure, productivity economics, and the ROI of workforce investments. Use when asked to \"model the cost of this workforce decision\", \"calculate fully loaded labor cost\", \"build a business case for headcount\", \"analyze workforce productivity economics\", or \"compare the cost of hiring vs. contracting\".",
       "skills": [
         "./skills/hr-workforce-economics"
       ]

--- a/README.md
+++ b/README.md
@@ -126,27 +126,22 @@ Claude automatically uses the recruiting skill to generate structured, competenc
 
 ## Available skills
 
-The repository currently includes more than 40 HR skills covering topics such as:
+The repository includes 100+ HR skills, organized into the following functional clusters (see the root [`SKILL.md`](SKILL.md) router for the full, up-to-date list of skills in each):
 
-- Recruiting
-- Talent Acquisition
-- Interviewing
-- Job Descriptions
-- HR Analytics
-- HR Technology
-- People Operations
-- Performance Management
-- Learning and Development
-- Compensation and Benefits
-- Leadership Development
-- Employer Branding
-- Workforce Planning
-- Compliance
-- Employee Experience
-- Organizational Development
-- Software Engineering recruiting
-- Vietnam HR
-- and many more.
+- Talent acquisition & recruiting
+- Onboarding, offboarding & people operations
+- Performance, talent & career management
+- Compensation, benefits & rewards
+- Learning & development
+- Organizational development, design & change
+- Workforce planning & analytics
+- HR technology, data & AI
+- Compliance, labor relations & risk
+- Culture, engagement, experience & wellbeing
+- Project management & global/local context
+- Software-engineering & technical hiring specialists
+
+New skills are added continuously, so the exact count and per-cluster breakdown always live in [`SKILL.md`](SKILL.md) rather than here.
 
 ## Repository structure
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -105,6 +105,7 @@ the task and tell you which `skills/<name>/SKILL.md` to load next.
 | [hr-job-architecture](skills/hr-job-architecture) | Job families, career levels, leveling criteria, grade structures |
 | [hr-recognition](skills/hr-recognition) | Recognition programs, peer recognition, service awards |
 | [hr-salary-benchmarking](skills/hr-salary-benchmarking) | Market pay data, salary ranges, competitiveness assessment |
+| [hr-retirement-benefits](skills/hr-retirement-benefits) | Retirement/pension plan design, provider comparison, employee education |
 
 ### Learning & development
 
@@ -134,6 +135,7 @@ the task and tell you which `skills/<name>/SKILL.md` to load next.
 | [hr-crisis-management](skills/hr-crisis-management) | HR crisis playbooks, incident response, business continuity |
 | [hr-mergers-acquisitions](skills/hr-mergers-acquisitions) | HR due diligence, culture fit assessment, pre-close deal risk |
 | [hr-post-merger-integration](skills/hr-post-merger-integration) | Post-close org/culture/systems harmonization, retention |
+| [hr-ma-integration-by-country](skills/hr-ma-integration-by-country) | Country-specific labor law, works councils, consultation rules for cross-border M&A |
 
 ### Workforce planning & analytics
 
@@ -149,6 +151,7 @@ the task and tell you which `skills/<name>/SKILL.md` to load next.
 | [hr-workforce-scenario-planning](skills/hr-workforce-scenario-planning) | Multi-scenario headcount modeling, stress-testing plans |
 | [hr-strategic-workforce-planning](skills/hr-strategic-workforce-planning) | Long-range business strategy to workforce roadmap |
 | [hr-workforce-economics](skills/hr-workforce-economics) | Fully loaded labor cost, headcount business cases, ROI |
+| [hr-people-budgeting](skills/hr-people-budgeting) | People budget by cost center, budget cycles, variance tracking |
 | [hr-organization-network-analysis](skills/hr-organization-network-analysis) | Informal collaboration networks, hidden influencers, silos |
 | [hr-workforce-forecasting](skills/hr-workforce-forecasting) | Quantitative headcount/attrition/hiring demand forecasts |
 | [hr-predictive-analytics](skills/hr-predictive-analytics) | Attrition/performance/hiring-success predictive models |
@@ -172,6 +175,7 @@ the task and tell you which `skills/<name>/SKILL.md` to load next.
 | [hr-ai-evaluation](skills/hr-ai-evaluation) | AI vendor evaluation, bias/accuracy assessment, pilots |
 | [hr-ai-adoption](skills/hr-ai-adoption) | Driving sustained AI tool adoption, enablement, resistance |
 | [hr-system-integration](skills/hr-system-integration) | HRIS/ATS/payroll integration architecture, data sync issues |
+| [hr-chatbot-design](skills/hr-chatbot-design) | HR chatbot conversation flows, Slack/Teams bot scripts, escalation design |
 
 ### Compliance, labor relations & risk
 
@@ -186,6 +190,7 @@ the task and tell you which `skills/<name>/SKILL.md` to load next.
 | [hr-policy-management](skills/hr-policy-management) | Writing/updating HR policies and the employee handbook |
 | [hr-immigration](skills/hr-immigration) | Visa sponsorship, global mobility, work-authorization compliance |
 | [hr-payroll](skills/hr-payroll) | Payroll processing, compliance, calendars, discrepancies, multi-country payroll |
+| [hr-accessibility-accommodation](skills/hr-accessibility-accommodation) | Accommodation request process, accessible hiring, disability inclusion |
 
 ### Culture, engagement, experience & wellbeing
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,7 @@ This document is a living, maintainer-level roadmap reverse-engineered directly 
 
 ### What this project is
 
-**HR Skills** is a Bun/Turborepo monorepo that packages **141 domain-specific [Agent Skills](https://agentskills.io/)** for Human Resources and Talent Acquisition professionals, distributed as `SKILL.md` files consumable by **Claude Code** and **claude.ai**. Alongside the content library, the repository ships two internal TypeScript packages (`hr-skills-build`, `skills-ref`) that validate, sync, and programmatically consume those skills, plus a `.claude-plugin/marketplace.json` manifest that turns the whole collection into an installable Claude plugin marketplace.
+**HR Skills** is a Bun/Turborepo monorepo that packages **146 domain-specific [Agent Skills](https://agentskills.io/)** for Human Resources and Talent Acquisition professionals, distributed as `SKILL.md` files consumable by **Claude Code** and **claude.ai**. Alongside the content library, the repository ships two internal TypeScript packages (`hr-skills-build`, `skills-ref`) that validate, sync, and programmatically consume those skills, plus a `.claude-plugin/marketplace.json` manifest that turns the whole collection into an installable Claude plugin marketplace.
 
 Unlike a typical "prompt collection" repo, this project treats skill content as **structured, versioned, schema-validated software artifacts** — every `SKILL.md` has required frontmatter, required sections, line-count ceilings, and an automated validator that runs in CI. That is the defining architectural decision of the whole repository: **content is code**.
 
@@ -65,9 +65,9 @@ The repository sits at the intersection of three ecosystems:
 ### Design philosophy
 
 - **Content is code.** Skills are validated with the same rigor as TypeScript source: schema-checked frontmatter, required sections, length ceilings, blank-line-before-list Markdown rules enforced by a custom validator — not just markdownlint.
-- **Router, don't repeat.** The root `SKILL.md` is explicitly documented as carrying "no HR opinions" — it is a pure dispatcher to the 141 specialized skills, keeping domain knowledge in exactly one place per topic.
+- **Router, don't repeat.** The root `SKILL.md` is explicitly documented as carrying "no HR opinions" — it is a pure dispatcher to the 146 specialized skills, keeping domain knowledge in exactly one place per topic.
 - **Progressive disclosure.** `SKILL.md` is described in `AGENTS.md` as "an overview, not an exhaustive manual" — deeper material is pushed into optional `content/`, `prompts/`, and `examples/` directories so the base skill stays inside a shared context budget (hard 500-line ceiling, enforced by `validateLineCount`).
-- **Intentional heterogeneity.** The README explicitly states that varying levels of skill completeness (`SKILL.md`-only vs. fully-fleshed skills with `content/`, `prompts/`, `examples/`) is a deliberate design choice, not an oversight — though this roadmap will show the current split (72 bare / 34 partial / 36 full) is skewed further toward "bare" than is ideal for a mature library.
+- **Intentional heterogeneity.** The README explicitly states that varying levels of skill completeness (`SKILL.md`-only vs. fully-fleshed skills with `content/`, `prompts/`, `examples/`) is a deliberate design choice, not an oversight — though this roadmap will show the current split (76 bare / 34 partial / 36 full) is skewed further toward "bare" than is ideal for a mature library.
 
 ### Architectural philosophy
 
@@ -97,15 +97,15 @@ MIT-licensed content, Apache-2.0-licensed `skills-ref` library (a deliberate spl
 
 | Metric | Count | Notes |
 |---|---:|---|
-| HR skill packages (`skills/hr-*`) | **141** | Discovered via `getHrSkills()` at runtime; matches `.claude-plugin/marketplace.json` plugin count exactly (141) |
+| HR skill packages (`skills/hr-*`) | **146** | Discovered via `getHrSkills()` at runtime; matches `.claude-plugin/marketplace.json` plugin count exactly (146) |
 | Maintainer/meta skills (`.agents/skills/*`) | **12** | `biome`, `bun`, `turbo`, `typescript`, `valibot`, `markdown`, `pdf`, `humanizer`, `skill-vetter`, `hr-skills-maintaining`, `hr-root-router-maintaining`, `github-awesome-copilot-git-commit` |
-| Total `SKILL.md` files | **154** | 141 HR + 12 `.agents` + 1 root router |
+| Total `SKILL.md` files | **159** | 146 HR + 12 `.agents` + 1 root router |
 | Skills with `content/` | **~70** | Human-readable companion guidance per domain |
 | Skills with `examples/` | **~70** | Practical end-to-end workflow files |
 | Skills with `prompts/` | **~36** | Reusable, topic-grouped prompt libraries |
-| **Bare skills (`SKILL.md` only)** | **72 (≈51%)** | No `content/`, `prompts/`, or `examples/` at all |
+| **Bare skills (`SKILL.md` only)** | **76 (≈52%)** | No `content/`, `prompts/`, or `examples/` at all — includes all recently-added skills, which shipped `SKILL.md`-only per the "bare is an acceptable starting tier" convention |
 | **Fully-fleshed skills (all three dirs)** | **36 (≈25%)** | The "gold standard" tier |
-| **Partial skills (`content/` + `examples/`, no `prompts/`)** | **34 (≈24%)** | The largest structured-but-incomplete tier |
+| **Partial skills (`content/` + `examples/`, no `prompts/`)** | **34 (≈23%)** | The largest structured-but-incomplete tier |
 | Internal TypeScript packages | **2** | `packages/hr-skills-build`, `packages/skills-ref` |
 | Unit test files | **9** | 5 in `skills-ref`, 4 in `hr-skills-build` |
 | GitHub Actions workflows | **3** | `lint.yml`, `test.yml`, `typecheck.yml` — **no release/publish workflow** |
@@ -137,21 +137,21 @@ hr-skills/ (root workspace, private, version 1.0.3)
 ├── packages/*                     ← Bun workspace glob
 │   ├── hr-skills-build/           ← app-like tooling package (validate, sync)
 │   └── skills-ref/                ← publishable-shaped library package
-├── skills/hr-*/                   ← 141 content packages (not a Bun workspace member)
+├── skills/hr-*/                   ← 146 content packages (not a Bun workspace member)
 ├── .agents/skills/*                ← 12 meta/maintainer skills (not a Bun workspace member)
 ├── .claude/                        ← Claude Code project config (commands, settings)
 ├── .claude-plugin/                 ← generated marketplace manifest
 └── docs/format.md                  ← the Agent-Skills-for-this-repo specification
 ```
 
-**Important architectural note:** `skills/` and `.agents/` are **not** part of the Bun `workspaces.packages` glob (`packages/*` only). They are plain content directories, discovered at runtime by `hr-skills-build` via `readdir`, not by Bun's workspace resolver. This is correct — they aren't npm packages — but it means the "workspace" mental model only really applies to the two TypeScript packages; the 141+12 skills are a parallel, filesystem-convention-driven system layered on top.
+**Important architectural note:** `skills/` and `.agents/` are **not** part of the Bun `workspaces.packages` glob (`packages/*` only). They are plain content directories, discovered at runtime by `hr-skills-build` via `readdir`, not by Bun's workspace resolver. This is correct — they aren't npm packages — but it means the "workspace" mental model only really applies to the two TypeScript packages; the 146+12 skills are a parallel, filesystem-convention-driven system layered on top.
 
 ### Package relationships
 
 ```mermaid
 graph LR
     A["skills-ref<br/>(Apache-2.0, generic Agent-Skills library)"] -->|workspace:*| B["hr-skills-build<br/>(MIT, HR-repo-specific tooling)"]
-    B -->|reads/writes| C["skills/hr-*/SKILL.md<br/>(141 content packages)"]
+    B -->|reads/writes| C["skills/hr-*/SKILL.md<br/>(146 content packages)"]
     B -->|reads/writes| D[".claude-plugin/marketplace.json"]
     E["root SKILL.md<br/>(router, no HR content)"] -->|links to| C
     F[".agents/skills/*<br/>(12 meta skills)"] -.->|documents how to maintain| B
@@ -177,7 +177,7 @@ graph LR
 
 ### Current architecture
 
-A two-layer system: (1) a **content layer** of 141 independently-versioned `SKILL.md` packages with optional supporting directories, and (2) a **tooling layer** of two TypeScript packages that discover, validate, and sync that content into a distributable manifest. Turborepo orchestrates the tooling layer's tasks (`build`, `test`, `typecheck`, `validate`, `sync`); the content layer has no build step of its own — a `SKILL.md` file *is* the shipped artifact.
+A two-layer system: (1) a **content layer** of 146 independently-versioned `SKILL.md` packages with optional supporting directories, and (2) a **tooling layer** of two TypeScript packages that discover, validate, and sync that content into a distributable manifest. Turborepo orchestrates the tooling layer's tasks (`build`, `test`, `typecheck`, `validate`, `sync`); the content layer has no build step of its own — a `SKILL.md` file *is* the shipped artifact.
 
 ### Desired architecture (near-term)
 
@@ -315,17 +315,19 @@ graph TD
 
 ### Coverage
 
-The 141 HR skills are organized (per the root router) into **9 functional clusters**: Talent Acquisition & Recruiting (25 skills), Onboarding/Offboarding/People Ops (11), Performance/Talent/Career Management (10), Compensation/Benefits/Rewards (5), Learning & Development (7), Org Development/Design/Change (12), Workforce Planning & Analytics (13), HR Technology/Data/AI (14), Compliance/Labor Relations/Risk (9), Culture/Engagement/Experience/Wellbeing (10), Project Management & Global/Local Context (4), and Software-Engineering/Technical Hiring Specialists (18). This is genuinely comprehensive coverage of the modern HR function — the README's claim of "40 HR skills" **understates the current library by roughly 3.5×** (see [Technical Debt](#technical-debt)).
+The 146 HR skills are organized (per the root router) into **12 functional clusters**: Talent Acquisition & Recruiting (26 skills), Onboarding/Offboarding/People Ops (11), Performance/Talent/Career Management (10), Compensation/Benefits/Rewards (6), Learning & Development (7), Org Development/Design/Change (13), Workforce Planning & Analytics (14), HR Technology/Data/AI (16), Compliance/Labor Relations/Risk (10), Culture/Engagement/Experience/Wellbeing (10), Project Management & Global/Local Context (4), and Software-Engineering/Technical Hiring Specialists (19). This is genuinely comprehensive coverage of the modern HR function. ✅ The README's former "40 HR skills" understatement has been fixed — it now states "100+" and points to the root `SKILL.md` router as the single source of truth for the live count and per-cluster breakdown, so it no longer needs manual re-syncing every time the skill count changes (see [Technical Debt](#technical-debt)).
 
 ### Missing domains
 
-Despite broad coverage, a few plausible domains have no dedicated skill yet:
+The five domain gaps identified in the previous edition of this roadmap have all been closed:
 
-- **HR budgeting & financial planning** (People budget ownership, cost-center modeling) — adjacent to `hr-workforce-economics` but not the same scope.
-- **Internal communications tooling specifics** (Slack/Teams HR bot design) beyond `hr-employee-communications`.
-- **Retirement/pension specialist guidance** beyond the general `hr-compensation-benefits` bucket.
-- **HR M&A integration playbooks by country** — `hr-mergers-acquisitions` and `hr-post-merger-integration` exist, but only `hr-vietnam-context` gets country-specific depth; no equivalent for other major markets (US, EU, India).
-- **Accessibility/disability accommodation** as a first-class skill (currently folded into `hr-compliance`'s ADA prompts only).
+- ✅ **HR budgeting & financial planning** — added as `hr-people-budgeting` (people budget by cost center, budget cycles, variance tracking), distinct in scope from `hr-workforce-economics`.
+- ✅ **Internal communications tooling specifics** — added as `hr-chatbot-design` (Slack/Teams HR bot conversation flows, escalation design), distinct from the content-focused `hr-employee-communications`.
+- ✅ **Retirement/pension specialist guidance** — added as `hr-retirement-benefits`, split out from the general `hr-compensation-benefits` bucket.
+- ✅ **HR M&A integration playbooks by country** — added as `hr-ma-integration-by-country`, covering works-council/consultation requirements across major markets (US, EU, India) alongside the existing `hr-mergers-acquisitions` and `hr-post-merger-integration`.
+- ✅ **Accessibility/disability accommodation** — added as `hr-accessibility-accommodation`, promoted out of `hr-compliance`'s ADA prompts into a first-class skill.
+
+No further plausible domain gaps have been identified as of this edit; this section should be re-derived the next time the library is audited for coverage.
 
 ### Overlap
 
@@ -340,13 +342,13 @@ This isn't necessarily wrong (HR genuinely has fine-grained sub-disciplines) but
 
 ### Consistency
 
-- ✅ 141/141 skills present in the router's routing tables, and 141/141 present in `marketplace.json` — **perfect sync today**, verified directly against the filesystem.
+- ✅ 146/146 skills present in the router's routing tables, and 146/146 present in `marketplace.json` — **perfect sync today**, verified directly against the filesystem (this is currently maintained by discipline/manual regeneration, not yet an automated CI rule — see [Missing Features](#missing-features)).
 - ⚠ `metadata.author` inconsistency: `.agents/skills/valibot/SKILL.md` uses `author: open-circle` (a third-party-sourced skill) while every other skill in the repo uses `Tuan Duc Tran` — the validator's `validateAuthor()` would reject this if `.agents/skills/` were ever brought under the same validation umbrella as `skills/hr-*/` (currently it is not, since `discoverSkills()` filters by the `hr-` prefix under `skills/` only).
 - ⚠ `metadata.version: "1.0"` in the same `valibot` skill breaks the semantic-version convention (`"1.0.0"`) used everywhere else.
 
 ### Versioning
 
-All 141 HR skills are pinned in `AGENTS.md`'s root-`SKILL.md` "Notes" section as **"v1.0.0 unless otherwise noted"** — in practice this means the library has **no per-skill version history**; every skill was likely bulk-stamped at `1.0.0` on creation, and there is no tooling today to bump an individual skill's version when its content changes (only the monorepo-level `package.json` version is bumped by `changelogen`). The `.agents/skills/*` meta-skills, by contrast, *do* show real version drift (`bun` at `1.1.1`, `turbo`/`typescript` at `1.1.0`, `github-awesome-copilot-git-commit` at `2.0.0`) — proving the versioning mechanism works when actually used.
+All 146 HR skills are pinned in `AGENTS.md`'s root-`SKILL.md` "Notes" section as **"v1.0.0 unless otherwise noted"** — in practice this means the library has **no per-skill version history**; every skill was likely bulk-stamped at `1.0.0` on creation, and there is no tooling today to bump an individual skill's version when its content changes (only the monorepo-level `package.json` version is bumped by `changelogen`). The `.agents/skills/*` meta-skills, by contrast, *do* show real version drift (`bun` at `1.1.1`, `turbo`/`typescript` at `1.1.0`, `github-awesome-copilot-git-commit` at `2.0.0`) — proving the versioning mechanism works when actually used.
 
 ### Templates
 
@@ -363,7 +365,7 @@ Covered exhaustively in [Validation Roadmap](#validation-roadmap).
 ### Future expansion
 
 - A **skill maturity model** (Bare → Content → Content+Examples → Full) formalized as a `metadata.maturity` frontmatter field, surfaced in `marketplace.json` and the README, so users can filter for "battle-tested" vs. "stub" skills.
-- **Skill deprecation/aliasing support** — as the library grows past 141 skills, some will inevitably need renaming or merging; there is currently no documented deprecation path (only `hr-root-router-maintaining` mentions "renaming a skill directory" as a supported maintenance task, with no corresponding redirect mechanism for users with the old name installed locally).
+- **Skill deprecation/aliasing support** — as the library grows past 146 skills, some will inevitably need renaming or merging; there is currently no documented deprecation path (only `hr-root-router-maintaining` mentions "renaming a skill directory" as a supported maintenance task, with no corresponding redirect mechanism for users with the old name installed locally).
 
 ### Skill quality matrix (representative sample by cluster)
 
@@ -379,7 +381,7 @@ Covered exhaustively in [Validation Roadmap](#validation-roadmap).
 | `hr-compliance` | ✅ Full | ✅ | ✅ | ✅ (23 prompt files) | Validated in CI | Highest prompt-file count in the repo — good template to replicate |
 | `hr-workforce-planning` | ✅ Full | ✅ | ✅ (2) | ✅ (2) | Validated in CI | — |
 
-*(Full 141-row matrix should be generated programmatically — see [Missing Features](#missing-features): "Metadata explorer.")*
+*(Full 146-row matrix should be generated programmatically — see [Missing Features](#missing-features): "Metadata explorer.")*
 
 ---
 
@@ -471,7 +473,7 @@ Currently covers `name`, `description`, `author`, `version`. **Not currently val
 
 ### README
 
-Functional and welcoming but **materially stale**: states "more than 40 HR skills" against an actual count of 141 — a **~3.5× undercount** that undersells the project to newcomers and should be treated as the top documentation-debt item.
+✅ **Resolved.** Previously stated "more than 40 HR skills" against an actual count of 146 (a ~3.5× undercount). Now states "100+ HR skills" and points readers to the root `SKILL.md` router's 12 functional clusters instead of an ad hoc topic list — a self-stabilizing form of the count that doesn't need manual re-syncing every time a skill is added, at the cost of no longer showing the exact number in the README itself.
 
 ### Docs (`docs/format.md`)
 
@@ -553,7 +555,7 @@ See [Testing Roadmap](#testing-roadmap).
 
 ### Current tests
 
-9 unit test files across both packages, all using `bun test`, well-organized by source file (`errors.test.ts`, `models.test.ts`, `parser.test.ts` ×2, `prompt.test.ts`, `validator.test.ts`, `config.test.ts`, `validate.test.ts`, `sync.test.ts`). Coverage style is thorough at the unit level: `validator.test.ts` even includes an integration-style assertion ("validates all HR skills without errors") that doubles as a regression guard against the entire 141-skill corpus.
+9 unit test files across both packages, all using `bun test`, well-organized by source file (`errors.test.ts`, `models.test.ts`, `parser.test.ts` ×2, `prompt.test.ts`, `validator.test.ts`, `config.test.ts`, `validate.test.ts`, `sync.test.ts`). Coverage style is thorough at the unit level: `validator.test.ts` even includes an integration-style assertion ("validates all HR skills without errors") that doubles as a regression guard against the entire 146-skill corpus.
 
 ### Coverage
 
@@ -578,7 +580,7 @@ Existing tests already cover several good edge cases (non-existent path, missing
 
 ### Performance tests
 
-None exist. Not urgent at current scale (141 skills, single-digit-KB files) but worth a baseline benchmark before the library reaches ~500 skills (see [Performance Roadmap](#performance-roadmap)).
+None exist. Not urgent at current scale (146 skills, single-digit-KB files) but worth a baseline benchmark before the library reaches ~500 skills (see [Performance Roadmap](#performance-roadmap)).
 
 ### Snapshot / regression tests
 
@@ -598,7 +600,7 @@ None beyond the "validates all HR skills without errors" integration-style asser
 
 ### Recommended improvements
 
-- ⚠ **`bun run validate` (SKILL.md structural validation) is not run in any CI workflow.** This is the single most important missing CI gate for a repo whose entire value proposition is 141 schema-conformant content files — a PR that adds a broken `SKILL.md` would currently pass lint/test/typecheck and merge cleanly. **This should be P0.**
+- ⚠ **`bun run validate` (SKILL.md structural validation) is not run in any CI workflow.** This is the single most important missing CI gate for a repo whose entire value proposition is 146 schema-conformant content files — a PR that adds a broken `SKILL.md` would currently pass lint/test/typecheck and merge cleanly. **This should be P0.**
 - ⚠ `bun run knip` (unused-file/dependency detection) is wired into the local `pre-push` Lefthook hook but **not** into CI — a contributor who skips or bypasses hooks (`--no-verify`) gets no CI backstop.
 - ⚠ `bun run lint:links` (Markdown link validation) is a defined script but not run in `lint.yml` or anywhere else in CI.
 - ❌ **No release workflow.** Releases are 100% local (`bun run release`). A `release.yml` triggered on `main` push (or manually via `workflow_dispatch`) running `changelogen` and creating a GitHub Release would remove the single point of failure of one maintainer's local machine.
@@ -658,11 +660,11 @@ Both internal packages are `private: true`, minimizing supply-chain blast radius
 
 ### Parser performance
 
-At 141 skills averaging a few KB each, `skills-ref`'s regex-based frontmatter parsing and `hr-skills-build`'s `readdir`+`readFile` discovery are trivially fast (sub-second for the whole corpus) — not a current bottleneck.
+At 146 skills averaging a few KB each, `skills-ref`'s regex-based frontmatter parsing and `hr-skills-build`'s `readdir`+`readFile` discovery are trivially fast (sub-second for the whole corpus) — not a current bottleneck.
 
 ### Validation performance
 
-`validateSkill()` runs sequentially per skill inside a `for` loop in `validate()` rather than `Promise.all`-parallelized (contrast with `sync()`, which correctly uses `Promise.all(skillNames.map(parseSkillMeta))`). At 141 skills this is still fast in absolute terms, but it's an easy, low-risk parallelization win as the library grows.
+`validateSkill()` runs sequentially per skill inside a `for` loop in `validate()` rather than `Promise.all`-parallelized (contrast with `sync()`, which correctly uses `Promise.all(skillNames.map(parseSkillMeta))`). At 146 skills this is still fast in absolute terms, but it's an easy, low-risk parallelization win as the library grows.
 
 ### Build performance
 
@@ -744,7 +746,7 @@ Checklist of plausible future capabilities, grouped by theme. None of these exis
 ### Discovery & indexing
 
 - [ ] ⬜ Generated `skills/CATALOG.md` (previously existed per CHANGELOG history, currently absent)
-- [ ] ⬜ Searchable/filterable web index of all 141 skills (static site generated from `marketplace.json`)
+- [ ] ⬜ Searchable/filterable web index of all 146 skills (static site generated from `marketplace.json`)
 - [ ] ⬜ Tag/category metadata beyond the router's manual clustering
 - [ ] ⬜ Dependency/relationship graph between skills that are "commonly loaded together" (e.g., `hr-job-description` + `hr-backend`)
 
@@ -776,10 +778,10 @@ Checklist of plausible future capabilities, grouped by theme. None of these exis
 
 | Version | Goals | Deliverables | Breaking changes | Migration | Priority |
 |---|---|---|---|---|---|
-| **v1.1.0** | Close the CI/validation gap; fix documentation drift | `bun run validate` added to CI (new `validate.yml` or folded into `lint.yml`); README skill-count corrected to 141+; consolidate to one dependency bot | None | None | **P0** |
+| **v1.1.0** | Close the CI/validation gap; fix documentation drift | `bun run validate` added to CI (new `validate.yml` or folded into `lint.yml`); ✅ README skill-count drift fixed (now "100+", sourced from the router); consolidate to one dependency bot | None | None | **P0** |
 | **v1.2.0** | Template/doc de-duplication | Single-source `SKILL.md` template; declare canonical `AGENTS.md`; add `docs/versioning.md` and `docs/deprecation.md` | None | None | P1 |
-| **v1.3.0** | Prompt-structure enforcement | Code the 3–6 subtopic / 4–7 prompts-per-subtopic validator rule; run against all 141 skills, fix any that fail | Possible — some existing skills may need prompt restructuring to pass | Contributors update non-conformant skills before merge | P1 |
-| **v1.4.0** | Bare-skill remediation wave | Bring the 72 bare skills to at least "content-only" tier, prioritized by cluster importance (AI/GenAI cluster first, given fast-moving domain) | None | None | P1 |
+| **v1.3.0** | Prompt-structure enforcement | Code the 3–6 subtopic / 4–7 prompts-per-subtopic validator rule; run against all 146 skills, fix any that fail | Possible — some existing skills may need prompt restructuring to pass | Contributors update non-conformant skills before merge | P1 |
+| **v1.4.0** | Bare-skill remediation wave | Bring the 76 bare skills to at least "content-only" tier, prioritized by cluster importance (AI/GenAI cluster first, given fast-moving domain) | None | None | P1 |
 | **v1.5.0** | Release automation | `release.yml` CI workflow; GitHub Release artifacts; `skill-vetter` wired into CI | None | None | P2 |
 | **v2.0.0** | `skills-ref` becomes a real public library | Publish `skills-ref` to npm (`1.0.0`, `private: false`); add plugin system for custom validation rules; add remote skill-source support | **Yes** — `skills-ref`'s public API surface becomes a formal semver contract | Downstream consumers pin to `^1.0.0`; internal `hr-skills-build` updates its dependency from `workspace:*` to a real version range if ever extracted | P2 |
 | **v3.0.0** | Skills-as-a-platform | Skill maturity metadata, searchable index site, localization framework, skill-relationship graph | Possible — `marketplace.json` schema likely grows new required fields | Sync script auto-migrates existing entries | P3 |
@@ -793,7 +795,7 @@ Checklist of plausible future capabilities, grouped by theme. None of these exis
 | Task | Description | Reason | Complexity | Dependencies | Expected impact |
 |---|---|---|---|---|---|
 | Add `bun run validate` to CI | Wire the existing script into a workflow (new file or extend `lint.yml`) | Currently a broken `SKILL.md` can merge without any CI gate catching it — the single largest correctness gap in the repo | Low | None | Prevents silent content regressions in the repo's core product |
-| Fix README skill count | Update "40+" to the real 141 figure (and periodically re-sync) | Directly undersells the project by ~3.5×; first thing any visitor reads | Trivial | None | Improves adoption/credibility immediately |
+| ✅ ~~Fix README skill count~~ *(done)* | Updated "40+" to "100+", sourced from the router's 12 clusters instead of a hardcoded figure so it won't drift again | Directly undersells the project by ~3.5×; first thing any visitor reads | Trivial | None | Improves adoption/credibility immediately |
 
 ### P1 — High
 
@@ -811,7 +813,7 @@ Checklist of plausible future capabilities, grouped by theme. None of these exis
 |---|---|---|---|---|---|
 | CI-driven release workflow | `release.yml` running `changelogen` on `main` | Removes single-point-of-failure local release process | Medium | GitHub token/permissions setup | More resilient, repeatable releases |
 | Wire `skill-vetter` into CI | Turn the documented meta-skill into real automated checks | Closes stated-but-unimplemented security tooling gap | Medium | New `hr-skills-build` rules | Concrete supply-chain risk reduction |
-| Bare-skill remediation (AI cluster first) | Add `content/` to `hr-agentic-ai`, `hr-ai-ethics`, `hr-genai`, etc. | 72/141 skills currently ship with zero supporting material; fast-moving domains benefit most | High (content work, not code) | None | Materially improves the library's depth where it matters most today |
+| Bare-skill remediation (AI cluster first) | Add `content/` to `hr-agentic-ai`, `hr-ai-ethics`, `hr-genai`, etc. | 76/146 skills currently ship with zero supporting material; fast-moving domains benefit most | High (content work, not code) | None | Materially improves the library's depth where it matters most today |
 | Publish `skills-ref` to npm | Flip `private: false`, bump to `1.0.0`, `npm publish --provenance` | Packaging is already publish-ready; currently wasted potential | Medium | Decide on public API stability commitment | Positions the repo as an ecosystem contributor, not just an HR content pack |
 
 ### P3 — Nice to have
@@ -829,13 +831,13 @@ Checklist of plausible future capabilities, grouped by theme. None of these exis
 
 | # | Problem | Impact | Priority | Suggested solution |
 |---|---|---|---|---|
-| 1 | README claims "40+" skills; actual count is 141 | Undersells project; misleads new visitors and potential contributors about scope | P0 | Update README, consider auto-generating the count from `marketplace.json` at release time |
+| 1 | ✅ ~~README claimed "40+" skills; actual count was 146~~ *(resolved)* | Previously undersold project; misled new visitors and potential contributors about scope | ~~P0~~ Done | README now states "100+" and links to the router's live cluster breakdown instead of a hardcoded figure |
 | 2 | `bun run validate` absent from all CI workflows | Broken `SKILL.md` content can merge undetected | P0 | Add to `lint.yml` or a new `validate.yml` |
 | 3 | Three overlapping dependency-scanning tools (Renovate, Dependabot, Mend/Whitesource) | Duplicate/conflicting PRs, dashboard fragmentation, maintainer overhead | P1 | Consolidate to Renovate only |
 | 4 | `SKILL.md` template duplicated in `CONTRIBUTING.md` and `.claude/commands/new-skill.md` | Template drift risk over time | P1 | Single-source into one referenced file |
 | 5 | Prompt-subtopic structure rule (3–6 subtopics, 4–7 prompts each) documented in `docs/format.md` but not implemented in `validate.ts` | Spec/implementation mismatch; unenforced quality bar | P1 | Implement as a new validator rule |
 | 6 | `ValidationError` name collision between `skills-ref` (class) and `hr-skills-build` (interface) | Confusing cross-package symbol, IDE auto-import risk | P1 | Rename one; consider re-export/`instanceof` unification |
-| 7 | 72/141 skills (≈51%) have no `content/`, `prompts/`, or `examples/` at all | Library depth is shallower than the skill count suggests; several fast-moving AI/HR-tech skills are among the bare ones | P1–P2 | Prioritized content remediation, AI cluster first |
+| 7 | 76/146 skills (≈52%) have no `content/`, `prompts/`, or `examples/` at all | Library depth is shallower than the skill count suggests; several fast-moving AI/HR-tech skills are among the bare ones | P1–P2 | Prioritized content remediation, AI cluster first |
 | 8 | `.agents/skills/valibot/SKILL.md` has `metadata.author: open-circle` and `metadata.version: "1.0"` (not `"1.0.0"`), inconsistent with every other skill | Would fail repo validation rules if `.agents/` were ever brought into scope; currently silently exempt | P2 | Either normalize metadata or explicitly document `.agents/` as exempt from HR-skill policy |
 | 9 | `hr-skills-build` has no `build` script but participates in Turborepo's `build` dependency graph | Conceptually inconsistent, though functionally harmless | P2 | Add explicit no-op/comment, or restructure task dependencies |
 | 10 | `bun run knip` and `bun run lint:links` run locally (hooks) but not in CI | Contributors bypassing hooks get no backstop for unused files/deps or broken links | P2 | Add both to CI |
@@ -852,9 +854,9 @@ Checklist of plausible future capabilities, grouped by theme. None of these exis
 | Category | Metric | Current baseline | Target |
 |---|---|---|---|
 | **Repository health** | CI workflows covering all `package.json` quality scripts | 5/9 scripts covered in CI (`lint`, `lint:md`, `test`, `typecheck`, — missing `validate`, `knip`, `lint:links`) | 8/9+ (all except `sync`, which is inherently a write operation) |
-| **Documentation accuracy** | README skill count vs. actual count | 40+ claimed / 141 actual (65% understatement) | Auto-generated, always accurate |
-| **Skill depth** | % of skills with at least `content/` | ~49% (69/141) | 80%+ |
-| **Skill depth** | % of skills with all three optional dirs (full tier) | ~26% (36/141) | 50%+ |
+| **Documentation accuracy** | README skill count vs. actual count | ✅ Fixed — README now states "100+" and sources the cluster breakdown from `SKILL.md` instead of a hardcoded figure | Self-stabilizing (done); revisit only if a future redesign wants an exact auto-generated number back |
+| **Skill depth** | % of skills with at least `content/` | ~48% (70/146) | 80%+ |
+| **Skill depth** | % of skills with all three optional dirs (full tier) | ~25% (36/146) | 50%+ |
 | **Validation coverage** | Documented rules vs. implemented rules in `docs/format.md` | ~91% (10/11 major documented behaviors implemented; prompt-subtopic structure unenforced) | 100% |
 | **Testing** | Unit test files | 9 | 12+ (add router-consistency, integration sync→validate, and skill-vetter tests) |
 | **Testing** | Code coverage measurement | Not tracked | Tracked with a defined threshold (e.g., 80%) |
@@ -869,14 +871,14 @@ Checklist of plausible future capabilities, grouped by theme. None of these exis
 
 ### 1 year
 
-- All P0/P1 backlog items shipped: `validate` in CI, README accuracy, consolidated dependency bots, de-duplicated templates, enforced prompt-structure rule, and the majority of the 72 bare skills brought to at least `content/`-tier, prioritized by the fast-moving AI/HR-tech cluster.
+- All P0/P1 backlog items shipped: `validate` in CI, README accuracy, consolidated dependency bots, de-duplicated templates, enforced prompt-structure rule, and the majority of the 76 bare skills brought to at least `content/`-tier, prioritized by the fast-moving AI/HR-tech cluster.
 - `release.yml` exists; releases are CI-driven and reproducible.
 - Router ↔ filesystem ↔ marketplace consistency is enforced automatically, not maintained by discipline alone.
 
 ### 2 years
 
 - `skills-ref` is a genuinely independent, published npm package with its own external user base beyond `hr-skills-build`, validated by real adoption (issues, PRs, stars on the package itself distinct from the HR content repo).
-- The library has grown meaningfully beyond 141 skills (plausibly 200+) while *maintaining or improving* the full-tier percentage — proving the "intentional heterogeneity" philosophy scales without degrading into permanent stub-sprawl.
+- The library has grown meaningfully beyond 146 skills (plausibly 200+) while *maintaining or improving* the full-tier percentage — proving the "intentional heterogeneity" philosophy scales without degrading into permanent stub-sprawl.
 - A localization precedent beyond Vietnam exists (at least one additional country/region-context skill cluster), validating the `hr-vietnam-context` model as a repeatable pattern rather than a one-off.
 - `skill-vetter` has moved from documentation to enforced, automated CI tooling — meaningful given the broader Agent Skills ecosystem's exposure to prompt-injection-via-content risk.
 
@@ -901,7 +903,7 @@ Checklist of plausible future capabilities, grouped by theme. None of these exis
 graph TB
     subgraph "Content layer"
         R["root SKILL.md<br/>(router)"]
-        SK["skills/hr-*/<br/>141 packages"]
+        SK["skills/hr-*/<br/>146 packages"]
         AG[".agents/skills/*<br/>12 meta skills"]
     end
 
@@ -945,18 +947,18 @@ graph LR
 ```mermaid
 graph TD
     Router["root SKILL.md router"]
-    Router --> TA["Talent Acquisition &<br/>Recruiting (25)"]
+    Router --> TA["Talent Acquisition &<br/>Recruiting (26)"]
     Router --> ON["Onboarding, Offboarding &<br/>People Ops (11)"]
     Router --> PF["Performance, Talent &<br/>Career Mgmt (10)"]
-    Router --> CB["Compensation, Benefits &<br/>Rewards (5)"]
+    Router --> CB["Compensation, Benefits &<br/>Rewards (6)"]
     Router --> LD["Learning &<br/>Development (7)"]
-    Router --> OD["Org Development,<br/>Design & Change (12)"]
-    Router --> WP["Workforce Planning &<br/>Analytics (13)"]
-    Router --> TE["HR Technology,<br/>Data & AI (14)"]
-    Router --> CO["Compliance, Labor<br/>Relations & Risk (9)"]
+    Router --> OD["Org Development,<br/>Design & Change (13)"]
+    Router --> WP["Workforce Planning &<br/>Analytics (14)"]
+    Router --> TE["HR Technology,<br/>Data & AI (16)"]
+    Router --> CO["Compliance, Labor<br/>Relations & Risk (10)"]
     Router --> CE["Culture, Engagement,<br/>Experience & Wellbeing (10)"]
     Router --> PM["Project Mgmt &<br/>Global/Local Context (4)"]
-    Router --> SE["Software-Engineering &<br/>Technical Hiring (18)"]
+    Router --> SE["Software-Engineering &<br/>Technical Hiring (19)"]
     TA -.always pairs with.-> VN["hr-vietnam-context<br/>(if VN-based org)"]
     ON -.-> VN
     CO -.-> VN

--- a/skills/hr-accessibility-accommodation/SKILL.md
+++ b/skills/hr-accessibility-accommodation/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: hr-accessibility-accommodation
+description: Help HR and people ops teams design and manage workplace accessibility and disability accommodation as a first-class, proactive practice, not just an ADA compliance checklist. Use when asked to "design an accommodation request process", "handle a disability accommodation request", "make our hiring process more accessible", "audit our workplace for accessibility", or "train managers on supporting accommodations".
+metadata:
+  author: Tuan Duc Tran
+  version: "1.0.0"
+---
+
+# Accessibility & disability accommodation
+
+Design and manage workplace accessibility and disability accommodation as a proactive, well-run practice — accommodation request processes, accessible hiring and interviewing, and manager enablement — going beyond minimum compliance to genuinely inclusive practice.
+
+## Supported tasks
+
+- Designing a clear, accessible accommodation request process
+- Handling an individual accommodation request through interactive dialogue
+- Making recruiting and interview processes accessible by default
+- Auditing physical and digital workplace accessibility
+- Training managers on supporting accommodations without overstepping medical boundaries
+- Designing accommodations for remote and hybrid work arrangements
+- Communicating accommodation policy to employees without requiring self-disclosure pressure
+- Handling accommodation requests that involve competing business constraints
+- Coordinating accommodation decisions with legal and occupational health where needed
+- Assessing digital accessibility (tools, intranet, HR systems) for employees with disabilities
+- Building accessibility considerations into office design and facilities planning
+- Auditing accommodation request outcomes for consistency and fairness over time
+
+## Key prompts
+
+### Process design
+
+1. "Design a clear, employee-friendly accommodation request process from initial request through implementation."
+2. "What should the interactive dialogue process look like when an employee requests an accommodation for [condition/limitation]?"
+3. "Draft a policy communicating how employees can request accommodations without requiring unnecessary self-disclosure."
+
+### Handling requests
+
+1. "Walk through how to handle an accommodation request for [specific scenario] while respecting medical privacy and business needs."
+2. "Draft a response to a manager who is unsure how to support a team member's approved accommodation."
+3. "How should we handle an accommodation request that appears to conflict with a core business requirement, without dismissing it prematurely?"
+
+### Making processes accessible by default
+
+1. "Audit our interview and hiring process for accessibility barriers and recommend improvements."
+2. "What accessibility considerations should we build into remote and hybrid work arrangements by default, not just on request?"
+3. "Assess our HR systems and internal tools for digital accessibility gaps affecting employees with disabilities."
+
+### Training and culture
+
+1. "Design a manager training module on supporting employee accommodations appropriately, including what not to ask."
+2. "Draft guidance helping managers distinguish between reasonable accommodation requests and requests that need HR/legal involvement."
+3. "Audit our past accommodation request outcomes for consistency and fairness across similar cases."
+
+## Tips
+
+- Build accessibility in by default rather than only reacting to individual requests — accessible interview formats and flexible work options benefit everyone, not just employees who self-identify.
+- Keep the accommodation conversation focused on functional needs and job requirements, not medical diagnosis; managers and HR don't need to know the "why," only what would help.
+- Respond to accommodation requests promptly; delay itself can create legal risk and signals the request isn't being taken seriously.
+- Involve legal or occupational health for complex or ambiguous cases, but don't default every request to a formal legal process — most accommodations are straightforward and shouldn't feel like a legal proceeding to the employee.
+- Review accommodation decisions periodically for consistency across similar situations, since inconsistent handling is a common source of both unfairness and legal exposure.

--- a/skills/hr-chatbot-design/SKILL.md
+++ b/skills/hr-chatbot-design/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: hr-chatbot-design
+description: Help HR technology teams design HR service-delivery chatbots and conversational tools for platforms like Slack and Microsoft Teams. Use when asked to "design an HR chatbot", "build a Slack bot for HR questions", "plan a Teams HR assistant", "write conversation flows for an HR bot", or "decide what an HR bot should and shouldn't handle".
+metadata:
+  author: Tuan Duc Tran
+  version: "1.0.0"
+---
+
+# HR chatbot design
+
+Design HR service-delivery chatbots and conversational tools for platforms like Slack and Microsoft Teams — scoping what the bot should handle, designing conversation flows, and setting escalation paths to a human.
+
+## Supported tasks
+
+- Scoping what an HR chatbot should and shouldn't handle
+- Designing conversation flows for common HR self-service requests
+- Writing bot response scripts for FAQs (policy questions, benefits, time off)
+- Designing escalation paths from bot to a human HR rep
+- Planning intent recognition categories for an HR chatbot
+- Integrating chatbot responses with HRIS or knowledge-base data sources
+- Designing onboarding flows delivered through a chatbot
+- Handling sensitive topics (harassment, mental health, legal questions) with appropriate bot guardrails
+- Measuring chatbot deflection rate and resolution quality
+- Piloting a chatbot with a limited use case before broader rollout
+- Localizing chatbot conversation flows for multi-language workforces
+- Iterating on chatbot scripts based on real usage and unresolved queries
+
+## Key prompts
+
+### Scoping the bot
+
+1. "Scope what an HR chatbot for [Slack/Teams] should handle in its first release — which request types are good fits and which aren't."
+2. "What HR questions are safe for full bot automation vs. requiring a human in the loop?"
+3. "Design intent categories for an HR chatbot covering the most common employee self-service requests."
+
+### Designing conversation flows
+
+1. "Design a conversation flow for an employee asking about [time-off balance / benefits enrollment / policy question] through the bot."
+2. "Write bot response scripts for the top 10 most common HR FAQ questions at [company]."
+3. "Design an onboarding flow delivered through the chatbot for a new hire's first week."
+
+### Escalation and guardrails
+
+1. "Design escalation logic for when the bot should hand off to a human HR rep rather than attempt to answer."
+2. "What guardrails should the bot have around sensitive topics like harassment complaints, mental health, or legal questions?"
+3. "Draft a fallback response for when the bot doesn't understand or can't confidently answer a question."
+
+### Piloting and improving
+
+1. "Design a pilot plan for testing the HR chatbot with [one team/use case] before wider rollout."
+2. "What metrics should we track to measure whether the chatbot is actually deflecting HR tickets successfully?"
+3. "Review this log of unresolved chatbot queries and recommend script or intent-recognition improvements."
+
+## Tips
+
+- Start narrow — a bot that reliably handles five FAQ categories builds more trust than one that vaguely attempts everything and gets things wrong.
+- Design explicit escalation paths for anything sensitive (harassment, mental health, legal, pay disputes) — a bot mishandling these erodes trust fast and can create real risk.
+- Keep responses grounded in an actual knowledge base or HRIS data, not free-form generation, for anything involving policy or personal data accuracy.
+- Track deflection rate alongside resolution quality; a bot that "answers" quickly but incorrectly creates more work than it saves.
+- Review real unresolved queries regularly — the gap between what employees actually ask and what the bot was scoped for is where the best improvements come from.

--- a/skills/hr-ma-integration-by-country/SKILL.md
+++ b/skills/hr-ma-integration-by-country/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: hr-ma-integration-by-country
+description: Help HR and integration leaders navigate country-specific labor law and cultural considerations when integrating an acquired workforce in major markets like the US, EU, and India. Use when asked to "what labor law applies to this M&A integration in [country]", "compare works council requirements across our merger markets", "plan country-specific integration steps for [US/EU/India]", or "identify country-level people risks in this cross-border deal".
+metadata:
+  author: Tuan Duc Tran
+  version: "1.0.0"
+---
+
+# M&A integration by country
+
+Navigate country-specific labor law, consultation requirements, and cultural considerations when integrating an acquired workforce across major markets — extending general M&A and post-merger integration practice with the local depth cross-border deals require.
+
+## Supported tasks
+
+- Identifying country-specific labor law requirements affecting integration timeline and approach
+- Comparing works council, union, and employee consultation requirements across deal markets
+- Planning country-specific Day 1 and 100-day integration steps
+- Assessing redundancy and restructuring rules that vary materially by jurisdiction
+- Identifying mandatory employee consultation or notification periods before integration actions
+- Comparing benefits and employment term harmonization complexity across countries
+- Flagging country-specific risks that could delay or complicate integration timeline
+- Coordinating local legal counsel input into the broader integration plan
+- Adapting communication and change management approach for local cultural norms
+- Sequencing multi-country integration to respect the slowest, most consultation-heavy jurisdiction
+- Documenting country-by-country integration requirements for the deal team
+- Comparing integration complexity across markets to inform deal structuring decisions
+
+## Key prompts
+
+### Country-specific requirements
+
+1. "What labor law and consultation requirements should we expect when integrating an acquired workforce in [US/EU country/India]?"
+2. "Compare works council or employee representative consultation requirements across [country A] and [country B] for this integration."
+3. "What redundancy or restructuring rules in [country] would affect our integration timeline and approach?"
+
+### Planning integration by market
+
+1. "Plan country-specific Day 1 and 100-day integration steps for [country], accounting for local legal requirements."
+2. "Sequence our multi-country integration plan to respect the timeline of the most consultation-heavy jurisdiction involved."
+3. "What mandatory notification or consultation periods must be completed before we can take integration actions in [country]?"
+
+### Risk and complexity assessment
+
+1. "Flag country-specific people risks in this cross-border deal spanning [countries] that the deal team should know about early."
+2. "Compare the complexity of harmonizing benefits and employment terms across [country A], [country B], and [country C]."
+3. "How should local cultural norms in [country] shape our change management and communication approach during integration?"
+
+### Coordination and documentation
+
+1. "Draft a country-by-country requirements summary for the deal team covering [countries involved in this transaction]."
+2. "How should we coordinate input from local legal counsel in each market into a single, coherent integration plan?"
+
+## Tips
+
+- Treat the most consultation-heavy jurisdiction as the pacing item — a multi-country integration plan often can't move faster than its slowest-required legal process, commonly EU works council consultation.
+- Engage local legal counsel early in every market involved, not just at the country where the deal is headquartered; labor law risk is jurisdiction-specific and doesn't generalize from one market's experience.
+- Don't assume US-style at-will flexibility applies elsewhere — many markets require formal consultation, notice periods, or government filings before workforce changes can proceed.
+- Adapt communication tone and channel to local cultural norms; a message that lands well in one market can read as abrupt or insufficiently formal in another.
+- Document country-specific requirements centrally so the deal team has one place to see where integration risk and timeline constraints concentrate.

--- a/skills/hr-people-budgeting/SKILL.md
+++ b/skills/hr-people-budgeting/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: hr-people-budgeting
+description: Help HR leaders and people finance partners own the people budget — headcount cost-center modeling, budget planning cycles, and variance tracking. Use when asked to "build the people budget", "model headcount by cost center", "explain budget variance to finance", "plan the HR budget for next fiscal year", or "reconcile actual headcount spend against plan".
+metadata:
+  author: Tuan Duc Tran
+  version: "1.0.0"
+---
+
+# People budgeting & financial planning
+
+Own the people budget end-to-end — cost-center headcount modeling, annual and rolling budget cycles, and variance tracking — so HR speaks the same financial language as finance instead of treating budget as someone else's spreadsheet.
+
+## Supported tasks
+
+- Building a people budget by cost center, function, and location
+- Modeling headcount cost against approved and planned positions
+- Running the annual and rolling HR budget planning cycle
+- Reconciling actual people spend against budget and explaining variance
+- Allocating shared HR program costs (L&D, wellness, recruiting) across cost centers
+- Modeling the budget impact of mid-year headcount changes or reorgs
+- Building budget scenarios tied to hiring plan changes
+- Preparing people budget narratives for finance and executive reviews
+- Tracking budget-to-actual by month and flagging emerging risk early
+- Coordinating budget assumptions (merit cycle, attrition, backfill timing) with finance
+- Building a zero-based or activity-based view of HR program spend
+- Documenting budget ownership and approval authority across HR and finance
+
+## Key prompts
+
+### Building the budget
+
+1. "Build a people budget for [function/cost center] for [fiscal year], including base, benefits, and planned headcount changes."
+2. "Model headcount cost by cost center for [org unit], reflecting approved and planned-but-not-approved positions separately."
+3. "What assumptions (merit increase %, attrition rate, average backfill delay) should we align with finance before finalizing next year's people budget?"
+
+### Running the cycle
+
+1. "Design an annual people budgeting cycle and calendar that aligns with finance's broader planning timeline."
+2. "Build a rolling forecast update process for the people budget that reflects actual hiring pace each quarter."
+3. "How should we allocate shared HR program costs like L&D or recruiting marketing across business unit cost centers?"
+
+### Variance and reconciliation
+
+1. "Reconcile actual people spend against budget for [period] and explain the key drivers of variance."
+2. "Draft a variance narrative for finance explaining why [cost center] is over/under budget, in language finance will find credible."
+3. "Model the budget impact of [a mid-year reorg / accelerated hiring plan / hiring freeze] on the remaining fiscal year."
+
+### Presenting to finance and leadership
+
+1. "Prepare a people budget summary for the executive budget review, highlighting key assumptions and risks."
+2. "Build a zero-based view of our HR program spend for [function] to support a budget reprioritization conversation."
+3. "Document clear ownership and approval authority for people budget decisions between HR and finance."
+
+## Tips
+
+- Speak finance's language — use their terms (cost center, variance, run-rate, in-year vs. annualized) rather than HR-specific jargon when presenting.
+- Separate approved headcount from planned-but-not-approved in every model; conflating the two overstates commitment and confuses forecasting.
+- Explain variance with drivers, not just numbers — "under budget due to slower-than-planned hiring in Q2" is far more useful than a bare percentage.
+- Align budget assumptions (merit timing, attrition rate, backfill delay) with finance explicitly and in writing so both sides use the same numbers.
+- Revisit the budget on a rolling basis rather than only at annual planning; hiring pace and cost drivers shift throughout the year.

--- a/skills/hr-retirement-benefits/SKILL.md
+++ b/skills/hr-retirement-benefits/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: hr-retirement-benefits
+description: Help compensation and benefits teams design, communicate, and administer retirement and pension benefits. Use when asked to "design our retirement benefit offering", "explain 401(k)/pension options to employees", "compare retirement plan providers", "communicate a retirement plan change", or "help an employee understand their retirement benefits".
+metadata:
+  author: Tuan Duc Tran
+  version: "1.0.0"
+---
+
+# Retirement & pension benefits
+
+Design, communicate, and administer retirement and pension benefits — plan design decisions, provider comparison, employee education, and compliant communication of retirement benefit changes.
+
+## Supported tasks
+
+- Designing a retirement benefit offering (defined contribution, defined benefit, or hybrid)
+- Comparing retirement plan providers and fee structures
+- Setting employer matching and vesting schedule policy
+- Communicating retirement benefits clearly to employees at different career stages
+- Explaining retirement plan options and trade-offs to an individual employee
+- Designing retirement plan enrollment and education campaigns
+- Communicating retirement plan changes (provider switch, match change, plan freeze)
+- Benchmarking retirement benefits against market and industry norms
+- Coordinating retirement benefit compliance with legal and regulatory requirements
+- Supporting employees nearing retirement with transition planning resources
+- Auditing retirement plan participation rates and identifying engagement gaps
+- Explaining jurisdiction-specific retirement/pension requirements to global teams
+
+## Key prompts
+
+### Plan design
+
+1. "Compare defined contribution, defined benefit, and hybrid retirement plan structures for a company our size in [industry/region]."
+2. "Design an employer matching and vesting schedule policy that balances cost and competitiveness for [company profile]."
+3. "Benchmark our retirement benefit offering against [industry/region] market norms."
+
+### Provider and administration
+
+1. "Build a comparison framework for evaluating retirement plan providers on fees, fund options, and service quality."
+2. "What compliance requirements should we account for when administering a retirement plan in [jurisdiction]?"
+3. "Audit our retirement plan participation rates and identify where engagement gaps exist by demographic or tenure."
+
+### Employee communication and education
+
+1. "Write plain-language communication explaining retirement plan options for employees who are new to investing."
+2. "Draft an explanation of [specific plan feature, e.g. vesting/matching/catch-up contributions] appropriate for a general employee audience."
+3. "Design a retirement plan enrollment campaign to increase participation among eligible but not-yet-enrolled employees."
+
+### Change communication and transitions
+
+1. "Draft communication for employees explaining a change in [retirement provider / employer match / plan structure], addressing likely concerns."
+2. "What resources should we provide to employees nearing retirement to support their transition planning?"
+3. "Explain how retirement/pension requirements differ for employees in [country A] vs. [country B] for a global HR team."
+
+## Tips
+
+- Write employee-facing retirement communication in plain language — most employees are not investing experts, and jargon-heavy explanations reduce enrollment and engagement.
+- Model the true cost of any employer match or plan design change before committing, since retirement benefits are a significant and recurring cost line.
+- Communicate plan changes early and with a clear "what this means for you" section — retirement is a sensitive, long-horizon topic where trust matters.
+- Track participation and contribution rates by demographic to identify groups that may need additional education or nudges.
+- Coordinate closely with legal and compliance on jurisdiction-specific requirements, which vary significantly and change with regulation.


### PR DESCRIPTION
- add new HR skills across multiple functional areas
- register new skills in Claude marketplace
- update README with 100+ skills catalog
- reorganize skills into categorized sections
- refine skill descriptions and documentation