### PR TITLE
feat(employee-experience): upgrade lifecycle skills to full tier

### DIFF
--- a/docs/skill-matrix.md
+++ b/docs/skill-matrix.md
@@ -6,8 +6,8 @@
 
 | Tier | Count | % |
 |---|---:|---:|
-| 🟢 Full (SKILL.md + content + prompts + examples) | 84 | 58% |
-| 🟡 Partial (SKILL.md + some optional dirs) | 62 | 42% |
+| 🟢 Full (SKILL.md + content + prompts + examples) | 93 | 64% |
+| 🟡 Partial (SKILL.md + some optional dirs) | 53 | 36% |
 | 🔴 Bare (SKILL.md only) | 0 | 0% |
 | **Total** | **146** | 100% |
 
@@ -34,7 +34,7 @@
 | `hr-candidate-assessment` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-candidate-experience` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-candidate-sourcing` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-career-development` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-career-development` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-change-communication` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
 | `hr-change-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-chatbot-design` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
@@ -55,14 +55,14 @@
 | `hr-digital-hr` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-diversity-inclusion` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-embedded` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-employee-communications` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-employee-communications` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-employee-engagement` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-employee-experience` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-employee-journey-mapping` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
-| `hr-employee-lifecycle` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
-| `hr-employee-listening` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-employee-journey-mapping` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
+| `hr-employee-lifecycle` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
+| `hr-employee-listening` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-employee-relations` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
-| `hr-employee-self-service` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-employee-self-service` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-employer-branding` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
 | `hr-executive-assessment` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
 | `hr-executive-search` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
@@ -94,7 +94,7 @@
 | `hr-market-mapping` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-mergers-acquisitions` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
 | `hr-mobile` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
-| `hr-offboarding` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-offboarding` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-offer-management` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-onboarding` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-operating-model` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
@@ -116,7 +116,7 @@
 | `hr-project-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-prompt-engineering` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-qa` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
-| `hr-recognition` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-recognition` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-recruiting` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-recruitment-marketing` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-recruitment-operations` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
@@ -152,7 +152,7 @@
 | `hr-uiux` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
 | `hr-vendor-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-vietnam-context` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-wellbeing` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
+| `hr-wellbeing` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-workforce-capability` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-workforce-economics` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
 | `hr-workforce-forecasting` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |

--- a/skills/hr-career-development/examples/coaching-a-manager-through-a-not-yet-promotion-conversation.md
+++ b/skills/hr-career-development/examples/coaching-a-manager-through-a-not-yet-promotion-conversation.md
@@ -1,0 +1,27 @@
+# Coaching a manager through a "not yet" promotion conversation
+
+## Context
+
+A software engineer has told their manager they expect to be promoted to senior engineer this cycle. The manager and the calibration committee agree the engineer isn't ready yet — they're strong technically but haven't shown the cross-team influence the next level requires. The manager has never delivered this kind of message and is worried the engineer will quit.
+
+## Step 1: Prepare the manager before the conversation
+
+Sample prompt: "Write manager talking points for a promotion-readiness conversation when the honest answer is 'not yet' and the employee is expecting yes."
+
+Expected response: Talking points that open with a direct statement of the decision (no promotion this cycle), followed by two concrete strengths, the specific gap against the next level's criteria (cross-team influence), and an invitation to discuss what closing that gap could look like — avoiding vague language like "not quite there yet" that leaves the employee guessing.
+
+## Step 2: Turn the gap into a plan
+
+Sample prompt: "Draft an IDP for an employee who wants to move from individual contributor to team lead within 12 months, with specific stretch assignments" and "Design a skills gap assessment for an employee comparing their current competencies against the next level on our career ladder."
+
+Expected response: A gap assessment scoring the engineer against the senior-level competency model, showing strong technical depth but limited cross-team project ownership, paired with an IDP that assigns them ownership of one cross-team initiative next quarter as concrete, evaluable evidence for the next calibration cycle.
+
+## Step 3: Give the employee agency
+
+Sample prompt: "Draft a lateral-move pitch template an employee can use to propose a cross-functional move to their current and prospective manager."
+
+Expected response: A template the engineer could use if they wanted to build cross-team experience through a temporary rotation rather than waiting passively, giving them a concrete option instead of just a longer wait.
+
+## Workflow summary
+
+The manager delivers a direct, specific "not yet" instead of a vague one, backed by a clear gap assessment and a concrete plan the engineer can act on immediately, turning a difficult conversation into a defined path forward.

--- a/skills/hr-career-development/prompts/career-development-prompts.md
+++ b/skills/hr-career-development/prompts/career-development-prompts.md
@@ -1,0 +1,7 @@
+# Career development prompts
+
+- "Write a career conversation opener a manager can use with an employee who says they feel stuck but hasn't named what they want next."
+- "Draft an IDP for an employee who wants to move from individual contributor to team lead within 12 months, with specific stretch assignments."
+- "Design a skills gap assessment for an employee comparing their current competencies against the next level on our career ladder."
+- "Write manager talking points for a promotion-readiness conversation when the honest answer is 'not yet' and the employee is expecting yes."
+- "Draft a lateral-move pitch template an employee can use to propose a cross-functional move to their current and prospective manager."

--- a/skills/hr-employee-communications/examples/communicating-a-mid-year-reorganization-without-triggering-a-rumor-cycle.md
+++ b/skills/hr-employee-communications/examples/communicating-a-mid-year-reorganization-without-triggering-a-rumor-cycle.md
@@ -1,0 +1,27 @@
+# Communicating a Mid-Year Reorganization Without Triggering a Rumor Cycle
+
+## Context
+
+A 300-person division is being reorganized into two smaller units with new reporting lines. Leadership wants to announce the change company-wide next Monday, but three team leads already know informally and HR is worried the news will leak before managers are prepared to answer questions.
+
+## Step 1: Sequence the communication
+
+Sample prompt: "How should we sequence and time this announcement to minimize rumor and confusion before the official communication goes out?"
+
+Expected response: A sequencing plan briefing all directly affected managers first (Thursday), giving them time to prepare and ask questions privately, followed by the company-wide announcement (Monday morning) before informal word can spread further — with a clear cutoff time after which no manager should discuss it informally.
+
+## Step 2: Equip managers before employees hear the news
+
+Sample prompt: "Write manager talking points to accompany an announcement about a reorganization, so managers aren't caught off guard by their own team's questions."
+
+Expected response: Talking points covering what's changing (reporting lines, team names), what isn't (roles, compensation, location), and direct answers to the two questions managers are most likely to face — "will there be layoffs" and "who do I report to now" — so managers aren't improvising in front of their teams.
+
+## Step 3: Draft the announcement and anticipate questions
+
+Sample prompt: "Draft a plain-language announcement explaining the reorganization, including what stays the same and what employees must do before the deadline" and "Build an FAQ document anticipating the ten most likely employee questions after the change."
+
+Expected response: A short, direct announcement leading with what's changing and why, followed by an FAQ covering reporting-line changes, timeline for org charts to update, and where to direct questions not answered in the FAQ.
+
+## Workflow summary
+
+HR gets ahead of the leak risk by briefing managers first with concrete talking points, then sends a direct company-wide announcement paired with an FAQ, instead of letting the news spread informally before anyone is prepared to answer questions.

--- a/skills/hr-employee-communications/prompts/employee-communications-prompts.md
+++ b/skills/hr-employee-communications/prompts/employee-communications-prompts.md
@@ -1,0 +1,7 @@
+# Employee communications prompts
+
+- "Draft a plain-language announcement explaining a change to our health insurance provider, including what stays the same and what employees must do before the deadline."
+- "Write manager talking points to accompany an announcement about a reorganization, so managers aren't caught off guard by their own team's questions."
+- "Build an FAQ document anticipating the ten most likely employee questions after a return-to-office policy change."
+- "Draft a follow-up communication for a layoff announcement, sent two weeks later, addressing survivor concerns without reopening the original decision."
+- "Adapt this HR policy announcement into a two-minute town hall script and a one-paragraph Slack version, keeping the core message identical."

--- a/skills/hr-employee-journey-mapping/examples/redesigning-the-internal-transfer-journey-after-rising-complaints.md
+++ b/skills/hr-employee-journey-mapping/examples/redesigning-the-internal-transfer-journey-after-rising-complaints.md
@@ -1,0 +1,27 @@
+# Redesigning the Internal Transfer Journey After Rising Complaints
+
+## Context
+
+Employees who apply for internal transfers increasingly complain about the process: unclear approval steps, silence from hiring managers for weeks, and current managers sometimes finding out about a transfer request secondhand. HR wants to map the journey and fix the worst friction points before the next internal mobility push.
+
+## Step 1: Build the journey map from real data
+
+Sample prompt: "What data sources should feed a journey map for the internal transfer process, beyond the exit and onboarding surveys we already run?"
+
+Expected response: A recommendation to pull ATS timestamps for internal applications, a short survey of employees who transferred in the last two quarters, and informal interviews with managers who received transfer requests, since existing survey data wasn't built to capture this specific journey.
+
+## Step 2: Identify the moments that matter and the friction
+
+Sample prompt: "Map the first 90 days of the onboarding journey for a remote hire, flagging the two moments most likely to shape whether they stay past year one" (adapted to identify moments that matter in the transfer journey) and "Compare our intended promotion process design against what recently promoted employees report actually experiencing, and identify the gap."
+
+Expected response: A finding that the two moments that matter most are the initial silence after applying (employees interpret no response within a week as rejection) and how the current manager learns about the request — with the intended process (current manager informed before any interview) frequently not matching what's reported (managers finding out only after an offer is made).
+
+## Step 3: Prioritize fixes and build the case
+
+Sample prompt: "Draft a business case for redesigning the parental leave return journey, quantifying the cost of the current drop-off in retention" (adapted to the transfer journey) and "Design a journey mapping workshop agenda for HR, IT, and facilities to jointly redesign the day-one onboarding experience" (adapted to include recruiting and people managers for the transfer journey).
+
+Expected response: A prioritized fix list starting with a mandatory five-business-day acknowledgment SLA for internal applications and a required current-manager notification step before any interview is scheduled, plus a workshop agenda bringing recruiting, HRBPs, and a sample of managers together to agree on the new process before rollout.
+
+## Workflow summary
+
+HR fixes the transfer journey by grounding the redesign in real applicant and manager data rather than assumptions, pinpointing the specific moments driving the complaints, and prioritizing the fixes most employees are actually affected by first.

--- a/skills/hr-employee-journey-mapping/prompts/employee-journey-mapping-prompts.md
+++ b/skills/hr-employee-journey-mapping/prompts/employee-journey-mapping-prompts.md
@@ -1,0 +1,7 @@
+# Employee journey mapping prompts
+
+- "Map the first 90 days of the onboarding journey for a remote hire, flagging the two moments most likely to shape whether they stay past year one."
+- "Compare our intended promotion process design against what recently promoted employees report actually experiencing, and identify the gap."
+- "Design a journey mapping workshop agenda for HR, IT, and facilities to jointly redesign the day-one onboarding experience."
+- "Draft a business case for redesigning the parental leave return journey, quantifying the cost of the current drop-off in retention."
+- "What data sources should feed a journey map for the internal transfer process, beyond the exit and onboarding surveys we already run?"

--- a/skills/hr-employee-lifecycle/examples/building-a-lifecycle-risk-escalation-protocol-after-a-retention-blind-spot.md
+++ b/skills/hr-employee-lifecycle/examples/building-a-lifecycle-risk-escalation-protocol-after-a-retention-blind-spot.md
@@ -1,0 +1,27 @@
+# Building a Lifecycle Risk Escalation Protocol After a Retention Blind Spot
+
+## Context
+
+A company discovered that a high-performing team lost three employees within six weeks, and in hindsight each had shown disengagement signals — declining participation in meetings, no PTO usage, one-word survey responses — that no one connected until they resigned. HR wants a lifecycle-wide protocol so these signals trigger action earlier next time.
+
+## Step 1: Segment where the risk is concentrated
+
+Sample prompt: "Create a lifecycle segment analysis identifying which employee groups are at highest attrition risk based on tenure and role family" and "Create a cohort retention analysis framework comparing employees hired in the last three years by hire quarter."
+
+Expected response: An analysis showing the three departures shared a common pattern — all were 18-24 months tenure, past the new-hire engagement boost but before their first internal promotion cycle — a segment worth tracking distinctly from brand-new hires or long-tenured staff.
+
+## Step 2: Define escalation protocols
+
+Sample prompt: "Design escalation protocols for lifecycle risk signals, so an HRBP knows exactly when a disengagement signal warrants a manager conversation versus a skip-level."
+
+Expected response: A tiered protocol where a single signal (one skipped 1:1, one low pulse score) prompts the manager to check in informally, but two or more signals within a 60-day window (declining meeting participation plus unused PTO) triggers a required HRBP-facilitated conversation, not left to manager discretion alone.
+
+## Step 3: Build the check-in cadence to catch signals earlier
+
+Sample prompt: "Write lifecycle-aware conversation guides for 1:1 check-ins at the 30, 90, and 180-day marks for new hires" and "Build a lifecycle framework covering attract, hire, onboard, develop, retain, and exit" (used to place the new 18-24 month checkpoint into the broader lifecycle model).
+
+Expected response: A conversation guide adding a structured check-in at the 18-month mark specifically probing growth trajectory and sense of progress, since that's the tenure window where the recent departures occurred, integrated into the broader lifecycle framework so it isn't a one-off fix.
+
+## Workflow summary
+
+HR closes the blind spot by identifying the specific tenure segment where risk concentrated, building a clear escalation protocol so combined signals trigger action instead of being individually dismissed, and adding a structured check-in at the exact point in the lifecycle where the risk showed up.

--- a/skills/hr-employee-lifecycle/prompts/employee-lifecycle-prompts.md
+++ b/skills/hr-employee-lifecycle/prompts/employee-lifecycle-prompts.md
@@ -1,0 +1,7 @@
+# Employee lifecycle prompts
+
+- "Build a lifecycle framework covering attract, hire, onboard, develop, retain, and exit for a 500-person company scaling internationally."
+- "Create a cohort retention analysis framework comparing employees hired in the last three years by hire quarter."
+- "Design escalation protocols for lifecycle risk signals, so an HRBP knows exactly when a disengagement signal warrants a manager conversation versus a skip-level."
+- "Write lifecycle-aware conversation guides for 1:1 check-ins at the 30, 90, and 180-day marks for new hires."
+- "Create a lifecycle segment analysis identifying which employee groups are at highest attrition risk based on tenure and role family."

--- a/skills/hr-employee-listening/examples/turning-a-flat-engagement-survey-into-a-credible-action-plan.md
+++ b/skills/hr-employee-listening/examples/turning-a-flat-engagement-survey-into-a-credible-action-plan.md
@@ -1,0 +1,27 @@
+# Turning a Flat Engagement Survey Into a Credible Action Plan
+
+## Context
+
+The annual engagement survey results come back with a company-wide score that looks stable year over year, but HR suspects it's masking a real problem in one department where turnover has quietly doubled. Leadership wants a results readout and an action plan within three weeks.
+
+## Step 1: Look past the headline score
+
+Sample prompt: "Analyze these survey results and identify the top 3 priority areas for action, ranked by both severity and how many employees are affected" and "Design a driver analysis approach connecting our engagement survey dimensions to actual resignation data from the past year."
+
+Expected response: An analysis segmenting results by department showing the flat company average is hiding a significant decline in the operations team specifically, and a driver analysis linking low scores on "manager support" in that department to the resignations recorded there over the past year.
+
+## Step 2: Get qualitative context before acting
+
+Sample prompt: "Write a stay interview guide for managers to use with their strongest performers before a competitor tries to poach them" (adapted here to understand what's driving the operations team's decline).
+
+Expected response: A stay interview guide with open, non-leading questions about what's currently working and what would make them consider leaving, to be run by an HRBP rather than the operations team's own manager, since manager support is the flagged concern.
+
+## Step 3: Build the action plan and close the loop
+
+Sample prompt: "Develop a team-level action planning template a manager can complete in under 30 minutes after receiving their survey results" and "Draft a communication announcing survey results and planned actions that doesn't just restate the scores back to employees."
+
+Expected response: A short action-planning template for the operations manager focused on one or two specific commitments rather than a broad list, plus a company-wide communication that names the flat overall score honestly, discloses that one team is being prioritized for deeper support, and commits to a specific follow-up date.
+
+## Workflow summary
+
+HR avoids declaring a flat overall score a non-issue by segmenting the data to find where the real problem is, gathering qualitative context through stay interviews, and building a focused action plan with a visible follow-up commitment instead of a generic company-wide response.

--- a/skills/hr-employee-listening/prompts/employee-listening-prompts.md
+++ b/skills/hr-employee-listening/prompts/employee-listening-prompts.md
@@ -1,0 +1,7 @@
+# Employee listening prompts
+
+- "Analyze these survey results and identify the top 3 priority areas for action, ranked by both severity and how many employees are affected."
+- "Write a stay interview guide for managers to use with their strongest performers before a competitor tries to poach them."
+- "Develop a team-level action planning template a manager can complete in under 30 minutes after receiving their survey results."
+- "Draft a communication announcing survey results and planned actions that doesn't just restate the scores back to employees."
+- "Design a driver analysis approach connecting our engagement survey dimensions to actual resignation data from the past year."

--- a/skills/hr-employee-self-service/examples/fixing-a-low-adoption-hr-chatbot-before-a-full-rollout.md
+++ b/skills/hr-employee-self-service/examples/fixing-a-low-adoption-hr-chatbot-before-a-full-rollout.md
@@ -1,0 +1,27 @@
+# Fixing a Low-Adoption HR Chatbot Before a Full Rollout
+
+## Context
+
+An HR chatbot piloted with one department shows employees still email HR directly for questions the bot is supposed to handle. Login data looks fine, but resolution rate is low, and leadership wants to know whether to expand the pilot company-wide.
+
+## Step 1: Diagnose the real problem
+
+Sample prompt: "Identify which of our top 20 HR inquiries are actually suited for self-service versus needing a human, based on complexity and sensitivity."
+
+Expected response: A finding that several of the bot's assigned topics — leave policy exceptions, compensation questions — are too case-specific for self-service and were driving both the low resolution rate and the direct emails, since employees learned quickly the bot couldn't actually resolve those.
+
+## Step 2: Fix the content and the escalation path
+
+Sample prompt: "Write a clear, employee-friendly FAQ answer for 'How do I request unpaid leave?' that an employee can act on without calling HR" and "Design chatbot escalation paths so employees reach a human HR contact when the bot can't help, instead of getting stuck in a loop."
+
+Expected response: A rewritten FAQ answer giving the actual steps and eligibility criteria in plain language, plus an escalation path that routes to a named HR contact after one failed clarification attempt rather than looping the employee through repeated bot prompts.
+
+## Step 3: Rebuild trust before expanding
+
+Sample prompt: "Draft a change management plan to drive adoption of our new HR chatbot among employees who currently just email HR directly."
+
+Expected response: A plan that re-launches the bot to the pilot department only after the content fixes are in place, with a short message acknowledging the earlier gaps and highlighting the specific topics now fixed, before expanding to additional departments.
+
+## Workflow summary
+
+Rather than blaming low adoption on unfamiliarity, the team diagnoses that the bot was scoped to handle questions it couldn't actually resolve, fixes the content and escalation path, and rebuilds trust with the pilot group before expanding further.

--- a/skills/hr-employee-self-service/prompts/employee-self-service-prompts.md
+++ b/skills/hr-employee-self-service/prompts/employee-self-service-prompts.md
@@ -1,0 +1,7 @@
+# Employee self-service prompts
+
+- "Design chatbot escalation paths so employees reach a human HR contact when the bot can't help, instead of getting stuck in a loop."
+- "Write a clear, employee-friendly FAQ answer for 'How do I request unpaid leave?' that an employee can act on without calling HR."
+- "Identify which of our top 20 HR inquiries are actually suited for self-service versus needing a human, based on complexity and sensitivity."
+- "Design a manager self-service workflow for approving a compensation change, including which steps still require HR sign-off."
+- "Draft a change management plan to drive adoption of our new HR chatbot among employees who currently just email HR directly."

--- a/skills/hr-offboarding/examples/managing-a-resignation-where-institutional-knowledge-is-at-risk.md
+++ b/skills/hr-offboarding/examples/managing-a-resignation-where-institutional-knowledge-is-at-risk.md
@@ -1,0 +1,27 @@
+# Managing a Resignation Where Institutional Knowledge Is at Risk
+
+## Context
+
+A senior engineer who is the only person familiar with a legacy billing system resigns with a two-week notice period. Their manager is anxious about the knowledge gap, and HR needs to balance a respectful offboarding with protecting the business.
+
+## Step 1: Build the knowledge transfer plan first
+
+Sample prompt: "Create a knowledge transfer template for a departing senior engineer who owns the only documentation for a critical system."
+
+Expected response: A template prioritizing the highest-risk knowledge first — undocumented system dependencies and known workarounds — structured as short daily handoff sessions with a named successor over the two-week window, rather than a single end-of-notice document dump.
+
+## Step 2: Understand why they're leaving
+
+Sample prompt: "Write exit interview questions specifically designed to uncover whether a resignation was actually about a manager relationship, without asking that directly."
+
+Expected response: Questions that ask what would have changed their decision and how they'd describe day-to-day support from their manager, framed neutrally enough that the employee can surface manager-related concerns without feeling put on the spot about a specific person.
+
+## Step 3: Protect team morale during the transition
+
+Sample prompt: "Create a manager guide for delivering a termination conversation for performance reasons, including what not to say" (adapted here as guidance for the manager announcing a valued teammate's voluntary departure to the rest of the team).
+
+Expected response: Guidance for the manager to announce the departure honestly and briefly, avoid over-praising in a way that raises questions about counteroffers, and proactively address the knowledge-transfer plan so the team feels the risk is being managed rather than left unspoken.
+
+## Workflow summary
+
+HR treats the knowledge risk as the most urgent priority within the notice period, uses the exit interview to surface honest signal about manager-related attrition, and equips the manager to communicate the departure in a way that protects team confidence.

--- a/skills/hr-offboarding/prompts/offboarding-prompts.md
+++ b/skills/hr-offboarding/prompts/offboarding-prompts.md
@@ -1,0 +1,7 @@
+# Offboarding prompts
+
+- "Create a knowledge transfer template for a departing senior engineer who owns the only documentation for a critical system."
+- "Write exit interview questions specifically designed to uncover whether a resignation was actually about a manager relationship, without asking that directly."
+- "Draft a redundancy communication plan for a 15-person department restructuring, sequencing manager briefings before the team announcement."
+- "Create a manager guide for delivering a termination conversation for performance reasons, including what not to say."
+- "Design a boomerang employee policy defining under what conditions a former employee is eligible for rehire."

--- a/skills/hr-recognition/examples/fixing-an-uneven-recognition-program-before-it-damages-morale.md
+++ b/skills/hr-recognition/examples/fixing-an-uneven-recognition-program-before-it-damages-morale.md
@@ -1,0 +1,27 @@
+# Fixing an Uneven Recognition Program Before It Damages Morale
+
+## Context
+
+Six months after launching a peer-recognition platform, an HR analyst notices that 80% of recognition posts go to the same 15% of employees — mostly people in customer-facing roles who are naturally visible — while operations and back-office teams rarely appear. A few employees have quietly mentioned feeling invisible.
+
+## Step 1: Confirm and quantify the pattern
+
+Sample prompt: "Design a recognition equity audit to check whether recognition is concentrated on a few visible employees while others go unthanked."
+
+Expected response: An audit method comparing recognition-received counts against team, role, and visibility factors, confirming whether the skew is truly about role type (naturally more visible work) versus underlying bias, and identifying which teams have received close to zero recognition over the period.
+
+## Step 2: Equip managers to close the gap
+
+Sample prompt: "Write a guide for managers on giving specific, meaningful recognition instead of a generic 'great job' in team channels."
+
+Expected response: A guide specifically prompting managers of low-recognition teams to name concrete contributions from behind-the-scenes work — a resolved system issue, an accurate report delivered under deadline — since those employees' contributions are less naturally visible to the whole company than customer-facing work.
+
+## Step 3: Redesign the program to be more equitable
+
+Sample prompt: "Create a peer-to-peer recognition framework aligned to our company values that works for both in-office and remote employees" and "Develop a recognition program metrics framework tracking participation, frequency, and sentiment, not just number of shoutouts sent."
+
+Expected response: A redesigned framework adding a values category specific to operational excellence and reliability (not just visible customer wins), plus a metrics framework that tracks recognition distribution by team alongside total volume, so an uneven pattern gets caught early next time instead of six months in.
+
+## Workflow summary
+
+HR catches the recognition imbalance through a structured equity audit, coaches managers to name less-visible contributions specifically, and rebuilds the program's categories and metrics so distribution, not just volume, is tracked going forward.

--- a/skills/hr-recognition/prompts/employee-recognition-prompts.md
+++ b/skills/hr-recognition/prompts/employee-recognition-prompts.md
@@ -1,0 +1,7 @@
+# Employee recognition prompts
+
+- "Design a recognition equity audit to check whether recognition is concentrated on a few visible employees while others go unthanked."
+- "Write a guide for managers on giving specific, meaningful recognition instead of a generic 'great job' in team channels."
+- "Create a peer-to-peer recognition framework aligned to our company values that works for both in-office and remote employees."
+- "Develop a recognition program metrics framework tracking participation, frequency, and sentiment, not just number of shoutouts sent."
+- "Design a service anniversary program for 5, 10, and 15-year milestones that avoids feeling transactional or purely tenure-based."

--- a/skills/hr-wellbeing/prompts/employee-wellbeing-prompts.md
+++ b/skills/hr-wellbeing/prompts/employee-wellbeing-prompts.md
@@ -1,0 +1,7 @@
+# Employee wellbeing prompts
+
+- "Build a burnout risk assessment for a 150-person company using workload, overtime, and engagement signals, and rank teams by risk level."
+- "Design a manager early warning checklist identifying which behavioral signals indicate a team member may be approaching burnout."
+- "Draft a return-to-work plan for an employee returning after six weeks of burnout-related leave, with a 90-day check-in cadence."
+- "Write a manager guide for supporting a team member who disclosed a mental health concern, including what the manager should and shouldn't do."
+- "Help me model three wellbeing program options for addressing burnout risk in a high-pressure sales team and compare the trade-offs of each."


### PR DESCRIPTION
Add prompts/ and examples/ to hr-career-development, hr-employee-communications, hr-employee-journey-mapping, hr-employee-lifecycle, hr-employee-listening, hr-employee-self-service, hr-offboarding, and hr-recognition, upgrading them from Partial to Full. hr-wellbeing already had content/ and examples/ and only needed a prompts/ library added.

Regenerate docs/skill-matrix.md via bun run matrix (84 -> 93 Full skills).

Closes #105 