### PR TITLE
fix(hr-ai-privacy): normalize onboarding example H1 and remove jurisdiction-specific legal conclusions

### DIFF
--- a/.changeset/neutralize-ai-privacy-example.md
+++ b/.changeset/neutralize-ai-privacy-example.md
@@ -1,0 +1,5 @@
+---
+"hr-skills": patch
+---
+
+Updated HR AI privacy and agentic AI examples to align headings and remove jurisdiction-specific legal conclusions.

--- a/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
+++ b/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
@@ -1,4 +1,4 @@
-# Pilot an autonomous onboarding agent with guardrails
+# Piloting an autonomous onboarding agent with guardrails
 
 ## Context
 

--- a/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
+++ b/skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md
@@ -1,4 +1,4 @@
-# Piloting an Autonomous Onboarding Agent With Guardrails
+# Pilot an autonomous onboarding agent with guardrails
 
 ## Context
 

--- a/skills/hr-ai-privacy/examples/responding-to-a-data-subject-access-request-about-an-ai-tool.md
+++ b/skills/hr-ai-privacy/examples/responding-to-a-data-subject-access-request-about-an-ai-tool.md
@@ -12,16 +12,16 @@ Expected response: A map identifying the specific fields collected (review score
 
 ## Step 2: Determine legal obligations
 
-Sample prompt: "Assess whether processing employee data through [AI tool] requires a Data Protection Impact Assessment under our applicable privacy law."
+Sample prompt: "Assess what privacy obligations may apply when [AI tool] processes employee data, and identify where we need legal or privacy-specialist review."
 
-Expected response: A short assessment noting that automated profiling producing a risk score with potential managerial impact likely triggers heightened obligations, including disclosure of the logic involved and the employee's right to request human review of any action taken based on the score.
+Expected response: A short assessment that identifies the applicable jurisdictions, privacy notices, vendor terms, retention rules, and internal review paths to confirm before responding, without assuming that any specific disclosure, assessment, objection, or human-review right applies.
 
 ## Step 3: Respond to the employee
 
-Sample prompt: "Write a response to an employee's data subject access request asking what personal data an AI tool holds about them."
+Sample prompt: "Write a response to an employee's data subject access request asking what personal data an AI tool holds about them, subject to review by our privacy or legal specialist."
 
-Expected response: A response listing the specific data categories held, explaining in plain language how the attrition-risk score is generated and used (as an input for manager check-ins, not automatic action), and confirming the employee's right to request a human review of any decision informed by the score.
+Expected response: A response listing the specific data categories held, explaining in plain language how the attrition-risk score is generated and used (as an input for manager check-ins, not automatic action), and explaining any available review, correction, objection, escalation, or complaint options based on the organization's applicable privacy obligations.
 
 ## Workflow summary
 
-The team responds by first mapping the actual data flow rather than guessing, confirming the applicable legal obligations for automated profiling, and giving the employee a clear, honest, plain-language answer instead of a generic privacy-notice reference.
+The team responds by first mapping the actual data flow rather than guessing, assessing obligations under the privacy laws and policies that apply to the request, involving legal or privacy specialists where appropriate, and giving the employee a clear, honest, plain-language answer instead of a generic privacy-notice reference.


### PR DESCRIPTION
### Motivation

- Normalize the H1 in the agentic onboarding example to follow repository heading conventions (sentence case, avoid gerund, match file name). 
- Remove hard-coded, jurisdiction-specific legal assertions from the DSAR example so guidance is neutral and prompts readers to confirm obligations under applicable law and consult legal/privacy specialists.

### Description

- Changed the H1 in `skills/hr-agentic-ai/examples/piloting-an-autonomous-onboarding-agent-with-guardrails.md` from `# Piloting an Autonomous Onboarding Agent With Guardrails` to `# Pilot an autonomous onboarding agent with guardrails` to use sentence case and an imperative phrasing. 
- Revised wording in `skills/hr-ai-privacy/examples/responding-to-a-data-subject-access-request-about-an-ai-tool.md` to remove assertions about specific legal obligations (for example, explicit claims about DPIAs, automated-profiling disclosure, or guaranteed human-review rights) and replaced them with jurisdiction-agnostic guidance to identify applicable jurisdictions, notices, vendor terms, retention rules, and points for legal or privacy-specialist review. 
- Adjusted the sample prompts and expected responses in the DSAR example to require specialist review where appropriate and to describe available review/correction/escalation options in neutral terms. 
- Added a patch changeset at `.changeset/neutralize-ai-privacy-example.md` documenting the user-visible example updates.

### Testing

- Ran `git diff --check` which produced no whitespace or diff-check errors. 
- Attempted `bun run lint:md` but it failed because `markdownlint` is not available in the environment (tooling blocked). 
- Attempted `bun run validate` but it failed because `turbo` is not available in the environment (tooling blocked). 
- Attempted `bun install` but package fetches were blocked by the registry (403), preventing local install of dev tooling; content changes are limited to Markdown and a changeset and were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6038a4c264832794d6c6d9bf0ca63f)