### PR TITLE
feat(ai-governance): upgrade AI governance skills to full tier

### DIFF
--- a/.changeset/neutralize-ai-privacy-example.md
+++ b/.changeset/neutralize-ai-privacy-example.md
@@ -1,0 +1,5 @@
+---
+"hr-skills": patch
+---
+
+Updated HR AI privacy and agentic AI examples to align headings and remove jurisdiction-specific legal conclusions.

--- a/docs/skill-matrix.md
+++ b/docs/skill-matrix.md
@@ -1,13 +1,13 @@
 # HR Skills — Skill Matrix
 
-> Auto-generated on 2026-07-21 by `bun run matrix`. Do not edit manually.
+> Auto-generated on 2026-07-22 by `bun run matrix`. Do not edit manually.
 
 ## Summary
 
 | Tier | Count | % |
 |---|---:|---:|
-| 🟢 Full (SKILL.md + content + prompts + examples) | 75 | 51% |
-| 🟡 Partial (SKILL.md + some optional dirs) | 71 | 49% |
+| 🟢 Full (SKILL.md + content + prompts + examples) | 84 | 58% |
+| 🟡 Partial (SKILL.md + some optional dirs) | 62 | 42% |
 | 🔴 Bare (SKILL.md only) | 0 | 0% |
 | **Total** | **146** | 100% |
 
@@ -16,18 +16,18 @@
 | Skill | Tier | content/ | prompts/ | examples/ | Content files | Version |
 |---|---|:---:|:---:|:---:|---:|---|
 | `hr-accessibility-accommodation` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
-| `hr-agentic-ai` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-agentic-ai` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-ai` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-ai-adoption` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
-| `hr-ai-change-management` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
-| `hr-ai-ethics` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
-| `hr-ai-evaluation` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-ai-adoption` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
+| `hr-ai-change-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
+| `hr-ai-ethics` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
+| `hr-ai-evaluation` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-ai-governance` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-ai-privacy` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-ai-privacy` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-analytics` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-ar-vr` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-audit` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-automation` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-automation` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-backend` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-blockchain` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-business-partner` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
@@ -37,7 +37,7 @@
 | `hr-career-development` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-change-communication` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
 | `hr-change-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-chatbot-design` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-chatbot-design` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-cloud` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-coaching-mentoring` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-compensation-benefits` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
@@ -70,7 +70,7 @@
 | `hr-fullstack` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-future-of-work` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-game-development` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-genai` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-genai` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-global-expansion` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-global-hr` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-hr-coordination` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |

--- a/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
+++ b/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
@@ -1,4 +1,4 @@
-# Pilot an autonomous onboarding agent with guardrails
+# Piloting an autonomous onboarding agent with guardrails
 
 ## Context
 

--- a/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
+++ b/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
@@ -1,4 +1,4 @@
-# Piloting an Autonomous Onboarding Agent With Guardrails
+# Pilot an autonomous onboarding agent with guardrails
 
 ## Context
 

--- a/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
+++ b/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
@@ -1,0 +1,27 @@
+# Piloting an Autonomous Onboarding Agent With Guardrails
+
+## Context
+
+An HR operations team wants to pilot an AI agent that handles new-hire pre-boarding: sending document requests, scheduling IT setup, and answering common first-week questions, without a recruiter manually triggering every step.
+
+## Step 1: Define autonomy boundaries
+
+Sample prompt: "Define the exact boundary of what an onboarding agent may do autonomously (send reminders, schedule tasks) versus what always requires a human HR touch."
+
+Expected response: A boundary list allowing the agent to autonomously send document checklists, calendar invites, and FAQ answers, while requiring human handling for anything involving compensation questions, visa or work-authorization issues, or a new hire expressing hesitation about starting.
+
+## Step 2: Design staged rollout and rollback
+
+Sample prompt: "Design a staged autonomy plan moving a recruiting-screening agent from human-approves-every-action to human-reviews-weekly-samples" (adapted to onboarding) and "Draft a rollback plan for an HR inquiry-resolution agent that starts sending incorrect policy answers."
+
+Expected response: A three-stage plan starting with an HR coordinator approving every agent message for two weeks, moving to spot-checking a daily sample, and finally weekly sampling once error rates stay below an agreed threshold — plus a rollback plan that pauses the agent and reverts to manual outreach if it sends incorrect information twice in a week.
+
+## Step 3: Set transparency and escalation
+
+Sample prompt: "Write an employee disclosure notice explaining that an AI agent may contact them during onboarding" and "List the specific agent actions in an offboarding workflow that must never happen without a named human approver" (adapted to flag when the agent must hand off to a human).
+
+Expected response: A short notice sent with the offer letter explaining that pre-boarding messages come from an AI assistant with a named HR contact for anything the agent can't resolve, plus a hard rule that any message mentioning hesitation, a delayed start date, or a compensation question routes immediately to a human.
+
+## Workflow summary
+
+The team pilots the agent with clear autonomy limits, a staged trust-building rollout with a defined rollback trigger, and upfront transparency so new hires always know how to reach a human.

--- a/skills/hr-agentic-ai/prompts/agentic-ai-prompts.md
+++ b/skills/hr-agentic-ai/prompts/agentic-ai-prompts.md
@@ -1,0 +1,7 @@
+# Agentic AI Prompts
+
+- "Define the exact boundary of what an onboarding agent may do autonomously (send reminders, schedule tasks) versus what always requires a human HR touch."
+- "Draft a rollback plan for an HR inquiry-resolution agent that starts sending incorrect policy answers."
+- "Write an incident report template for the first time an HR AI agent takes an action outside its approved scope."
+- "Design a staged autonomy plan moving a recruiting-screening agent from human-approves-every-action to human-reviews-weekly-samples."
+- "List the specific agent actions in an offboarding workflow that must never happen without a named human approver."

--- a/skills/hr-ai-adoption/examples/driving-ai-tool-adoption-among-skeptical-recruiters.md
+++ b/skills/hr-ai-adoption/examples/driving-ai-tool-adoption-among-skeptical-recruiters.md
@@ -1,0 +1,27 @@
+# Driving AI Tool Adoption Among Skeptical Recruiters
+
+## Context
+
+A talent acquisition team rolled out an AI-assisted candidate screening tool three months ago. Usage logs show only 4 of 12 recruiters use it regularly, and several senior recruiters have told their manager the tool "doesn't understand our roles."
+
+## Step 1: Diagnose the resistance
+
+Sample prompt: "What are the most common sources of resistance to AI adoption in HR teams, and how should we address each?"
+
+Expected response: A breakdown distinguishing skill-based resistance (unclear how to use it), trust-based resistance (doubts about output quality), and identity-based resistance (fear the tool signals their judgment isn't valued) — with a different fix for each rather than one blanket training session.
+
+## Step 2: Build a targeted re-engagement plan
+
+Sample prompt: "Design a champion or early-adopter program to drive peer-led adoption of [AI tool]" and "Identify three low-risk HR tasks where a first-time AI user could get a quick win with [AI tool] this week."
+
+Expected response: A plan that pairs each skeptical recruiter with one of the four active users for a 20-minute shadow session, plus a short list of low-stakes tasks (first-pass resume triage on high-volume requisitions) where the tool clearly saves time without touching final decisions.
+
+## Step 3: Measure and sustain
+
+Sample prompt: "Design a way to measure actual usage and productivity impact of [AI tool], not just initial adoption numbers."
+
+Expected response: A monthly usage dashboard tracking screens completed per recruiter, time-to-shortlist before and after, and a short quarterly pulse question asking recruiters whether the tool made a specific task easier that week.
+
+## Workflow summary
+
+Rather than re-running the same training, the team diagnoses why each recruiter isn't using the tool, pairs skeptics with credible peers on low-risk tasks, and tracks real usage instead of one-time training attendance.

--- a/skills/hr-ai-adoption/prompts/ai-adoption-prompts.md
+++ b/skills/hr-ai-adoption/prompts/ai-adoption-prompts.md
@@ -1,0 +1,8 @@
+# AI Adoption Prompts
+
+- "Draft a 90-day adoption plan for [AI tool] in the recruiting team, with a named milestone at each 30-day mark."
+- "Write a manager talking-point sheet for introducing [AI tool] in a team meeting without sounding like a mandate."
+- "Design a lightweight scorecard recruiters can use to self-rate their comfort with [AI tool] before and after training."
+- "Draft a message from the CHRO addressing why HR is adopting [AI tool] now, including what won't change."
+- "Identify three low-risk HR tasks where a first-time AI user could get a quick win with [AI tool] this week."
+- "Write a short survey to check whether HR staff are actually using [AI tool] versus just aware it exists."

--- a/skills/hr-ai-change-management/examples/leading-change-for-an-ai-assisted-performance-review-rollout.md
+++ b/skills/hr-ai-change-management/examples/leading-change-for-an-ai-assisted-performance-review-rollout.md
@@ -1,0 +1,27 @@
+# Leading Change for an AI-Assisted Performance Review Rollout
+
+## Context
+
+A company is introducing an AI drafting assistant to help managers write performance reviews. An early pilot with 20 managers surfaced anxiety that the company is trying to "automate" people decisions, even though the tool only assists drafting.
+
+## Step 1: Assess readiness and segment the audience
+
+Sample prompt: "Assess our workforce's AI readiness across [departments] using [survey / focus group / data analysis] methods" and "How do we segment our workforce by AI readiness level and design targeted change strategies for each segment?"
+
+Expected response: A short readiness assessment identifying that senior managers are most worried about losing ownership of feedback quality, while newer managers welcome help structuring their first reviews — leading to two different rollout messages for each segment.
+
+## Step 2: Communicate honestly about what's changing
+
+Sample prompt: "Write an all-company communication announcing [AI tool adoption] that addresses employee concerns about job security honestly" and "Write a manager guide for having 1:1 conversations with team members who are worried about AI."
+
+Expected response: A communication that states plainly the tool drafts language only, the manager approves and edits every review, and no review is submitted without a human sign-off — paired with a manager guide for answering "does this mean my feedback doesn't matter anymore?"
+
+## Step 3: Build capability and reinforce through leadership
+
+Sample prompt: "Design an AI champion program that uses internal early adopters to accelerate broader workforce adoption" and "How do we build senior leader credibility as AI adoption sponsors when some leaders are themselves anxious about AI?"
+
+Expected response: A short champion cohort of managers from the pilot who share concrete before/after review examples in a leadership forum, with senior leaders visibly using the tool themselves before asking their teams to.
+
+## Workflow summary
+
+The rollout succeeds by segmenting anxious versus receptive managers, being explicit about what stays human, and using credible peer and leadership examples instead of a single top-down announcement.

--- a/skills/hr-ai-change-management/prompts/ai-change-management-prompts.md
+++ b/skills/hr-ai-change-management/prompts/ai-change-management-prompts.md
@@ -1,0 +1,7 @@
+# AI Change Management Prompts
+
+- "Draft a stakeholder map for an AI change initiative in [department], noting who needs to be informed, consulted, or actively involved."
+- "Write a manager script for a team meeting announcing that [process] will now involve an AI tool, including how to handle the first hard question."
+- "Design a 60-day change roadmap for introducing [AI tool] to [team], from readiness assessment to steady-state adoption."
+- "Draft a risk register entry for the change management workstream of an AI rollout, covering morale, attrition, and productivity dips."
+- "Write a debrief template for capturing lessons learned after an AI change initiative, to reuse on the next rollout."

--- a/skills/hr-ai-ethics/examples/auditing-an-ai-ranked-shortlist-for-hidden-bias.md
+++ b/skills/hr-ai-ethics/examples/auditing-an-ai-ranked-shortlist-for-hidden-bias.md
@@ -1,0 +1,27 @@
+# Auditing an AI-Ranked Shortlist for Hidden Bias
+
+## Context
+
+A recruiter notices that an AI-ranked shortlist for a senior engineering role skews heavily toward candidates from a small set of universities and none of the top-ranked candidates are women, despite a diverse applicant pool. Legal wants a documented review before proceeding.
+
+## Step 1: Test for disparate impact and proxy variables
+
+Sample prompt: "What statistical methods should we use to test for disparate impact in AI-assisted hiring decisions?" and "Identify proxy variables that could let our AI screening tool discriminate indirectly by gender even without using it directly."
+
+Expected response: A recommendation to compare pass-through rates by gender and school tier using a standard adverse-impact ratio test, plus a flag that "school prestige" and certain extracurricular keywords can act as proxies correlated with gender and socioeconomic background.
+
+## Step 2: Decide how to handle the flagged case
+
+Sample prompt: "Write escalation criteria for when an AI ethics reviewer, not just a manager, must sign off on a flagged case" and "How do we handle a situation where an AI tool recommends an HR decision that a human reviewer believes is wrong?"
+
+Expected response: Escalation criteria stating that any shortlist with a statistically significant disparate-impact ratio triggers manual re-ranking by a recruiter using the full applicant pool, with the AI score treated as one input, not the deciding factor.
+
+## Step 3: Document and disclose
+
+Sample prompt: "Draft a one-page ethical AI decision brief a hiring manager must sign before using AI-ranked shortlists in a final decision."
+
+Expected response: A one-page brief recording the disparate-impact test result, the corrective action taken (manual re-ranking), and the hiring manager's acknowledgment that the final shortlist reflects human review, filed for audit purposes.
+
+## Workflow summary
+
+The team catches the skew through a proxy-variable and disparate-impact review, escalates rather than proceeding on the flawed shortlist, and documents the correction so the decision holds up under audit.

--- a/skills/hr-ai-ethics/prompts/ai-ethics-prompts.md
+++ b/skills/hr-ai-ethics/prompts/ai-ethics-prompts.md
@@ -1,0 +1,7 @@
+# AI Ethics Prompts
+
+- "Design a bias audit checklist to run before an AI screening tool moves from pilot to full production."
+- "Draft a one-page ethical AI decision brief a hiring manager must sign before using AI-ranked shortlists in a final decision."
+- "Write escalation criteria for when an AI ethics reviewer, not just a manager, must sign off on a flagged case."
+- "Identify proxy variables that could let our AI [screening / performance-scoring] tool discriminate indirectly by [protected characteristic] even without using it directly."
+- "Draft a plain-language answer to a candidate who asks whether AI was used to reject their application."

--- a/skills/hr-ai-evaluation/examples/comparing-two-ai-screening-vendors-before-procurement.md
+++ b/skills/hr-ai-evaluation/examples/comparing-two-ai-screening-vendors-before-procurement.md
@@ -1,0 +1,27 @@
+# Comparing Two AI Screening Vendors Before Procurement
+
+## Context
+
+An HR technology team has narrowed its resume-screening vendor search to two finalists and needs a defensible, consistent comparison before recommending one to procurement and legal.
+
+## Step 1: Build a shared scorecard
+
+Sample prompt: "Build a weighted scorecard to compare two AI interview-scheduling vendors on accuracy, bias risk, integration effort, and cost" (adapted to resume screening).
+
+Expected response: A scorecard with weighted categories — bias testing evidence (30%), accuracy against a validation sample (25%), ATS integration effort (20%), transparency and explainability (15%), and cost (10%) — so both vendors are rated on identical criteria.
+
+## Step 2: Interrogate vendor claims
+
+Sample prompt: "Draft the exact questions to ask a vendor's sales engineer about how their model was trained and validated for resume screening."
+
+Expected response: Specific questions covering the source and recency of training data, whether an independent third party conducted bias testing, what the vendor's disparate-impact results were by demographic group, and how often the model is retrained or updated.
+
+## Step 3: Pilot and decide
+
+Sample prompt: "Design a 30-day pilot success criteria document for an AI resume-screening tool before it replaces manual first-pass review" and "Write a go/no-go decision memo template summarizing an AI tool evaluation for HR leadership sign-off."
+
+Expected response: Success criteria requiring the pilot tool's shortlist to match human-reviewer judgment on a held-out sample above a set agreement threshold, with no disparate-impact flags, followed by a one-page decision memo summarizing scorecard results and the pilot outcome for leadership sign-off.
+
+## Workflow summary
+
+The team avoids choosing on price or a polished demo alone by scoring both vendors on the same evidence-based criteria, pressure-testing their claims directly, and requiring a real pilot before committing.

--- a/skills/hr-ai-evaluation/prompts/ai-evaluation-prompts.md
+++ b/skills/hr-ai-evaluation/prompts/ai-evaluation-prompts.md
@@ -1,0 +1,7 @@
+# AI Evaluation Prompts
+
+- "Build a weighted scorecard to compare two AI interview-scheduling vendors on accuracy, bias risk, integration effort, and cost."
+- "Draft the exact questions to ask a vendor's sales engineer about how their model was trained and validated for [use case]."
+- "Design a 30-day pilot success criteria document for an AI resume-screening tool before it replaces manual first-pass review."
+- "Write a go/no-go decision memo template summarizing an AI tool evaluation for HR leadership sign-off."
+- "Draft a re-evaluation trigger list — the specific events that should force us to re-review an already-approved AI tool."

--- a/skills/hr-ai-privacy/examples/responding-to-a-data-subject-access-request-about-an-ai-tool.md
+++ b/skills/hr-ai-privacy/examples/responding-to-a-data-subject-access-request-about-an-ai-tool.md
@@ -1,0 +1,27 @@
+# Responding to a Data Subject Access Request About an AI Tool
+
+## Context
+
+An employee submits a formal request asking what personal data an AI-powered performance-analytics platform holds about them and how it is used, after hearing the tool flags "attrition risk" scores to managers.
+
+## Step 1: Map what data actually exists
+
+Sample prompt: "Draft a data flow map showing what employee data our AI performance-analytics tool collects, stores, and shares with the vendor."
+
+Expected response: A map identifying the specific fields collected (review scores, tenure, engagement survey responses, manager notes), where they are stored, how long they are retained, and which fields the vendor uses to calculate the attrition-risk score.
+
+## Step 2: Determine legal obligations
+
+Sample prompt: "Assess whether processing employee data through [AI tool] requires a Data Protection Impact Assessment under our applicable privacy law."
+
+Expected response: A short assessment noting that automated profiling producing a risk score with potential managerial impact likely triggers heightened obligations, including disclosure of the logic involved and the employee's right to request human review of any action taken based on the score.
+
+## Step 3: Respond to the employee
+
+Sample prompt: "Write a response to an employee's data subject access request asking what personal data an AI tool holds about them."
+
+Expected response: A response listing the specific data categories held, explaining in plain language how the attrition-risk score is generated and used (as an input for manager check-ins, not automatic action), and confirming the employee's right to request a human review of any decision informed by the score.
+
+## Workflow summary
+
+The team responds by first mapping the actual data flow rather than guessing, confirming the applicable legal obligations for automated profiling, and giving the employee a clear, honest, plain-language answer instead of a generic privacy-notice reference.

--- a/skills/hr-ai-privacy/examples/responding-to-a-data-subject-access-request-about-an-ai-tool.md
+++ b/skills/hr-ai-privacy/examples/responding-to-a-data-subject-access-request-about-an-ai-tool.md
@@ -12,16 +12,16 @@ Expected response: A map identifying the specific fields collected (review score
 
 ## Step 2: Determine legal obligations
 
-Sample prompt: "Assess whether processing employee data through [AI tool] requires a Data Protection Impact Assessment under our applicable privacy law."
+Sample prompt: "Assess what privacy obligations may apply when [AI tool] processes employee data, and identify where we need legal or privacy-specialist review."
 
-Expected response: A short assessment noting that automated profiling producing a risk score with potential managerial impact likely triggers heightened obligations, including disclosure of the logic involved and the employee's right to request human review of any action taken based on the score.
+Expected response: A short assessment that identifies the applicable jurisdictions, privacy notices, vendor terms, retention rules, and internal review paths to confirm before responding, without assuming that any specific disclosure, assessment, objection, or human-review right applies.
 
 ## Step 3: Respond to the employee
 
-Sample prompt: "Write a response to an employee's data subject access request asking what personal data an AI tool holds about them."
+Sample prompt: "Write a response to an employee's data subject access request asking what personal data an AI tool holds about them, subject to review by our privacy or legal specialist."
 
-Expected response: A response listing the specific data categories held, explaining in plain language how the attrition-risk score is generated and used (as an input for manager check-ins, not automatic action), and confirming the employee's right to request a human review of any decision informed by the score.
+Expected response: A response listing the specific data categories held, explaining in plain language how the attrition-risk score is generated and used (as an input for manager check-ins, not automatic action), and explaining any available review, correction, objection, escalation, or complaint options based on the organization's applicable privacy obligations.
 
 ## Workflow summary
 
-The team responds by first mapping the actual data flow rather than guessing, confirming the applicable legal obligations for automated profiling, and giving the employee a clear, honest, plain-language answer instead of a generic privacy-notice reference.
+The team responds by first mapping the actual data flow rather than guessing, assessing obligations under the privacy laws and policies that apply to the request, involving legal or privacy specialists where appropriate, and giving the employee a clear, honest, plain-language answer instead of a generic privacy-notice reference.

--- a/skills/hr-ai-privacy/prompts/ai-privacy-prompts.md
+++ b/skills/hr-ai-privacy/prompts/ai-privacy-prompts.md
@@ -1,0 +1,7 @@
+# AI Privacy Prompts
+
+- "Draft a data flow map showing what employee data our AI performance-analytics tool collects, stores, and shares with the vendor."
+- "Write a response to an employee's data subject access request asking what personal data an AI tool holds about them."
+- "Assess whether processing employee data through [AI tool] requires a Data Protection Impact Assessment under our applicable privacy law."
+- "Draft a data retention and deletion schedule for candidate data processed by an AI screening tool after a role is filled."
+- "Write plain-language talking points for a manager who is asked by an employee why an AI tool has access to their performance data."

--- a/skills/hr-automation/examples/automating-the-leave-request-approval-workflow.md
+++ b/skills/hr-automation/examples/automating-the-leave-request-approval-workflow.md
@@ -1,0 +1,27 @@
+# Automating the Leave Request Approval Workflow
+
+## Context
+
+An HR shared-services team manually processes over 400 leave requests a month across email and spreadsheets, causing approval delays and payroll errors. Leadership wants to automate the routine cases while keeping human judgment for exceptions.
+
+## Step 1: Map the process and find automation potential
+
+Sample prompt: "Map the offboarding process end to end and flag which steps can be automated versus which need a human decision" (adapted to leave requests).
+
+Expected response: A process map showing that standard, policy-compliant requests (sufficient balance, advance notice met) can be auto-approved and synced to payroll, while requests involving negative balances, overlapping team absences, or protected leave types are flagged for a human reviewer.
+
+## Step 2: Design the automated workflow
+
+Sample prompt: "Design an automated escalation rule that routes a leave request to HR only when it falls outside standard policy parameters."
+
+Expected response: A rule set auto-approving requests meeting all standard criteria and routing exceptions to an HR queue with the specific reason flagged (for example, "balance insufficient" or "protected leave type"), so reviewers aren't re-checking every request from scratch.
+
+## Step 3: Validate data quality and plan for failure
+
+Sample prompt: "Write a data-quality checklist to run before automating a workflow that depends on HRIS employee records" and "Draft a rollback plan for an automated onboarding workflow that starts sending incorrect task assignments" (adapted to leave automation).
+
+Expected response: A checklist confirming leave balances, employment type, and manager-of-record fields are accurate in the HRIS before go-live, plus a rollback plan that reverts to manual review for any employee whose auto-approved leave doesn't match their subsequent payroll record.
+
+## Workflow summary
+
+The team automates the routine, low-risk majority of leave requests while explicitly routing exceptions to a human, and protects against silent errors with a data-quality check and a rollback path.

--- a/skills/hr-automation/prompts/hr-automation-prompts.md
+++ b/skills/hr-automation/prompts/hr-automation-prompts.md
@@ -1,0 +1,7 @@
+# HR Automation Prompts
+
+- "Map the offboarding process end to end and flag which steps can be automated versus which need a human decision."
+- "Draft an automation business case comparing the cost of manual offer-letter generation to an automated document workflow."
+- "Design an automated escalation rule that routes a leave request to HR only when it falls outside standard policy parameters."
+- "Write a data-quality checklist to run before automating a workflow that depends on HRIS employee records."
+- "Draft a rollback plan for an automated onboarding workflow that starts sending incorrect task assignments."

--- a/skills/hr-chatbot-design/examples/designing-a-slack-bot-for-benefits-enrollment-questions.md
+++ b/skills/hr-chatbot-design/examples/designing-a-slack-bot-for-benefits-enrollment-questions.md
@@ -1,0 +1,27 @@
+# Designing a Slack Bot for Benefits Enrollment Questions
+
+## Context
+
+An HR team is launching a Slack bot to reduce the volume of repetitive benefits questions during a two-week open enrollment window, without giving employees inaccurate plan information.
+
+## Step 1: Scope the intent list
+
+Sample prompt: "Design the intent-recognition category list for a benefits-enrollment chatbot handling questions during open enrollment."
+
+Expected response: A list covering plan comparison questions, enrollment deadline reminders, dependent-eligibility questions, and "how do I change my current elections" — with a note that plan cost calculations and life-event special enrollment questions are excluded from the first release because they require case-specific review.
+
+## Step 2: Build the conversation flow
+
+Sample prompt: "Write the bot's fallback and clarification script for when it recognizes an intent but is missing information it needs from the employee."
+
+Expected response: A script where the bot asks a clarifying follow-up (for example, which plan the employee is comparing) before answering, and a fallback message that says plainly it can't answer and offers a direct link to schedule time with a benefits specialist rather than guessing.
+
+## Step 3: Set escalation rules and plan the audit
+
+Sample prompt: "Write escalation criteria distinguishing a routine PTO-balance question from one that should route straight to a human HR rep" (adapted to benefits) and "Design a script auditing process to review 50 real chatbot transcripts and flag where the bot gave a wrong or incomplete answer."
+
+Expected response: Escalation rules routing any question involving a life event, dependent eligibility dispute, or a dollar-amount claim straight to a human, plus a weekly review of a transcript sample during the enrollment window to catch and fix any confidently wrong answers before they spread.
+
+## Workflow summary
+
+The bot launches with a narrow, well-defined intent scope, clear fallback behavior instead of guessing, and a short weekly audit loop that catches mistakes early during the high-stakes enrollment window.

--- a/skills/hr-chatbot-design/prompts/hr-chatbot-design-prompts.md
+++ b/skills/hr-chatbot-design/prompts/hr-chatbot-design-prompts.md
@@ -1,0 +1,7 @@
+# HR Chatbot Design Prompts
+
+- "Write the bot's fallback and clarification script for when it recognizes an intent but is missing information it needs from the employee."
+- "Design the intent-recognition category list for a benefits-enrollment chatbot handling questions during open enrollment."
+- "Draft a Slack bot conversation flow for an employee reporting they can't access their payslip."
+- "Write escalation criteria distinguishing a routine PTO-balance question from one that should route straight to a human HR rep."
+- "Design a script auditing process to review 50 real chatbot transcripts and flag where the bot gave a wrong or incomplete answer."

--- a/skills/hr-genai/examples/using-genai-to-summarize-exit-interview-themes.md
+++ b/skills/hr-genai/examples/using-genai-to-summarize-exit-interview-themes.md
@@ -1,0 +1,27 @@
+# Using GenAI to Summarize Exit Interview Themes
+
+## Context
+
+An HR business partner has 40 exit interview notes from the past quarter and needs to identify recurring themes for a retention review with leadership, without exposing individual employees' identifiable comments.
+
+## Step 1: Draft the summarization prompt with guardrails
+
+Sample prompt: "Summarize this batch of exit interview notes and identify the two most common themes without quoting any individual verbatim."
+
+Expected response: A prompt structure that feeds in anonymized notes (names and identifying details stripped beforehand), asks for theme frequency and representative paraphrased patterns rather than direct quotes, and explicitly instructs against attributing any theme to a specific person or team of fewer than five people.
+
+## Step 2: Review output quality before use
+
+Sample prompt: "Draft a quality-review checklist an HR generalist should run through before sending a GenAI-drafted policy explanation to employees" (adapted to a leadership-facing summary).
+
+Expected response: A checklist confirming the summary doesn't include identifiable quotes, that theme counts match a manual spot-check of the source notes, and that any sensitive theme (such as harassment mentions) is flagged for direct HR follow-up rather than folded into a generic summary line.
+
+## Step 3: Present findings responsibly
+
+Sample prompt: "Draft a GenAI usage guardrail specifically for compensation-related HR communications, given their sensitivity" (adapted as a general sensitivity guardrail for the leadership readout).
+
+Expected response: Guidance to present themes as aggregate patterns with sample sizes attached (for example, "6 of 40 departures cited limited growth opportunity"), and to route any theme touching potential policy or legal risk to HR leadership for direct review before it appears in a broader readout.
+
+## Workflow summary
+
+The HR business partner uses GenAI to speed up theme identification across a large volume of notes, while keeping anonymization, human quality review, and sensitive-topic escalation firmly in place before anything reaches leadership.

--- a/skills/hr-genai/prompts/genai-for-hr-prompts.md
+++ b/skills/hr-genai/prompts/genai-for-hr-prompts.md
@@ -1,0 +1,7 @@
+# GenAI for HR Prompts
+
+- "Use GenAI to draft three variations of an interview-rejection email at different stages, then flag which tone fits a final-round candidate versus an early screen-out."
+- "Draft a quality-review checklist an HR generalist should run through before sending a GenAI-drafted policy explanation to employees."
+- "Summarize this batch of exit-interview notes and identify the two most common themes without quoting any individual verbatim."
+- "Draft a GenAI usage guardrail specifically for compensation-related HR communications, given their sensitivity."
+- "Write a short internal guide teaching HR generalists how to prompt GenAI for a first-draft PIP versus a first-draft coaching note."


### PR DESCRIPTION
Add prompts/ and examples/ to hr-ai-adoption, hr-ai-change-management, hr-ai-ethics, hr-ai-evaluation, hr-ai-privacy, hr-agentic-ai, hr-automation, hr-chatbot-design, and hr-genai, upgrading them from Partial to Full. hr-embedded was already Full and required no changes.

Regenerate docs/skill-matrix.md via bun run matrix (75 -> 84 Full skills).

Closes #104 