### PR TITLE
feat(workforce-planning): upgrade workforce analytics to full tier

### DIFF
--- a/docs/skill-matrix.md
+++ b/docs/skill-matrix.md
@@ -6,8 +6,8 @@
 
 | Tier | Count | % |
 |---|---:|---:|
-| 🟢 Full (SKILL.md + content + prompts + examples) | 93 | 64% |
-| 🟡 Partial (SKILL.md + some optional dirs) | 53 | 36% |
+| 🟢 Full (SKILL.md + content + prompts + examples) | 100 | 68% |
+| 🟡 Partial (SKILL.md + some optional dirs) | 46 | 32% |
 | 🔴 Bare (SKILL.md only) | 0 | 0% |
 | **Total** | **146** | 100% |
 
@@ -49,7 +49,7 @@
 | `hr-crisis-management` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
 | `hr-culture` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-data` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-demand-planning` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
+| `hr-demand-planning` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-design-thinking` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
 | `hr-devops` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-digital-hr` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
@@ -104,14 +104,14 @@
 | `hr-organizational-development` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
 | `hr-passive-candidate-engagement` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-payroll` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-people-budgeting` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-people-budgeting` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-people-leadership` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-people-operations` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-performance-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-performance-review` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-policy-management` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
 | `hr-post-merger-integration` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
-| `hr-predictive-analytics` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
+| `hr-predictive-analytics` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-product-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-project-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-prompt-engineering` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
@@ -124,12 +124,12 @@
 | `hr-retained-search` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-retirement-benefits` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-risk-management` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
-| `hr-salary-benchmarking` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-salary-benchmarking` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-search-strategy` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
 | `hr-security` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
 | `hr-service-delivery` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-shared-services` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-skills-intelligence` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
+| `hr-skills-intelligence` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-skills-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-skills-taxonomy` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
 | `hr-social-recruiting` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
@@ -154,8 +154,8 @@
 | `hr-vietnam-context` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-wellbeing` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-workforce-capability` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-workforce-economics` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
-| `hr-workforce-forecasting` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
+| `hr-workforce-economics` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
+| `hr-workforce-forecasting` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-workforce-intelligence` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-workforce-planning` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-workforce-scenario-planning` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |

--- a/skills/hr-demand-planning/examples/prioritizing-headcount-demand-when-recruiting-capacity-falls-short.md
+++ b/skills/hr-demand-planning/examples/prioritizing-headcount-demand-when-recruiting-capacity-falls-short.md
@@ -1,0 +1,27 @@
+# Prioritizing Headcount Demand When Recruiting Capacity Falls Short
+
+## Context
+
+A workforce planner has 40 approved open requisitions for the quarter, but the recruiting team's realistic capacity is 25 fills based on current recruiter headcount and average time-to-fill. Business leaders each believe their reqs are the priority, and the planner needs a defensible way to decide what gets filled first.
+
+## Step 1: Score the reqs objectively
+
+Sample prompt: "Build a role criticality scoring framework to decide which of our 40 open reqs to prioritize when TA can only fill 25 this quarter."
+
+Expected response: A scoring framework weighing revenue impact, compliance or safety criticality, how long the role has already sat open, and whether the role blocks other hires (for example, a manager role needed before their team can be filled) — producing a ranked list instead of a first-come-first-served approach.
+
+## Step 2: Validate the underlying demand signals
+
+Sample prompt: "Write the questions an HRBP should ask a VP who says they need '10 more engineers' with no further detail."
+
+Expected response: A short set of validating questions covering what specifically breaks if the hires don't happen this quarter, whether budget is confirmed or pending, and whether the need is net-new growth or backfill — surfacing that some of the ten are aspirational rather than committed.
+
+## Step 3: Communicate the prioritization decision
+
+Sample prompt: "Build a monthly demand vs. supply report for the CFO showing approved reqs, filled reqs, and where TA capacity is falling behind."
+
+Expected response: A report format showing the 40 reqs against the realistic 25-fill capacity, with the top 25 by criticality score highlighted as this quarter's committed plan and the remaining 15 flagged for next quarter, giving leadership a credible, criteria-based answer instead of an unexplained gap.
+
+## Workflow summary
+
+Rather than treating every req as equally urgent, the planner scores demand against objective criticality criteria, validates soft requests before they consume capacity, and reports the prioritization transparently so business leaders understand why their req landed where it did.

--- a/skills/hr-demand-planning/prompts/demand-planning-prompts.md
+++ b/skills/hr-demand-planning/prompts/demand-planning-prompts.md
@@ -1,0 +1,7 @@
+# Demand planning prompts
+
+- "Build a role criticality scoring framework to decide which of our 40 open reqs to prioritize when TA can only fill 25 this quarter."
+- "Draft a demand intake template for engineering that forces business leaders to separate confirmed budget from aspirational headcount."
+- "Model headcount demand for customer support scaling from 30 to 45 agents over two quarters, accounting for attrition and ramp time."
+- "Write the questions an HRBP should ask a VP who says they need '10 more engineers' with no further detail."
+- "Build a monthly demand vs. supply report for the CFO showing approved reqs, filled reqs, and where TA capacity is falling behind."

--- a/skills/hr-people-budgeting/examples/explaining-a-budget-overrun-to-finance-without-losing-credibility.md
+++ b/skills/hr-people-budgeting/examples/explaining-a-budget-overrun-to-finance-without-losing-credibility.md
@@ -1,0 +1,27 @@
+# Explaining a Budget Overrun to Finance Without Losing Credibility
+
+## Context
+
+The engineering cost center is tracking 8% over its people budget at the midpoint of the fiscal year. Finance has flagged it for review, and the HR business partner needs to explain the variance credibly before finance assumes the overage reflects poor planning.
+
+## Step 1: Identify the real driver before writing anything
+
+Sample prompt: "Reconcile actual people spend against budget for the year to date and explain the key drivers of variance" (used internally to separate cause from symptom before drafting the finance-facing narrative).
+
+Expected response: An analysis showing the overage isn't from headcount growing faster than planned, but from two senior backfills being hired at market rates above the budget's original salary assumptions set 10 months earlier — a data-driven root cause rather than a vague "hiring ran hot" explanation.
+
+## Step 2: Draft the variance narrative
+
+Sample prompt: "Draft a variance narrative for finance explaining why engineering is 8% over budget, in language finance will find credible."
+
+Expected response: A narrative stating the specific driver (two backfills hired above stale salary assumptions), the dollar impact, and that headcount itself is on plan — framed in finance's own terms (run-rate impact, one-time versus recurring) rather than HR jargon.
+
+## Step 3: Prevent recurrence
+
+Sample prompt: "What assumptions on merit increase percentage, attrition rate, and backfill delay should we align with finance before finalizing next year's budget?"
+
+Expected response: A recommendation to refresh salary assumptions quarterly against current market data rather than locking them for the full fiscal year, so budget-to-market misalignment surfaces earlier next cycle instead of accumulating into a midyear surprise.
+
+## Workflow summary
+
+The HRBP diagnoses the true driver of the overage before writing anything, explains it to finance in their own financial language with a clear dollar story, and proposes a concrete process fix so the same gap doesn't reappear next cycle.

--- a/skills/hr-people-budgeting/prompts/people-budgeting-prompts.md
+++ b/skills/hr-people-budgeting/prompts/people-budgeting-prompts.md
@@ -1,0 +1,7 @@
+# People budgeting prompts
+
+- "Draft a variance narrative for finance explaining why engineering is 8% over budget, in language finance will find credible."
+- "Model the budget impact of an immediate hiring freeze on the remaining two quarters of the fiscal year for customer support."
+- "Build a people budget for the marketing team for next fiscal year, separating approved headcount from planned-but-not-approved positions."
+- "What assumptions on merit increase percentage, attrition rate, and backfill delay should we align with finance before finalizing next year's budget?"
+- "Draft a one-page people budget summary a non-finance business leader can understand in under two minutes."

--- a/skills/hr-predictive-analytics/examples/rolling-out-an-attrition-risk-model-without-overstating-certainty.md
+++ b/skills/hr-predictive-analytics/examples/rolling-out-an-attrition-risk-model-without-overstating-certainty.md
@@ -1,0 +1,27 @@
+# Rolling Out an Attrition Risk Model Without Overstating Certainty
+
+## Context
+
+A people analytics team built a model that flags sales reps as high, medium, or low attrition risk based on tenure, engagement scores, and manager change history. Sales leadership wants the flags sent directly to frontline managers, but the analytics lead is concerned about managers treating scores as verdicts rather than signals.
+
+## Step 1: Check the model before rollout
+
+Sample prompt: "Assess this attrition model's feature importance output for potential bias before we let managers see individual risk scores" and "Compare this model's predictive accuracy against a simple tenure-based heuristic to decide whether the added complexity is worth it."
+
+Expected response: A bias check confirming the model isn't over-weighting a factor correlated with a protected characteristic (for example, recent parental leave inflating the "manager change" feature), plus a comparison showing the model modestly outperforms a simple tenure heuristic, justifying its use if deployed responsibly.
+
+## Step 2: Design responsible manager usage
+
+Sample prompt: "Design a process for how managers should use attrition risk flags as a conversation prompt, not an automated verdict."
+
+Expected response: A process where a "high risk" flag prompts the manager to have a genuine career or workload check-in within two weeks, explicitly framed as a prompt to investigate rather than a fact about the employee, with guidance not to mention the score or model to the employee directly.
+
+## Step 3: Make the output understandable
+
+Sample prompt: "Explain this model's top five predictors in plain language for an HRBP audience with no data science background."
+
+Expected response: A plain-language explanation translating feature importance into business terms — for example, "reps who haven't had a recent role change or recognition in the last two quarters show the strongest risk signal" — so HRBPs can coach managers without needing to understand the underlying statistics.
+
+## Workflow summary
+
+The team validates the model for bias and real predictive value before rollout, designs manager usage so flags prompt a conversation instead of a judgment, and translates the model's output into language HRBPs and managers can actually act on responsibly.

--- a/skills/hr-predictive-analytics/prompts/predictive-analytics-prompts.md
+++ b/skills/hr-predictive-analytics/prompts/predictive-analytics-prompts.md
@@ -1,0 +1,7 @@
+# Predictive people analytics prompts
+
+- "Frame 'which sales reps are likely to leave in the next 6 months' as a predictive modeling problem and list the data we'd need."
+- "Assess this attrition model's feature importance output for potential bias before we let managers see individual risk scores."
+- "Explain this model's top five predictors in plain language for an HRBP audience with no data science background."
+- "Design a process for how managers should use attrition risk flags as a conversation prompt, not an automated verdict."
+- "Compare this model's predictive accuracy against a simple tenure-based heuristic to decide whether the added complexity is worth it."

--- a/skills/hr-salary-benchmarking/examples/reconciling-a-benchmark-gap-with-an-internal-pay-equity-finding.md
+++ b/skills/hr-salary-benchmarking/examples/reconciling-a-benchmark-gap-with-an-internal-pay-equity-finding.md
@@ -1,0 +1,27 @@
+# Reconciling a Benchmark Gap With an Internal Pay Equity Finding
+
+## Context
+
+A compensation analyst benchmarks the "platform engineer" role and finds the team is paid 12% below the 60th market percentile, suggesting a raise is needed. But a separate internal pay equity review just found the same role is already internally consistent — every platform engineer is paid fairly relative to peers at the same level. Two data sources point to different conclusions.
+
+## Step 1: Verify the market comparison itself
+
+Sample prompt: "How should we accurately match our internal 'platform engineer' role to the closest external benchmark job code, given our scope differs from the market description?"
+
+Expected response: A review confirming whether the benchmark job code actually matches the internal role's real scope — finding that the external code assumes broader infrastructure ownership than the internal role currently has, meaning part of the apparent 12% gap reflects a scope mismatch, not a true pay gap.
+
+## Step 2: Reconcile the two findings
+
+Sample prompt: "Reconcile market benchmark data with internal pay equity findings for a role where the two suggest different pay actions."
+
+Expected response: A reconciliation explaining that internal equity confirms fairness relative to peers, while the market data (once scope-adjusted) shows a smaller but real gap against the external market — meaning the real risk isn't internal unfairness but external retention risk, which calls for a market adjustment rather than an equity-driven correction.
+
+## Step 3: Present a single clear recommendation
+
+Sample prompt: "Assess whether our current pay for senior product managers is competitive against the 65th percentile of market data" (adapted as the format for presenting the platform engineer recommendation) and "Draft a benchmarking methodology document explaining our data sources, job matching approach, and refresh cadence for compensation governance."
+
+Expected response: A recommendation to adjust platform engineer ranges by the scope-corrected market gap, paired with a documented methodology note explaining why the original job match overstated the gap, so future reviewers understand the reasoning rather than seeing two conflicting numbers with no explanation.
+
+## Workflow summary
+
+The analyst resolves the apparent conflict by first checking whether the market comparison itself was accurate, then reconciles the market and equity findings into one coherent story, and documents the methodology so the recommendation is defensible rather than confusing.

--- a/skills/hr-salary-benchmarking/prompts/salary-benchmarking-prompts.md
+++ b/skills/hr-salary-benchmarking/prompts/salary-benchmarking-prompts.md
@@ -1,0 +1,7 @@
+# Salary benchmarking prompts
+
+- "Assess whether our current pay for senior product managers is competitive against the 65th percentile of market data."
+- "How should we accurately match our internal 'platform engineer' role to the closest external benchmark job code, given our scope differs from the market description?"
+- "Build a salary range for a customer success manager in a secondary market using market data originally collected for our headquarters city."
+- "Draft a benchmarking methodology document explaining our data sources, job matching approach, and refresh cadence for compensation governance."
+- "Reconcile market benchmark data with internal pay equity findings for a role where the two suggest different pay actions."

--- a/skills/hr-skills-intelligence/examples/turning-a-skills-gap-finding-into-a-funded-reskilling-plan.md
+++ b/skills/hr-skills-intelligence/examples/turning-a-skills-gap-finding-into-a-funded-reskilling-plan.md
@@ -1,0 +1,27 @@
+# Turning a Skills Gap Finding Into a Funded Reskilling Plan
+
+## Context
+
+A workforce planner runs a skills intelligence analysis on the customer support organization and finds that automation is expected to reduce demand for tier-1 support roles over the next two years, while demand for technical support and QA roles is growing. Leadership needs a concrete plan, not just a warning.
+
+## Step 1: Confirm the risk is real before acting
+
+Sample prompt: "Which roles in our finance operations function carry the highest skill obsolescence risk over the next three years?" (adapted here to validate tier-1 support obsolescence risk) and "How should we validate self-reported skills data against actual project assignments before using it for a reskilling decision?"
+
+Expected response: A validation step cross-checking the obsolescence signal against external labor market trends and internal ticket-volume automation data, plus a check that agents' self-reported skills (many list "troubleshooting" broadly) are validated against actual ticket complexity handled, before assuming the whole team needs reskilling.
+
+## Step 2: Find realistic pathways
+
+Sample prompt: "Analyze skill adjacency for customer support agents to identify realistic reskilling pathways into technical support or QA roles."
+
+Expected response: An adjacency analysis showing which current tier-1 agents already handle technically complex tickets informally and are closest to a technical support transition, versus agents who would need a longer runway, giving the plan a realistic sequencing instead of treating the whole team as equally ready.
+
+## Step 3: Make the business case
+
+Sample prompt: "Draft an executive summary translating this skills gap analysis into three concrete L&D investment recommendations."
+
+Expected response: A summary recommending a funded technical support certification track for the readiest cohort first, a phased timeline tied to the automation rollout schedule, and a clear cost comparison against the alternative of external hiring for the growing technical support roles.
+
+## Workflow summary
+
+The planner validates the obsolescence signal against real data before alarming leadership, identifies which employees have a realistic adjacency path, and translates the finding into a funded, sequenced reskilling plan rather than a vague warning about future disruption.

--- a/skills/hr-skills-intelligence/prompts/skills-intelligence-prompts.md
+++ b/skills/hr-skills-intelligence/prompts/skills-intelligence-prompts.md
@@ -1,0 +1,7 @@
+# Skills intelligence prompts
+
+- "Identify emerging skills in cloud infrastructure that our current platform team likely lacks, based on recent job posting trends."
+- "Analyze skill adjacency for customer support agents to identify realistic reskilling pathways into technical support or QA roles."
+- "How should we validate self-reported skills data against actual project assignments before using it for a reskilling decision?"
+- "Which roles in our finance operations function carry the highest skill obsolescence risk over the next three years?"
+- "Draft an executive summary translating this skills gap analysis into three concrete L&D investment recommendations."

--- a/skills/hr-workforce-economics/examples/building-a-headcount-business-case-the-cfo-will-actually-approve.md
+++ b/skills/hr-workforce-economics/examples/building-a-headcount-business-case-the-cfo-will-actually-approve.md
@@ -1,0 +1,27 @@
+# Building a Headcount Business Case the CFO Will Actually Approve
+
+## Context
+
+A support team lead wants to request three additional headcount to address rising ticket backlog, but a similar request last year was rejected for lacking financial rigor. This time, the HRBP wants to build a business case the CFO will take seriously.
+
+## Step 1: Get the real cost right
+
+Sample prompt: "Calculate fully loaded labor cost for a mid-level data analyst in our two largest hiring markets, including base, benefits, taxes, and overhead" (adapted to support agents) and "Compare the total cost of hiring a full-time DevOps engineer versus contracting the same work over 12 months" (used to check whether contracting is a cheaper near-term alternative).
+
+Expected response: A fully loaded cost figure for three support agents that's meaningfully higher than the base salary the team lead was mentally budgeting, plus a comparison showing contracting could bridge the immediate backlog at lower short-term cost while permanent hiring is evaluated.
+
+## Step 2: Build the case in financial terms
+
+Sample prompt: "Build a financial business case for adding three headcount to the support team, including cost, expected output, and payback period."
+
+Expected response: A business case quantifying the current cost of the backlog (lost renewal revenue from slow response times, overtime pay for existing agents), the fully loaded cost of three new hires, and a payback period showing when the investment breaks even against the backlog's ongoing cost.
+
+## Step 3: Frame it the way the CFO thinks
+
+Sample prompt: "What financial framing will resonate most with our CFO when requesting headcount for a newly formed data team with no existing track record?" (adapted to this support team's context, drawing on the same principle of financial credibility).
+
+Expected response: Guidance to lead with payback period and cost-to-revenue-protected ratio rather than headcount count alone, and to explicitly state the assumptions used (ramp time, ticket volume growth rate) so the CFO can stress-test the numbers rather than having to take them on faith.
+
+## Workflow summary
+
+The HRBP replaces last year's unsupported headcount ask with a fully loaded cost calculation, a quantified cost of inaction, and a payback-period business case framed in the CFO's own financial language.

--- a/skills/hr-workforce-economics/prompts/workforce-economics-prompts.md
+++ b/skills/hr-workforce-economics/prompts/workforce-economics-prompts.md
@@ -1,0 +1,7 @@
+# Workforce economics prompts
+
+- "Calculate fully loaded labor cost for a mid-level data analyst in our two largest hiring markets, including base, benefits, taxes, and overhead."
+- "Compare the total cost of hiring a full-time DevOps engineer versus contracting the same work over 12 months."
+- "Build a financial business case for adding three headcount to the support team, including cost, expected output, and payback period."
+- "Model the financial impact of our current 22% turnover rate on the sales team, including replacement and productivity-loss costs."
+- "What financial framing will resonate most with our CFO when requesting headcount for a newly formed data team with no existing track record?"

--- a/skills/hr-workforce-forecasting/examples/reconciling-a-top-down-target-with-a-bottom-up-hiring-forecast.md
+++ b/skills/hr-workforce-forecasting/examples/reconciling-a-top-down-target-with-a-bottom-up-hiring-forecast.md
@@ -1,0 +1,27 @@
+# Reconciling a Top-Down Target With a Bottom-Up Hiring Forecast
+
+## Context
+
+Finance has set a year-end headcount target of 220 for engineering based on the overall revenue plan. The engineering leadership's own bottom-up forecast, based on team-level hiring plans, comes out to 245. The workforce planner needs to reconcile the two before either number goes into the annual plan.
+
+## Step 1: Surface where the gap comes from
+
+Sample prompt: "Reconcile a top-down headcount target from finance with a bottom-up hiring forecast from engineering leadership, and explain where they diverge."
+
+Expected response: A reconciliation showing the 25-person gap concentrates in two new teams engineering leadership wants to stand up that weren't reflected in finance's revenue-driven model, isolating the disagreement to a specific, discussable set of roles rather than an unexplained 25-person gap.
+
+## Step 2: Validate the bottom-up forecast's assumptions
+
+Sample prompt: "Backtest our last fiscal year's hiring forecast against actual outcomes and identify where the accuracy broke down."
+
+Expected response: A backtest showing engineering's bottom-up forecasts have historically overshot actual hires by around 15% due to optimistic timing assumptions, providing objective grounds to discount the 245 figure somewhat rather than accepting it at face value.
+
+## Step 3: Present a defensible reconciled number
+
+Sample prompt: "How should we present forecast uncertainty to the executive team instead of a single misleadingly precise headcount number?"
+
+Expected response: A recommendation to present a range (220–235) with the two new teams flagged as contingent on a separate budget approval, rather than forcing a single false-precision number that either side would view as capitulating.
+
+## Workflow summary
+
+The planner resolves the standoff by isolating exactly where the two forecasts diverge, using historical backtest data to calibrate how much to trust the more aggressive number, and presenting a transparent range instead of an artificially precise single figure.

--- a/skills/hr-workforce-forecasting/prompts/workforce-forecasting-prompts.md
+++ b/skills/hr-workforce-forecasting/prompts/workforce-forecasting-prompts.md
@@ -1,0 +1,7 @@
+# Workforce forecasting prompts
+
+- "Build a headcount forecast for the sales team over the next four quarters based on historical growth and the new territory expansion plan."
+- "Backtest our last fiscal year's hiring forecast against actual outcomes and identify where the accuracy broke down."
+- "Reconcile a top-down headcount target from finance with a bottom-up hiring forecast from engineering leadership, and explain where they diverge."
+- "Forecast seasonal staffing needs for the warehouse team based on the past three years of hiring and departure patterns."
+- "How should we present forecast uncertainty to the executive team instead of a single misleadingly precise headcount number?"


### PR DESCRIPTION
Add prompts/ and examples/ to hr-demand-planning,
hr-predictive-analytics, hr-people-budgeting, hr-salary-benchmarking, hr-skills-intelligence, hr-workforce-economics, and hr-workforce-forecasting, upgrading them from Partial to Full. hr-talent-intelligence and hr-workforce-intelligence were already Full and required no changes.

Regenerate docs/skill-matrix.md via bun run matrix (93 -> 100 Full skills).

Closes #106 