### PR TITLE
feat(skills): complete remaining partial skills to full tier

### DIFF
--- a/.changeset/complete-remaining-partial-skills.md
+++ b/.changeset/complete-remaining-partial-skills.md
@@ -1,0 +1,5 @@
+---
+"hr-skills": minor
+---
+
+Completed the remaining ten Partial skills to Full tier (`hr-change-communication`, `hr-employer-branding`, `hr-retirement-benefits`, `hr-search-strategy`, `hr-security`, `hr-skills-taxonomy`, `hr-succession-planning`, `hr-talent-supply-chain`, `hr-total-rewards`, and `hr-uiux`) by adding the missing `prompts/` and `examples/` subdirectories. New prompt libraries and operational workflow examples match the structure, tone, and quality of existing Full skills, with `content/` files cross-linked to their new examples. Regenerated the Skill Matrix (146 full, 0 partial, 0 bare) — the repository now has zero remaining Partial or Bare skills.

--- a/docs/skill-matrix.md
+++ b/docs/skill-matrix.md
@@ -6,8 +6,8 @@
 
 | Tier | Count | % |
 |---|---:|---:|
-| 🟢 Full (SKILL.md + content + prompts + examples) | 136 | 93% |
-| 🟡 Partial (SKILL.md + some optional dirs) | 10 | 7% |
+| 🟢 Full (SKILL.md + content + prompts + examples) | 146 | 100% |
+| 🟡 Partial (SKILL.md + some optional dirs) | 0 | 0% |
 | 🔴 Bare (SKILL.md only) | 0 | 0% |
 | **Total** | **146** | 100% |
 
@@ -35,7 +35,7 @@
 | `hr-candidate-experience` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-candidate-sourcing` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-career-development` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-change-communication` | 🟡 Partial | ✅ | — | — | 2 | 1.0.0 |
+| `hr-change-communication` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-change-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-chatbot-design` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-cloud` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
@@ -63,7 +63,7 @@
 | `hr-employee-listening` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-employee-relations` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-employee-self-service` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-employer-branding` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
+| `hr-employer-branding` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-executive-assessment` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-executive-search` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-frontend` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
@@ -122,21 +122,21 @@
 | `hr-recruitment-operations` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-reference-checking` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-retained-search` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-retirement-benefits` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-retirement-benefits` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-risk-management` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-salary-benchmarking` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-search-strategy` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
-| `hr-security` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
+| `hr-search-strategy` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
+| `hr-security` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-service-delivery` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-shared-services` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-skills-intelligence` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-skills-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-skills-taxonomy` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
+| `hr-skills-taxonomy` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-social-recruiting` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-software-architecture` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-strategic-planning` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-strategic-workforce-planning` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-succession-planning` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
+| `hr-succession-planning` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-system-design` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-system-integration` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-talent-acquisition` | 🟢 Full | ✅ | ✅ | ✅ | 3 | 1.0.0 |
@@ -144,12 +144,12 @@
 | `hr-talent-intelligence` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
 | `hr-talent-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-talent-mapping` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.0 |
-| `hr-talent-supply-chain` | 🟡 Partial | ✅ | — | — | 1 | 1.0.0 |
+| `hr-talent-supply-chain` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-technology` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-time-attendance` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-total-rewards` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
+| `hr-total-rewards` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-training-development` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
-| `hr-uiux` | 🟡 Partial | ✅ | — | ✅ | 1 | 1.0.0 |
+| `hr-uiux` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-vendor-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-vietnam-context` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |
 | `hr-wellbeing` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.0 |

--- a/skills/hr-change-communication/content/change-communication-guide.md
+++ b/skills/hr-change-communication/content/change-communication-guide.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+> Related example: [Communicating a Restructuring Across a Multi-Site Organization](../examples/communicating-a-restructuring-across-a-multi-site-organization.md).
+
 Change communication is how organizations help employees understand, accept, and adapt to significant changes — restructurings, strategy shifts, leadership transitions, M&A events, technology transformations, and policy changes. It is one of the highest-leverage activities in change management and one of the most consistently underfunded.
 
 Most change communication fails not because the message is wrong, but because it is too late, too infrequent, too abstract, or too one-directional. Employees fill communication gaps with rumor. The organization that communicates proactively, honestly, and frequently controls more of the narrative than the one that communicates only when legally required.

--- a/skills/hr-change-communication/examples/communicating-a-restructuring-across-a-multi-site-organization.md
+++ b/skills/hr-change-communication/examples/communicating-a-restructuring-across-a-multi-site-organization.md
@@ -1,0 +1,109 @@
+# Communicating a Restructuring Across a Multi-Site Organization
+
+## Context
+
+You are the HR communications lead for a 1,200-employee company with offices in three countries. Leadership has approved a restructuring that will consolidate two business units, eliminate roughly 40 roles, and change reporting lines for another 150 employees. The announcement is scheduled in two weeks, and legal has not yet finalized the affected-employee list. Leadership wants a communication plan that is honest without creating panic before decisions are final.
+
+## Step 1 — Sequencing What Can Be Said Now
+
+**Sample prompt:**
+
+> "We can't share who's affected yet, but rumors are already starting. What should we communicate now?"
+
+**Expected skill response:**
+
+Communicate the fact of the change before the details, so employees hear it from leadership first:
+
+- Confirm that a restructuring is under review and will affect team structures
+- Explain the business reason in plain terms (market conditions, strategy shift, integration)
+- Commit to a specific date when more detail will be shared
+- Acknowledge directly that this creates uncertainty, rather than minimizing it
+
+> **Avoid:** Do not promise "no layoffs" or "no changes to your role" unless leadership is certain — a broken promise here does lasting damage to trust, far beyond this one change.
+
+## Step 2 — Segmenting the Audience
+
+**Sample prompt:**
+
+> "Help me figure out who needs to hear what, and in what order."
+
+**Skill walkthrough — audience sequence:**
+
+| Audience | What they need | When |
+|---|---|---|
+| Directly impacted (role eliminated) | 1:1 notification, severance details, support resources | Before the broader announcement |
+| Managers of impacted teams | Talking points, timeline, how to support their team | Same day, before their teams hear |
+| Employees with new reporting lines | Clear explanation of the change and who to contact | Announcement day |
+| Unaffected employees | Confirmation of no personal impact and business rationale | Announcement day |
+
+> **Recommendation framing:** Impacted employees always hear first, in person or by video call, never by mass email. Managers need enough lead time to process the news themselves before supporting their teams.
+
+## Step 3 — Drafting the Leadership Announcement
+
+**Sample prompt:**
+
+> "Draft the all-hands announcement message for the day of the restructuring."
+
+**Skill response — structure:**
+
+1. **What is changing** — state the restructuring plainly, no euphemisms like "right-sizing"
+2. **Why now** — the specific business driver, not generic language
+3. **What is not changing** — anchor employees with what remains stable
+4. **What happens next** — timeline for individual conversations and org chart updates
+5. **Where to go with questions** — a named channel, not just "reach out to HR"
+
+> **What to avoid:** Long justifications that read as defensive. State the reason once, clearly, and move to what employees need to know next.
+
+## Step 4 — Preparing Managers for Difficult Questions
+
+**Sample prompt:**
+
+> "Managers are going to get hard questions right after the announcement. Give me a prep guide."
+
+**Skill response — manager Q&A prep:**
+
+- "Will there be more changes?" → Answer honestly with what is known; do not speculate beyond confirmed decisions
+- "Why wasn't I told sooner?" → Acknowledge the timing constraint (legal, confidentiality) without being defensive
+- "Is my job safe?" → Confirm directly if the manager knows the answer; if uncertain, commit to following up by a specific date
+
+> **Manager coaching note:** Managers should not improvise answers to questions outside their knowledge. "I don't know, but I'll find out by [date]" preserves trust better than a guess.
+
+## Step 5 — Designing the Follow-Up Cadence
+
+**Sample prompt:**
+
+> "How do we keep communicating after the initial announcement so this doesn't go quiet?"
+
+**Skill response — cadence plan:**
+
+- **Week 1:** Confirm individual conversations are complete; publish updated org chart
+- **Week 2-4:** Short leadership update on integration progress, even if the update is "on track, no new changes"
+- **Day 60-90:** Retrospective communication acknowledging what worked and what the organization is still adjusting to
+
+> Silence after the initial announcement is read as either bad news being withheld or leadership losing interest — neither builds trust.
+
+## Full Change Communication Workflow Summary
+
+```text
+Confirm the change is real and communicate the fact before the detail
+                    ↓
+Segment audiences and sequence who hears what, and when
+                    ↓
+Draft the leadership announcement: what, why, what stays, what's next
+                    ↓
+Prepare managers with honest, scoped answers to hard questions
+                    ↓
+Notify impacted employees individually, before the broad announcement
+                    ↓
+Sustain a follow-up cadence through the 30-60-90 day window
+```
+
+### Common Change Communication Mistakes
+
+| Mistake | How to avoid it |
+|---|---|
+| Waiting until every detail is final to say anything | Communicate the fact of the change early, details as confirmed |
+| Sending impacted employees the same email as everyone else | Notify them individually and first |
+| Promising outcomes leadership can't guarantee | State only what is certain; commit to a follow-up date for the rest |
+| Letting managers improvise answers | Give managers scoped, honest talking points in advance |
+| Going silent after the announcement | Maintain a visible cadence through at least day 90 |

--- a/skills/hr-change-communication/prompts/change-communication-prompts.md
+++ b/skills/hr-change-communication/prompts/change-communication-prompts.md
@@ -1,0 +1,10 @@
+# Change communication prompts
+
+Use these prompts when planning, drafting, and sequencing communication for HR-led organizational changes.
+
+- "Draft a change communication plan for announcing a restructuring affecting [number] employees across [departments], including audience segmentation and channel sequencing."
+- "Write a leadership announcement email for a reduction in force, balancing transparency with legal and empathy considerations."
+- "Create a manager talking points guide to help frontline managers answer employee questions after a reorg is announced."
+- "Draft an FAQ document addressing likely employee concerns about a new hybrid work policy rollout."
+- "Write a town hall script and anticipated Q&A for leadership to use when announcing a new HR system implementation."
+- "Draft a communication cadence plan spanning pre-announcement, launch day, and 30-60-90 day follow-up messaging for a merger integration."

--- a/skills/hr-employer-branding/prompts/employer-branding-prompts.md
+++ b/skills/hr-employer-branding/prompts/employer-branding-prompts.md
@@ -1,0 +1,10 @@
+# Employer branding prompts
+
+Use these prompts when designing, auditing, and communicating an employer brand and EVP.
+
+- "Draft an Employee Value Proposition (EVP) framework for [company type] competing for [talent segment], grounded in what current employees actually say about working there."
+- "Design an employer brand audit plan covering Glassdoor, LinkedIn, and social listening signals, with a scoring rubric for reputation health."
+- "Write careers page content that translates our EVP into role-specific messaging for [function, for example engineering or sales] candidates."
+- "Draft a response plan for a negative Glassdoor review trend, including internal remediation steps and external response guidelines."
+- "Create an employee advocacy content calendar to support a referral and recruitment marketing campaign for [role or team]."
+- "Design a candidate experience journey map identifying where our employer brand promise breaks down between application and offer stages."

--- a/skills/hr-retirement-benefits/content/retirement-benefits-strategy.md
+++ b/skills/hr-retirement-benefits/content/retirement-benefits-strategy.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+> Related example: [Redesigning the 401(k) Plan and Communicating a Provider Change](../examples/redesigning-the-401k-plan-and-communicating-a-provider-change.md).
+
 Retirement benefits are the most significant long-term financial obligation an organization takes on. They affect employee retention, recruitment competitiveness, organizational liability, and financial statements. Designing and managing retirement benefits is highly technical, regulated, and consequential.
 
 A retirement plan is not just "we put money in a savings account for you." It is a complex system involving tax treatment, vesting schedules, investment options, required disclosures, fiduciary duties, and actuarial assumptions.

--- a/skills/hr-retirement-benefits/examples/redesigning-the-401k-plan-and-communicating-a-provider-change.md
+++ b/skills/hr-retirement-benefits/examples/redesigning-the-401k-plan-and-communicating-a-provider-change.md
@@ -1,0 +1,118 @@
+# Redesigning the 401(k) Plan and Communicating a Provider Change
+
+## Context
+
+You are the benefits manager at a 300-employee company that has offered a 401(k) with a mediocre match and a provider with limited fund options and no in-house advisory support. Leadership has approved a budget increase for a better match, and finance wants to switch providers to reduce administrative fees. You need to design the new plan and communicate the transition without triggering confusion or a wave of employee opt-outs.
+
+## Step 1 — Framing the Plan Design Decision
+
+**Sample prompt:**
+
+> "We have budget for a better match. What are our options and how do I compare them?"
+
+**Expected skill response:**
+
+Frame the decision around three levers, not just the match percentage:
+
+**Match structure:**
+
+- Flat match (for example, 100% up to 4% of pay) — simple to communicate, predictable cost
+- Tiered match (for example, 100% on the first 3%, 50% on the next 2%) — encourages higher contribution, slightly more complex to explain
+
+**Vesting schedule:**
+
+- Immediate vesting — most attractive to employees, higher cost if turnover is high
+- Graded vesting (for example, 20% per year over 5 years) — balances retention incentive with cost control
+
+**Auto-enrollment and auto-escalation:**
+
+- Auto-enrollment at a default rate significantly increases participation over opt-in designs
+- Auto-escalation (annual automatic increase, capped) improves long-term retirement readiness without requiring employees to act
+
+> **Recommendation framing:** For a company prioritizing participation and simplicity, a flat match with auto-enrollment at 4% and a 1% annual auto-escalation up to 8% is easy to explain and measurably improves outcomes over an opt-in-only design.
+
+## Step 2 — Comparing Providers
+
+**Sample prompt:**
+
+> "Help me build a comparison to evaluate our current provider against two others finance is considering."
+
+**Skill response — comparison matrix:**
+
+| Criterion | Current provider | Provider B | Provider C |
+|---|---|---|---|
+| Administrative fee (per participant) | High | Lower | Lowest |
+| Fund lineup breadth | Limited | Broad | Broad |
+| Target-date fund quality | Below average | Strong | Strong |
+| Employee self-service tools | Basic | Modern | Modern |
+| 1:1 advisory access | None | Included | Add-on cost |
+
+> **What to bring to finance:** Fee reduction alone should not drive the decision — weigh it against fund quality and employee-facing tools, since a cheaper plan with poor investment options creates worse retirement outcomes and more employee complaints later.
+
+## Step 3 — Sequencing the Transition Communication
+
+**Sample prompt:**
+
+> "We're switching providers in 90 days. Draft the communication plan."
+
+**Skill response — phased plan:**
+
+| Phase | Timing | Message |
+|---|---|---|
+| Advance notice | 90 days before | Change is coming, why, and what stays the same (contribution rates carry over) |
+| Blackout period notice | 30 days before | Dates when accounts are temporarily locked during the transfer, required by law |
+| Action-needed reminder | 14 days before | Any elections that do not automatically transfer (for example, beneficiary designations) |
+| Go-live confirmation | Day of transition | New portal access, new advisory contact, confirmation that balances transferred correctly |
+
+> **Avoid:** Do not bury the blackout period notice in a general email — it has legal disclosure requirements and employees need enough lead time to make any trades before their accounts lock.
+
+## Step 4 — Writing the Employee-Facing Explainer
+
+**Sample prompt:**
+
+> "Employees are going to ask 'do I need to do anything?' Draft a plain-language explainer."
+
+**Skill response — explainer structure:**
+
+1. **What's changing** — new provider, new portal, and (if applicable) new match structure
+2. **What's not changing** — your current contribution rate and vested balance carry over automatically
+3. **What you might need to do** — re-confirm beneficiary designations, since these sometimes don't transfer automatically
+4. **Where to get help** — a specific contact or scheduled info session, not just a generic HR inbox
+
+> Employees at different career stages need different framing: someone early in their career cares most about the match and auto-escalation; someone nearing retirement cares most about fund stability and advisory access during the transition.
+
+## Step 5 — Running the Enrollment and Education Campaign
+
+**Sample prompt:**
+
+> "How do we get participation up now that the match is better?"
+
+**Skill response — campaign design:**
+
+- Host short info sessions timed around the go-live date, recorded for employees who can't attend live
+- Send a simple decision guide: "if you're not sure what to pick, here's a reasonable default" for employees who find fund selection overwhelming
+- Highlight the new match in payroll communication so the improved benefit is visible, not buried in a policy document
+
+## Full Retirement Benefits Workflow Summary
+
+```text
+Frame the plan design decision: match structure, vesting, auto-enrollment
+                    ↓
+Compare providers on fees, fund quality, and employee tools — not fees alone
+                    ↓
+Sequence transition communication with legally required blackout notice
+                    ↓
+Write a plain-language explainer segmented by career stage
+                    ↓
+Run an enrollment and education campaign to convert improved benefits into participation
+```
+
+### Common Retirement Benefits Mistakes
+
+| Mistake | How to avoid it |
+|---|---|
+| Choosing a provider on fees alone | Weigh fund quality and employee tools alongside cost |
+| Burying the blackout period notice | Give it a dedicated, clearly timed communication |
+| Using one message for all employees | Segment by career stage and likely concerns |
+| Assuming auto-enrollment alone is enough | Pair with auto-escalation and a simple default guide |
+| Treating enrollment as a one-time event | Reinforce with ongoing education, not a single announcement |

--- a/skills/hr-retirement-benefits/prompts/retirement-benefits-prompts.md
+++ b/skills/hr-retirement-benefits/prompts/retirement-benefits-prompts.md
@@ -1,0 +1,10 @@
+# Retirement and pension benefits prompts
+
+Use these prompts when designing, comparing, and communicating retirement and pension benefit programs.
+
+- "Compare defined contribution, defined benefit, and hybrid retirement plan structures for a [company size] company, including cost and administrative trade-offs."
+- "Draft an employer matching and vesting schedule policy proposal for a 401(k) plan, benchmarked against [industry] norms."
+- "Write an employee-facing explainer comparing our retirement plan options for someone early in their career versus someone nearing retirement."
+- "Draft a communication plan for a retirement plan provider change, including timeline, required employee actions, and FAQ."
+- "Create a retirement plan enrollment campaign for new hires, including a simple decision guide for contribution rate selection."
+- "Draft a provider comparison matrix evaluating fee structures, investment options, and support quality across [providers under consideration]."

--- a/skills/hr-search-strategy/content/designing-a-search-strategy-before-sourcing-begins.md
+++ b/skills/hr-search-strategy/content/designing-a-search-strategy-before-sourcing-begins.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+> Related example: [Building a Search Strategy for a Hard-to-Fill Engineering Leadership Role](../examples/building-a-search-strategy-for-a-hard-to-fill-engineering-leadership-role.md).
+
 Sourcing that starts before the search is strategically planned tends to produce a scattered, inconsistent candidate pool and a much longer time-to-fill than a search that invests upfront in defining target companies, channels, and positioning. The search brief is the artifact that forces this planning to happen deliberately, rather than being figured out reactively as sourcing proceeds.
 
 ## Building the Search Brief

--- a/skills/hr-search-strategy/examples/building-a-search-strategy-for-a-hard-to-fill-engineering-leadership-role.md
+++ b/skills/hr-search-strategy/examples/building-a-search-strategy-for-a-hard-to-fill-engineering-leadership-role.md
@@ -1,0 +1,120 @@
+# Building a Search Strategy for a Hard-to-Fill Engineering Leadership Role
+
+## Context
+
+You are a senior recruiter assigned a search for a VP of Engineering at a Series C startup. The hiring manager gave you a 20-minute intake call with a vague brief: "someone who's scaled engineering before, technical enough to be credible, and can build a leadership bench." No sourcing has started. You need a search strategy before spending time on outreach.
+
+## Step 1 — Translating the Brief Into a Structured Search
+
+**Sample prompt:**
+
+> "The hiring manager brief is vague. Help me turn this into something I can actually search against."
+
+**Expected skill response:**
+
+Break the vague brief into concrete, searchable criteria before sourcing:
+
+**Must-haves (non-negotiable):**
+
+- Has scaled an engineering org from roughly [X] to [Y] engineers
+- Has built or rebuilt a leadership layer (director/manager hires), not just individual contributors
+- Comes from a company at a similar or slightly later stage than ours
+
+**Strong signals (not disqualifying if absent):**
+
+- Prior experience in [our industry or a technically adjacent one]
+- A visible technical background (open source, conference talks, engineering blog)
+
+**Disqualifiers:**
+
+- No people-management experience beyond a single team lead role
+- No experience operating without established process (if coming from a large, mature org only)
+
+> **Avoid:** Do not start sourcing on "VP of Engineering" as a title alone — title inflation varies enormously by company size, and this will surface a mix of genuinely qualified and severely underqualified candidates.
+
+## Step 2 — Defining Target Companies
+
+**Sample prompt:**
+
+> "Where should I be looking for this person?"
+
+**Skill response — target company logic:**
+
+- Companies 1-2 growth stages ahead of ours, where the target already scaled through the transition we're facing
+- Companies of a similar size that are now struggling or have had a recent leadership change (a signal of open-to-move talent)
+- Adjacent industries with similar technical complexity, if our industry alone is too narrow a pool
+
+> **Recommendation framing:** Present the hiring manager with a target list of 15-20 companies and ask them to flag any "we'd never hire from there" companies before sourcing starts — this avoids wasted effort later.
+
+## Step 3 — Selecting the Channel Mix
+
+**Sample prompt:**
+
+> "Help me decide where to spend sourcing effort — direct outreach, referrals, or an agency."
+
+**Skill response — channel comparison:**
+
+| Channel | Expected yield for this role | Notes |
+|---|---|---|
+| Direct sourcing (LinkedIn, target companies) | High, but slow | Best for precision on must-haves |
+| Employee referrals | High quality, low volume | Ask engineering leadership to tap their network directly |
+| Executive search / retained agency | Faster reach, added cost | Consider if internal search stalls after 4-6 weeks |
+| Inbound / job ads | Low fit for this level | Not a primary channel for VP-level search |
+
+> Given the urgency and narrow criteria, direct sourcing plus a referral push from the CTO's network should run in parallel for the first month before escalating to a retained search.
+
+## Step 4 — Setting the Search Timeline
+
+**Sample prompt:**
+
+> "What's a realistic timeline, and how do I set expectations with the hiring manager?"
+
+**Skill response — timeline with milestones:**
+
+```text
+Week 1-2:   Finalize search brief and target company list, begin direct sourcing
+Week 3-4:   First candidate slate presented (3-5 candidates)
+Week 5-6:   First-round conversations, calibrate brief based on market feedback
+Week 7-10:  Onsite/panel interviews for finalists
+Week 11-12: Offer and close
+```
+
+> **What to bring to the hiring manager:** If no viable slate exists by week 4, that is a signal to revisit the brief's must-haves, not to keep sourcing against the same criteria.
+
+## Step 5 — Defining Success Criteria
+
+**Sample prompt:**
+
+> "How do we know this search actually succeeded, beyond just filling the role?"
+
+**Skill response — success criteria:**
+
+- A hire who is still in the role and performing at 12 months, not just an accepted offer
+- A slate that gave the hiring manager real choice (at least 2-3 comparably strong finalists)
+- A process that didn't lose strong candidates to slow decision-making internally
+
+## Full Search Strategy Workflow Summary
+
+```text
+Translate vague brief into must-haves, strong signals, and disqualifiers
+                    ↓
+Define target companies and validate the list with the hiring manager
+                    ↓
+Select and sequence the channel mix
+                    ↓
+Set a realistic timeline with checkpoint milestones
+                    ↓
+Define success criteria before sourcing begins
+                    ↓
+Begin sourcing against a defensible, agreed strategy
+```
+
+### Common Search Strategy Mistakes
+
+| Mistake | How to avoid it |
+|---|---|
+| Sourcing on job title alone | Break the brief into must-haves, signals, and disqualifiers |
+| Skipping target company validation | Confirm the list with the hiring manager before outreach |
+| Using one channel for a hard search | Run direct sourcing and referrals in parallel from day one |
+| No checkpoint to revisit a stalled search | Set a explicit week-4 review trigger |
+| Defining success as "offer accepted" | Track retention and slate quality, not just placement |

--- a/skills/hr-search-strategy/prompts/search-strategy-prompts.md
+++ b/skills/hr-search-strategy/prompts/search-strategy-prompts.md
@@ -1,0 +1,10 @@
+# Search strategy prompts
+
+Use these prompts when translating a hiring manager brief into a structured search plan before sourcing begins.
+
+- "Translate this hiring manager brief for [role] into a structured search strategy with target companies, functions, and candidate profile."
+- "Recommend a channel mix — direct sourcing, referrals, agencies, or ads — for a search for [role] in [market], with rationale for each channel's expected yield."
+- "Draft a search timeline with milestones for filling [role] within [timeframe], flagging where the timeline is at risk."
+- "Define success criteria for this search assignment so both the recruiter and hiring manager agree on what 'done' looks like before sourcing starts."
+- "Help me decide between a contingent, retained, or internal-led search approach for [role], weighing cost, urgency, and market difficulty."
+- "Draft a target company list and positioning angle for approaching passive candidates for [role], based on our competitive strengths."

--- a/skills/hr-security/prompts/security-hiring-prompts.md
+++ b/skills/hr-security/prompts/security-hiring-prompts.md
@@ -1,0 +1,10 @@
+# Security hiring prompts
+
+Use these prompts when screening, interviewing, and evaluating cybersecurity and security engineering candidates.
+
+- "Draft first-round screening questions to evaluate a candidate's hands-on experience with [AppSec, Cloud Security, or SOC operations] for a [level] role."
+- "Create an interview scorecard rubric for evaluating threat modeling, incident response, and vulnerability triage skills."
+- "Write a practical take-home assignment brief asking a candidate to review a sample application or infrastructure config for security flaws."
+- "Draft a comparison guide explaining the differences between AppSec, Cloud Security, SOC, Red Team, and GRC roles for a non-technical recruiter."
+- "Create behavioral interview questions probing how a security engineer handled a real incident, including containment and post-incident reporting."
+- "Draft a job description for a Senior Cloud Security Engineer emphasizing threat detection, identity and access management, and compliance alignment."

--- a/skills/hr-skills-taxonomy/prompts/skills-taxonomy-prompts.md
+++ b/skills/hr-skills-taxonomy/prompts/skills-taxonomy-prompts.md
@@ -1,0 +1,10 @@
+# Skills taxonomy prompts
+
+Use these prompts when designing, building, and applying a skills taxonomy across an organization.
+
+- "Design a skills taxonomy hierarchy for [function, for example engineering or sales] aligned to our existing job architecture."
+- "Build a skills inventory template that maps job descriptions and employee profiles to a standardized skills list."
+- "Run a skills gap analysis for [team or role] comparing current skills coverage against the skills the role requires."
+- "Design skills clusters that connect our taxonomy to career pathing and internal mobility for [function]."
+- "Draft a proposal for benchmarking our workforce skills taxonomy against external market skills data for [industry]."
+- "Connect our skills taxonomy to L&D program design by identifying which skill gaps should be prioritized for training investment."

--- a/skills/hr-succession-planning/prompts/succession-planning-prompts.md
+++ b/skills/hr-succession-planning/prompts/succession-planning-prompts.md
@@ -1,0 +1,10 @@
+# Succession planning prompts
+
+Use these prompts when mapping critical roles, running talent reviews, and building leadership pipelines.
+
+- "Identify critical roles across [department or organization] and flag which ones currently have no viable internal successor."
+- "Design a 9-box calibration session agenda for a leadership team reviewing [number] senior leaders, including how to structure the discussion to reduce bias."
+- "Draft criteria for identifying high-potential employees for a succession pipeline in [function], beyond current performance ratings."
+- "Build an individual development plan template for a successor candidate targeting [role] within [timeframe]."
+- "Design a leadership pipeline program that connects succession planning to our existing leadership development curriculum."
+- "Draft a talent review readout for the executive team summarizing bench strength, coverage gaps, and flight risk for critical roles."

--- a/skills/hr-talent-supply-chain/content/designing-a-build-buy-borrow-bot-talent-strategy.md
+++ b/skills/hr-talent-supply-chain/content/designing-a-build-buy-borrow-bot-talent-strategy.md
@@ -2,6 +2,8 @@
 
 ## Overview
 
+> Related example: [Building a Resilient Talent Supply Chain for a Scarce Technical Skill](../examples/building-a-resilient-talent-supply-chain-for-a-scarce-technical-skill.md).
+
 Most organizations default to "buy" (external hiring) as the answer to nearly every talent gap, largely because it's the most familiar lever, not because it's consistently the best one. A deliberate talent supply chain strategy treats build, buy, borrow, and bot as genuine alternatives, each with a different cost, speed, and risk profile, and matches the lever to the specific gap rather than reaching for the same tool every time.
 
 ## The Four Levers

--- a/skills/hr-talent-supply-chain/examples/building-a-resilient-talent-supply-chain-for-a-scarce-technical-skill.md
+++ b/skills/hr-talent-supply-chain/examples/building-a-resilient-talent-supply-chain-for-a-scarce-technical-skill.md
@@ -1,0 +1,115 @@
+# Building a Resilient Talent Supply Chain for a Scarce Technical Skill
+
+## Context
+
+You are a workforce planning lead at a mid-size technology company. Engineering leadership has flagged that hiring for a specific scarce skill (a niche ML infrastructure specialty) has taken over 6 months per hire for the last three roles, and demand is forecast to double over the next year. Leadership wants a proactive plan, not another one-off search each time a role opens.
+
+## Step 1 — Diagnosing the Supply Problem
+
+**Sample prompt:**
+
+> "Every search for this skill takes forever. Help me figure out if this is a sourcing problem or a supply problem."
+
+**Expected skill response:**
+
+Separate execution issues from genuine market scarcity before designing a fix:
+
+**Signs it's a sourcing/execution problem:**
+
+- Searches start from scratch each time with no reusable talent pool
+- Candidates are found but lost to slow internal process
+- Outreach only starts once a requisition is open
+
+**Signs it's genuine market scarcity:**
+
+- Very few companies actually use this specialty at the depth required
+- Competing offers consistently come from a small, identifiable set of companies
+- Internal capability to build this skill through training is limited
+
+> Given three consecutive 6-month searches with candidates lost mid-process, this looks like both — a supply constraint made worse by a reactive, restart-from-zero sourcing model.
+
+## Step 2 — Designing the Build-Buy-Borrow-Bot Mix
+
+**Sample prompt:**
+
+> "Help me model a build-buy-borrow-bot strategy so we're not solely dependent on external hiring."
+
+**Skill response — options:**
+
+| Lever | Approach | Timeframe | Trade-off |
+|---|---|---|---|
+| Build | Identify strong internal engineers and invest in targeted upskilling | 6-12 months | Slower, but reduces market dependency long-term |
+| Buy | Maintain a warm, continuously sourced external talent pool | Ongoing | Requires sustained sourcing investment even when no role is open |
+| Borrow | Contract or fractional specialists for short-term capacity | Weeks | Fast, but not a long-term capability fix |
+| Bot | Automate or tool-assist parts of the work to reduce headcount need | 3-6 months | Reduces demand but doesn't eliminate the need for specialists |
+
+> **Recommendation framing:** Given the doubling demand forecast, recommend a combined approach: start building 2-3 internal engineers now, maintain a warm external pool instead of restarting searches, and use contractors to bridge the gap while the build track matures.
+
+## Step 3 — Building the Proactive Talent Pool
+
+**Sample prompt:**
+
+> "How do we stop restarting from zero every time a role opens?"
+
+**Skill response — talent pool design:**
+
+- Maintain ongoing, low-pressure relationships with strong candidates from past searches, even when no role is open
+- Re-engage this pool quarterly with genuine updates (not just "are you open to new roles"), so the relationship stays warm
+- Track pool health as a metric: how many pool candidates are still engaged, and how many convert when a role opens
+
+> A talent pool that isn't nurtured between searches decays quickly — treat it as an ongoing relationship function, not a list.
+
+## Step 4 — Connecting Supply to the Demand Forecast
+
+**Sample prompt:**
+
+> "Engineering says demand for this skill will double. How do I plan supply against that?"
+
+**Skill response — supply-demand mapping:**
+
+```text
+Forecasted demand:     6 roles over next 12 months
+Current internal bench: 0 ready-now, 2 in development (6-12 month horizon)
+Current external pool:  4 warm candidates, historical 25% convert rate
+Projected gap:          approximately 2-3 roles uncovered by build + pool alone
+```
+
+> **What to bring to leadership:** Name the gap explicitly and recommend closing it with contractor bridge capacity while the build track matures, rather than assuming the pool alone will cover demand.
+
+## Step 5 — Assessing and Communicating Talent Supply Risk
+
+**Sample prompt:**
+
+> "How do I explain this risk to leadership in a way that gets investment approved?"
+
+**Skill response — risk framing:**
+
+- Quantify the cost of the status quo: 6-month searches at current pace mean roles sit open, delaying roadmap work
+- Present the combined build-buy-borrow-bot plan as a risk-reduction investment, not just a recruiting request
+- Set a review checkpoint at 6 months to confirm the internal build track and pool conversion are tracking to plan
+
+## Full Talent Supply Chain Workflow Summary
+
+```text
+Diagnose whether the problem is execution, scarcity, or both
+                    ↓
+Model a build-buy-borrow-bot mix against the constraint
+                    ↓
+Build and maintain a proactively nurtured talent pool
+                    ↓
+Map supply against the demand forecast to name the gap explicitly
+                    ↓
+Present the risk and investment case to leadership
+                    ↓
+Review progress against the plan at defined checkpoints
+```
+
+### Common Talent Supply Chain Mistakes
+
+| Mistake | How to avoid it |
+|---|---|
+| Treating every scarce-skill search as a one-off | Build a reusable, nurtured talent pool |
+| Relying solely on external hiring for a doubling demand | Combine build, buy, borrow, and bot levers |
+| Letting a talent pool go cold between searches | Re-engage on a regular cadence with genuine updates |
+| Presenting risk without quantifying the cost of inaction | Tie the gap to concrete roadmap or delivery impact |
+| Skipping checkpoints on multi-lever plans | Set explicit review points to confirm the build track is on pace |

--- a/skills/hr-talent-supply-chain/prompts/talent-supply-chain-prompts.md
+++ b/skills/hr-talent-supply-chain/prompts/talent-supply-chain-prompts.md
@@ -1,0 +1,10 @@
+# Talent supply chain prompts
+
+Use these prompts when designing and managing a proactive talent supply chain for critical and scarce roles.
+
+- "Design a build-buy-borrow-bot strategy for filling [critical role] given current internal bench strength and external market scarcity."
+- "Analyze external talent supply for [role] in [market], including estimated candidate pool size and competitive hiring pressure."
+- "Build a talent pool strategy for [role family] to reduce time-to-fill for recurring critical hires."
+- "Design an internal talent pipeline that feeds succession candidates into [critical role] over the next [timeframe]."
+- "Connect our talent supply chain plan to the workforce demand forecast for [business unit] and flag where supply and demand diverge."
+- "Assess talent supply risk for [scarce skill] and recommend mitigation options beyond traditional external hiring."

--- a/skills/hr-total-rewards/prompts/total-rewards-prompts.md
+++ b/skills/hr-total-rewards/prompts/total-rewards-prompts.md
@@ -1,0 +1,10 @@
+# Total rewards prompts
+
+Use these prompts when designing compensation structures, benchmarking pay, and communicating total rewards.
+
+- "Design a salary band structure and job leveling framework for [function], benchmarked against [market or industry] data."
+- "Run a pay equity analysis across gender and level for [department], and outline how to interpret and remediate any gaps found."
+- "Draft an incentive plan structure for [role type, for example sales or executive] including target payout, accelerators, and caps."
+- "Build a total rewards statement template that translates base pay, bonus, equity, and benefits into a single employee-facing summary."
+- "Compare stock option, RSU, and ESPP structures for [company stage] to recommend an equity compensation approach."
+- "Calculate and interpret compa-ratio distribution for [team] and identify which employees may be under- or over-banded."

--- a/skills/hr-uiux/prompts/uiux-hiring-prompts.md
+++ b/skills/hr-uiux/prompts/uiux-hiring-prompts.md
@@ -1,0 +1,10 @@
+# UI/UX hiring prompts
+
+Use these prompts when screening, interviewing, and evaluating UI/UX and Product Design candidates.
+
+- "Draft first-round screening questions to evaluate a candidate's experience with user research, interaction design, and design systems for a [level] role."
+- "Create an interview scorecard rubric for evaluating portfolio depth, design rationale, and cross-functional collaboration with engineering and product."
+- "Write a practical design exercise brief asking a candidate to redesign a flawed flow in [product area] and explain their reasoning."
+- "Draft a comparison guide explaining the differences between UI Design, UX Design, Product Design, and UX Research roles for a non-technical recruiter."
+- "Create behavioral interview questions probing how a designer handled conflicting stakeholder feedback or a failed usability test."
+- "Draft a job description for a Senior Product Designer emphasizing design systems ownership, user research fluency, and end-to-end product thinking."


### PR DESCRIPTION
Add prompts/ and (where missing) examples/ to the ten remaining Partial skills: hr-change-communication, hr-employer-branding, hr-retirement-benefits, hr-search-strategy, hr-security, hr-skills-taxonomy, hr-succession-planning, hr-talent-supply-chain, hr-total-rewards, hr-uiux.

- 10 new prompts/*.md files (6 quoted prompts each)
- 4 new examples/*.md files for skills that also lacked examples/ (change-communication, retirement-benefits, search-strategy, talent-supply-chain), cross-linked from their content/ files
- Regenerated docs/skill-matrix.md: 146 full, 0 partial, 0 bare
- Added changeset for the minor release

Validated via bun run validate, test, typecheck, check, lint:md, lint:links, and build — all passing.

Closes #125 