### PR TITLE
feat(planner): implement Phase 4.2 skill planner foundation

### DIFF
--- a/.changeset/planner-fixes-and-docs.md
+++ b/.changeset/planner-fixes-and-docs.md
@@ -1,0 +1,5 @@
+---
+"hr-skills-build": patch
+---
+
+Fixed intent analysis and matching heuristics in the planner, adjusted tests to avoid CI-only modifiers, and updated various skill content and documentation. These are bug fixes and documentation improvements.

--- a/.changeset/planner-foundation.md
+++ b/.changeset/planner-foundation.md
@@ -1,0 +1,5 @@
+---
+"hr-skills-build": minor
+---
+
+Added Phase 4.2 skill planner foundation that generates deterministic execution plans from user intent. This introduces planner logic to analyze intents, match capabilities against the skill registry, and produce ordered execution steps.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ bun run sync         # Sync generated skill references after adding/removing a s
 bun run validate     # Validate all skill SKILL.md files
 bun run matrix       # Generate docs/skill-matrix.md — snapshot of every skill's maturity tier
 bun run registry     # Generate registry/skills.json — machine-readable skill registry (see docs/registry.md)
+bun run plan "<intent>"  # Generate execution plan for a user intent (see docs/planner.md)
 bun run test         # Run tests across workspace packages
 bun run typecheck    # Run type-checking across workspace packages
 bun run build        # Run all workspace build tasks through Turborepo

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -232,13 +232,20 @@ Build the machine-readable foundation for the skill ecosystem.
 
 Build a deterministic planning layer that composes workflows from the Skill Registry.
 
-* Intent analysis
-* Capability matching
-* Skill selection
-* Workflow planning
-* Dependency-aware execution planning
-* Context propagation model
-* Explainable execution plans
+Completed:
+
+* Intent analysis — deterministic capability extraction from natural language
+* Capability matching — token-based similarity scoring against skill capabilities
+* Skill selection — recursive dependency and related-skill addition
+* Workflow planning — ordered execution plans
+* Dependency-aware execution planning — topological sort (Kahn's algorithm)
+* Context propagation model — foundation for runtime input/output threading
+* Explainable execution plans — every decision includes reasoning
+* Plan validation — detect and report common issues (circular deps, dangling refs, order violations)
+* CLI tool (`bun run plan`) — generate and validate plans from user intent
+* Comprehensive documentation and tests
+
+See [`docs/planner.md`](planner.md) for detailed architecture and usage.
 
 #### 4.3 Workflow Runtime
 

--- a/docs/planner.md
+++ b/docs/planner.md
@@ -1,0 +1,322 @@
+# Skill Planner
+
+> Phase 4.2 of the [roadmap](ROADMAP.md) — deterministic workflow planning from user intent.
+
+## What it is
+
+The Skill Planner transforms user intent (natural language) into an execution plan (a structured list of skills to use and why).
+
+It is responsible for:
+
+- Understanding what the user is asking for (intent analysis)
+- Matching those requests against available skills (capability matching)
+- Selecting appropriate skills (skill selection)
+- Ordering skills for logical execution (dependency-aware ordering)
+- Producing an explainable plan (with reasoning for every decision)
+
+The planner is **NOT** responsible for:
+
+- Executing skills
+- Invoking tools
+- Generating prompts
+- Calling models
+- Mutating state
+
+These belong to the Workflow Runtime (Phase 4.3).
+
+## Architecture
+
+The planner consists of three layers:
+
+```text
+User Intent
+    ↓
+Intent Analysis (analyzeIntent)
+    ↓
+Capability Matching (matchCapabilityAgainstRegistry)
+    ↓
+Skill Selection & Ordering (selectSkills, buildExecutionSteps)
+    ↓
+Execution Plan (ExecutionPlan struct)
+```
+
+### Intent Analysis
+
+Converts natural language into a list of capabilities the user is requesting.
+
+**Method:** Simple, deterministic heuristic splitting:
+
+- Split on `,`, `;`, `and`, `or`, `then`
+- Normalize to lowercase
+- Remove filler words (`a`, `the`, `for`, etc.)
+
+**Why not ML?** Determinism is more important than accuracy at this stage. The planner's decisions must be explainable and reproducible. If semantic analysis becomes necessary, it can be added as an extension without breaking existing workflows.
+
+### Capability Matching
+
+Matches each requested capability against the Skill Registry using similarity scoring.
+
+**Method:** Token-based Jaccard similarity:
+
+1. Extract words from both the requested capability and each skill's declared capabilities
+2. Calculate overlap / union (Jaccard)
+3. Keep matches scoring > 0.3
+4. Rank by score (ties broken alphabetically)
+
+**Match types:**
+
+- **Direct:** Exact word overlap between requested capability and skill's stated capabilities
+- **Partial:** Semantic similarity (Jaccard score) suggests the skill might help
+
+### Skill Selection
+
+Chooses which skills to include in the plan based on matched capabilities.
+
+**Algorithm:**
+
+1. For each matched capability, select the top-ranked skill
+2. Add all dependencies of selected skills (recursively)
+3. Add related skills if plan is under-specified (< 8 skills)
+4. Limit depth to prevent bloat (max 8 skills)
+
+### Dependency-Aware Ordering
+
+Sorts selected skills using topological sort (Kahn's algorithm) to ensure dependencies always execute first.
+
+**Properties:**
+
+- Deterministic (same input always produces same order)
+- Respects all dependency constraints
+- Breaks circular dependencies (defensive) by taking the first remaining skill
+
+## Execution Plan Format
+
+```typescript
+interface ExecutionPlan {
+  // User's normalized intent
+  intent: string;
+
+  // Extracted capabilities from intent
+  requestedCapabilities: string[];
+
+  // How each capability matched against registry
+  capabilityMatches: CapabilityMatch[];
+
+  // Ordered list of skills to execute
+  steps: ExecutionStep[];
+
+  // Human-readable summary
+  summary: string;
+
+  // Complexity assessment: simple, moderate, complex
+  complexity: 'simple' | 'moderate' | 'complex';
+
+  // Optional warnings or notes
+  notes?: string[];
+}
+```
+
+### CapabilityMatch
+
+```typescript
+interface CapabilityMatch {
+  capability: string;
+  matches: Array<{
+    skillId: string;
+    matchType: 'direct' | 'partial' | 'related';
+    score: number;
+    explanation: string;
+  }>;
+  isMatched: boolean;
+  unmatchedReason?: string;
+}
+```
+
+### ExecutionStep
+
+```typescript
+interface ExecutionStep {
+  skillId: string;
+  order: number;
+  reason: 'direct-capability-match' | 'alias-match' | 'domain-expert' |
+          'dependency-requirement' | 'recommended-pairing' | 'related-skill';
+  rationale?: string;
+  dependencies: string[];
+  contextInputs?: Record<string, unknown>;
+}
+```
+
+The `reason` field is crucial for explainability — it tells future developers (and the user) exactly why this skill was included.
+
+## Usage
+
+### CLI
+
+Generate a plan and save to `execution-plan.json`:
+
+```bash
+bun src/generate-plan.ts "create interview questions for a senior manager"
+```
+
+Output includes:
+
+- Matching analysis (which capabilities matched which skills)
+- Execution steps (ordered with reasoning)
+- Validation results (any issues detected)
+- Suggestions (improvements the user might consider)
+
+### Programmatic
+
+```typescript
+import { generateExecutionPlan } from './planner.js';
+import { buildRegistry } from './registry.js';
+import { validateExecutionPlan } from './validate-planner.js';
+
+const registry = await buildRegistry();
+const plan = generateExecutionPlan('create an onboarding plan', registry);
+const validation = validateExecutionPlan(plan, registry);
+
+if (!validation.isValid) {
+  console.error('Plan has issues:', validation.issues);
+}
+```
+
+## Validation
+
+`validateExecutionPlan()` detects common issues:
+
+1. **Duplicate steps** — skill appears twice in plan
+2. **Dangling references** — step references skill not in registry
+3. **Dependency order violations** — dependency executes after dependent
+4. **Circular dependencies** — cycle in skill dependencies
+5. **Unmatched capabilities** — requested capability has no match (warning)
+6. **Empty plans** — no steps generated (warning)
+7. **Order field inconsistency** — step order fields not sequential
+
+### Improvement Suggestions
+
+`suggestPlanImprovements()` offers non-binding suggestions:
+
+- Plan is too simple or too complex for the request
+- Unmatched capabilities might need refinement
+- Independent skills could potentially be parallelized
+
+## Determinism
+
+The planner is **fully deterministic**:
+
+- Same user intent → same execution plan
+- Same registry state → same matching results
+- No randomness, no external ranking signals, no ML models
+
+This makes plans reproducible, testable, and debuggable.
+
+## Integration Points
+
+### Skill Registry (Phase 4.1)
+
+The planner consumes `registry/skills.json` generated by Phase 4.1.
+
+**Never:**
+
+- Parse `SKILL.md` directly
+- Maintain parallel metadata
+- Hardcode skill information
+
+**Always:**
+
+- Read from the registry
+- Leverage existing metadata (domain, tags, capabilities, dependencies)
+- Validate against registry schema
+
+### Workflow Runtime (Phase 4.3)
+
+The planner produces `ExecutionPlan` — the runtime's input.
+
+**The planner provides:**
+
+- What skills to execute
+- Why each skill was selected
+- Execution order with dependencies
+- Estimated complexity
+
+**The runtime will handle:**
+
+- Actually executing skills
+- Context propagation between steps
+- Retry and failure handling
+- Runtime state management
+
+## Extension Guidelines
+
+### Adding a capability source
+
+If you want to derive more metadata for matching (e.g. keywords in `SKILL.md` tips):
+
+1. Add extraction logic to `buildRegistry()` in `registry.ts`
+2. Store in `RegistryEntry`
+3. Use in `matchCapabilityAgainstRegistry()` to improve matching
+
+### Improving intent analysis
+
+Replace `analyzeIntent()` with a more sophisticated approach:
+
+- Semantic tokenization
+- Synonym expansion
+- Context-aware parsing
+
+The interface (`intent: string → capabilities: string[]`) doesn't change — swapping implementations is safe.
+
+### Custom matching algorithm
+
+Replace `matchCapabilityAgainstRegistry()` if needed:
+
+- BM25 scoring
+- Word embeddings
+- Semantic similarity
+- Keyword boosting
+
+Keep the output signature (`capability: string → CapabilityMatch`) stable.
+
+### Adding new selection strategies
+
+`selectSkills()` is where you'd add:
+
+- User preference for skill tier (full > partial > bare)
+- Domain expertise weighting
+- Feedback from previous executions
+- Manual override hints in the registry
+
+## Testing
+
+Run planner tests:
+
+```bash
+bun test packages/hr-skills-build/test/planner.test.ts
+```
+
+Tests cover:
+
+- Intent analysis (basic, with filler words, empty input)
+- Capability matching (direct match, partial, unmatched)
+- Plan generation (simple and complex scenarios)
+- Validation (correct plans, common issues)
+- Suggestions (complexity warnings, coverage gaps)
+
+## Future Improvements
+
+Potential enhancements beyond the initial implementation:
+
+1. **Semantic intent analysis** — move beyond token splitting to understand domain-specific language
+2. **Multi-turn planning** — refine plans based on user feedback iteratively
+3. **User preference modeling** — learn which skills users prefer for similar requests
+4. **Capability versioning** — track how skill capabilities change over time
+5. **Execution metrics** — collect success/failure data to improve matching
+6. **Skill recommendations** — suggest new skills that would improve coverage
+7. **Parallel execution** — identify independent steps for concurrent execution
+8. **Branching plans** — support conditional execution (`if...then...else`)
+9. **Fallback strategies** — suggest alternative skills if primary ones fail
+
+---
+
+Last updated: July 23, 2026

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"validate": "turbo run validate --filter=hr-skills-build",
 		"matrix": "turbo run matrix --filter=hr-skills-build",
 		"registry": "turbo run registry --filter=hr-skills-build",
+		"plan": "turbo run plan --filter=hr-skills-build",
 		"changeset": "changeset",
 		"release": "changeset version",
 		"prepare": "lefthook install",

--- a/packages/hr-skills-build/package.json
+++ b/packages/hr-skills-build/package.json
@@ -26,6 +26,7 @@
 		"sync": "bun src/sync.ts",
 		"matrix": "bun src/generate-skill-matrix.ts",
 		"registry": "bun src/generate-registry.ts",
+		"plan": "bun src/generate-plan.ts",
 		"test": "bun test",
 		"dev": "bun --watch src/validate.ts",
 		"typecheck": "tsc --noEmit"

--- a/packages/hr-skills-build/src/generate-plan.ts
+++ b/packages/hr-skills-build/src/generate-plan.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env bun
+
+/**
+ * CLI: Generate an execution plan for a given intent.
+ *
+ * Usage:
+ *   bun src/generate-plan.ts "create an onboarding checklist"
+ *   bun src/generate-plan.ts "help with succession planning and talent development"
+ */
+
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as p from '@clack/prompts';
+import { generateExecutionPlan } from './planner.js';
+import { buildRegistry } from './registry.js';
+import { suggestPlanImprovements, validateExecutionPlan } from './validate-planner.js';
+
+async function main() {
+	const intent = process.argv[2];
+
+	if (!intent) {
+		p.log.error('Usage: bun src/generate-plan.ts "<user intent>"');
+		p.log.info('Example:');
+		p.log.message(
+			'  bun src/generate-plan.ts "Create interview questions for a senior manager"',
+		);
+		process.exit(1);
+	}
+
+	p.intro('Execution Plan Generator');
+
+	const spinner = p.spinner();
+
+	spinner.start('Building Skill Registry...');
+	const registry = await buildRegistry();
+	spinner.stop(`Registry ready (${registry.skillCount} skills)`);
+
+	spinner.start(`Analyzing intent: "${intent}"`);
+	const plan = generateExecutionPlan(intent, registry);
+	spinner.stop('Plan generated');
+
+	// Validate plan
+	const validation = validateExecutionPlan(plan, registry);
+
+	// Output plan details
+	p.note(
+		`  
+Intent: ${plan.intent}  
+Complexity: ${plan.complexity}  
+Skills Selected: ${plan.steps.length}  
+Summary: ${plan.summary}  
+${plan.notes && plan.notes.length > 0 ? `Notes:\n${plan.notes.map((note) => `  • ${note}`).join('\n')}` : ''}  
+  `,
+		'EXECUTION PLAN',
+	);
+
+	// Capability matching
+	p.note(
+		plan.capabilityMatches
+			.map((match) => {
+				const status = match.isMatched ? '✓' : '✗';
+				const matches =
+					match.matches.length > 0
+						? match.matches
+								.map(
+									(m, i) =>
+										`   ${i + 1}. ${m.skillId} (${m.matchType}, score: ${m.score.toFixed(2)})\n      ${m.explanation}`,
+								)
+								.join('\n')
+						: match.unmatchedReason || '';
+				return `${status} "${match.capability}"\n${matches}`;
+			})
+			.join('\n\n'),
+		'CAPABILITY MATCHING',
+	);
+
+	// Execution steps
+	p.note(
+		plan.steps.length === 0
+			? '(No steps — plan is empty)'
+			: plan.steps
+					.map((step) => {
+						const deps =
+							step.dependencies.length > 0
+								? `Dependencies: ${step.dependencies.join(', ')}`
+								: '';
+						return `[${step.order + 1}] ${step.skillId}  
+     Reason: ${step.reason}  
+     ${step.rationale ? `Rationale: ${step.rationale}` : ''}  
+     ${deps}`;
+					})
+					.join('\n\n'),
+		'EXECUTION STEPS',
+	);
+
+	// Validation results
+	if (validation.isValid && validation.issues.length === 0) {
+		p.log.success('Plan is valid with no issues');
+	} else {
+		for (const issue of validation.issues) {
+			const icon =
+				issue.severity === 'error'
+					? '✗'
+					: issue.severity === 'warning'
+						? '⚠'
+						: 'ℹ';
+			p.log.message(`${icon} [${issue.severity.toUpperCase()}] ${issue.code}`);
+			p.log.message(`   ${issue.message}`);
+		}
+	}
+
+	const suggestions = suggestPlanImprovements(plan, registry);
+	if (suggestions.length > 0) {
+		p.note(suggestions.map((s) => `• ${s}`).join('\n'), 'IMPROVEMENT SUGGESTIONS');
+	}
+
+	// Save as JSON
+	const outputPath = join(process.cwd(), 'execution-plan.json');
+	writeFileSync(outputPath, JSON.stringify({ plan, validation, suggestions }, null, 2));
+
+	p.log.success(`Execution plan saved to: ${outputPath}`);
+
+	p.outro(validation.isValid ? 'Done' : 'Completed with issues');
+
+	process.exit(validation.isValid ? 0 : 1);
+}
+
+main().catch((err) => {
+	p.log.error(`Error: ${err.message}`);
+	process.exit(1);
+});

--- a/packages/hr-skills-build/src/planner.ts
+++ b/packages/hr-skills-build/src/planner.ts
@@ -143,7 +143,7 @@ function matchCapabilityAgainstRegistry(
 		);
 		const maxPartialScore = Math.max(...partialScores);
 
-		if (maxPartialScore > 0.3) {
+		if (maxPartialScore >= 0.2) {
 			matches.push({
 				skillId: entry.id,
 				matchType: 'partial',

--- a/packages/hr-skills-build/src/planner.ts
+++ b/packages/hr-skills-build/src/planner.ts
@@ -1,0 +1,467 @@
+/**
+ * Deterministic Skill Planner — Phase 4.2
+ *
+ * The Skill Planner transforms user intent into an execution plan by:
+ *  1. Analyzing user intent to extract requested capabilities
+ *  2. Matching capabilities against the Skill Registry
+ *  3. Selecting appropriate skills with clear rationale
+ *  4. Ordering skills based on dependencies and logical flow
+ *  5. Generating an explainable execution plan
+ *
+ * The planner is pure (no side effects, deterministic). It consumes only the
+ * generated Skill Registry and produces a complete execution plan with
+ * reasoning that future developers can understand.
+ *
+ * Key principle: The planner decides *what* to use and *why*, but does not
+ * execute skills, invoke tools, or generate prompts — that belongs to the
+ * Workflow Runtime (Phase 4.3).
+ */
+
+import type {
+	CapabilityMatch,
+	ExecutionPlan,
+	ExecutionStep,
+	Registry,
+	RegistryEntry,
+	SelectionReason,
+} from './types.js';
+
+// ============================================================================
+// Execution Plan Model
+// ============================================================================
+
+// Planner types have been moved to src/types.ts to centralize shared
+// interfaces and avoid duplication. See that file for the canonical
+// definitions used across planner, validator, and tests.
+
+// ============================================================================
+// Intent Analysis
+// ============================================================================
+
+/**
+ * Extract capabilities and key phrases from user intent.
+ *
+ * Uses simple heuristics to identify what the user is asking for:
+ *  - Split by commas and "and"
+ *  - Recognize patterns like "create", "write", "develop", "design", etc.
+ *  - Normalize to lowercase
+ *
+ * This is intentionally simple and deterministic — not powered by ML.
+ * Future extensions could replace this with semantic analysis if needed.
+ */
+export function analyzeIntent(intent: string): string[] {
+	if (!intent || intent.trim().length === 0) {
+		return [];
+	}
+
+	const normalized = intent.toLowerCase().trim();
+
+	// Split on common delimiters
+	const parts = normalized
+		.split(/[,;]|(?:\s+(?:and|or|then)\s+)/i)
+		.map((part) => part.trim())
+		.filter(Boolean);
+
+	// Remove common filler words
+	const fillerWords = new Set([
+		'a',
+		'an',
+		'the',
+		'for',
+		'with',
+		'to',
+		'in',
+		'on',
+		'at',
+	]);
+	const refined = parts.map((part) => {
+		const words = part.split(/\s+/);
+		return words.filter((w) => !fillerWords.has(w)).join(' ');
+	});
+
+	return refined.filter((c) => c.length > 0);
+}
+
+// ============================================================================
+// Capability Matching
+// ============================================================================
+
+/**
+ * Calculate similarity score between a requested capability and
+ * a skill's declared capabilities.
+ *
+ * Uses simple token overlap (Jaccard similarity) for deterministic,
+ * explainable matching.
+ */
+function calculateSimilarity(
+	requestedCapability: string,
+	skillCapability: string,
+): number {
+	const req = new Set(requestedCapability.toLowerCase().split(/\s+/));
+	const skill = new Set(skillCapability.toLowerCase().split(/\s+/));
+
+	if (req.size === 0 || skill.size === 0) return 0;
+
+	const intersection = new Set([...req].filter((x) => skill.has(x)));
+	const union = new Set([...req, ...skill]);
+
+	return intersection.size / union.size;
+}
+
+/**
+ * Match a user's requested capability against available skills.
+ *
+ * Returns matches ranked by score and classified by match type.
+ */
+function matchCapabilityAgainstRegistry(
+	capability: string,
+	registry: Registry,
+): CapabilityMatch {
+	const matches: CapabilityMatch['matches'] = [];
+
+	for (const entry of registry.skills) {
+		// Direct capability match — exact words in the skill's capabilities list
+		const directMatches = entry.capabilities.filter(
+			(skillCap) =>
+				skillCap.toLowerCase().includes(capability.toLowerCase()) ||
+				capability.toLowerCase().includes(skillCap.toLowerCase()),
+		);
+
+		if (directMatches.length > 0) {
+			matches.push({
+				skillId: entry.id,
+				matchType: 'direct',
+				score: 1.0,
+				explanation: `Skill explicitly supports "${directMatches[0]}"`,
+			});
+			continue;
+		}
+
+		// Partial match — semantic similarity within skill's capabilities
+		const partialScores = entry.capabilities.map((skillCap) =>
+			calculateSimilarity(capability, skillCap),
+		);
+		const maxPartialScore = Math.max(...partialScores);
+
+		if (maxPartialScore > 0.3) {
+			matches.push({
+				skillId: entry.id,
+				matchType: 'partial',
+				score: maxPartialScore,
+				explanation: `Skill's capabilities partially overlap with requested capability (score: ${maxPartialScore.toFixed(2)})`,
+			});
+		}
+
+		// Related match — skill is in same domain as other matched skills
+		// (this will be populated during ranking in the planner)
+	}
+
+	// Sort by score descending, then by skill ID for determinism
+	matches.sort((a, b) => b.score - a.score || a.skillId.localeCompare(b.skillId));
+
+	const result: CapabilityMatch = {
+		capability,
+		matches: matches.slice(0, 5), // Keep top 5 matches
+		isMatched: matches.length > 0,
+	};
+	if (matches.length === 0) {
+		// Only add the optional property when there's a real value — avoids
+		// assigning `undefined` to an optional property (exactOptionalPropertyTypes).
+		(result as CapabilityMatch & { unmatchedReason: string }).unmatchedReason =
+			`No skills found that support "${capability}"`;
+	}
+	return result;
+}
+
+// ============================================================================
+// Skill Selection & Ordering
+// ============================================================================
+
+/**
+ * Topological sort for dependency ordering using Kahn's algorithm.
+ *
+ * Returns skills in an order where all dependencies are satisfied before
+ * dependents are executed.
+ */
+function topologicalSort(skillIds: string[], registry: Registry): string[] {
+	const remaining = new Set(skillIds);
+	const result: string[] = [];
+
+	// Build a map of ID -> skill for fast lookup
+	const skillMap = new Map(registry.skills.map((s) => [s.id, s]));
+
+	while (remaining.size > 0) {
+		// Find a skill with no unsatisfied dependencies
+		let found: string | undefined;
+
+		for (const id of remaining) {
+			const skill = skillMap.get(id);
+			if (!skill) continue;
+
+			const unmetDeps = skill.dependencies.filter((dep) => remaining.has(dep));
+			if (unmetDeps.length === 0) {
+				found = id;
+				break;
+			}
+		}
+
+		if (!found) {
+			// Circular dependency detected — break by taking the first remaining
+			// (this should have been caught by validation, but be defensive)
+			found = Array.from(remaining)[0];
+		}
+
+		if (!found) {
+			throw new Error('Topological sort failed: no skill found to select');
+		}
+		result.push(found);
+		remaining.delete(found);
+	}
+
+	return result;
+}
+
+/**
+ * Select skills based on matched capabilities.
+ *
+ * Returns a set of unique skills, avoiding duplicates but preserving
+ * dependency relationships.
+ */
+function selectSkills(
+	capabilityMatches: CapabilityMatch[],
+	registry: Registry,
+): Map<string, { skill: RegistryEntry; reason: SelectionReason }> {
+	const selected = new Map<
+		string,
+		{ skill: RegistryEntry; reason: SelectionReason; rationale?: string }
+	>();
+
+	const skillMap = new Map(registry.skills.map((s) => [s.id, s]));
+
+	// First pass: select skills for matched capabilities
+	for (const match of capabilityMatches) {
+		if (match.matches.length === 0) continue;
+
+		const topMatch = match.matches[0];
+		if (!topMatch) continue;
+		const skill = skillMap.get(topMatch.skillId);
+		if (!skill) continue;
+
+		if (!selected.has(topMatch.skillId)) {
+			selected.set(topMatch.skillId, {
+				skill,
+				reason:
+					topMatch.matchType === 'direct'
+						? 'direct-capability-match'
+						: 'related-skill',
+				rationale: topMatch.explanation,
+			});
+		}
+	}
+
+	// Second pass: add dependencies and related skills for better coverage
+	const toProcess = Array.from(selected.keys());
+	const processed = new Set<string>();
+
+	while (toProcess.length > 0) {
+		const skillId = toProcess.shift();
+		if (!skillId || processed.has(skillId)) continue;
+		processed.add(skillId);
+
+		const skill = skillMap.get(skillId);
+		if (!skill) continue;
+
+		// Add dependencies
+		for (const depId of skill.dependencies) {
+			if (!selected.has(depId)) {
+				const depSkill = skillMap.get(depId);
+				if (depSkill) {
+					selected.set(depId, {
+						skill: depSkill,
+						reason: 'dependency-requirement',
+						rationale: `Required by ${skillId}`,
+					});
+					toProcess.push(depId);
+				}
+			}
+		}
+
+		// Add top related skill if not too crowded
+		if (skill.relatedSkills.length > 0 && selected.size < 8) {
+			const relatedId = skill.relatedSkills[0];
+			// RelatedId may be undefined despite the length check in weird runtime
+			// states; guard defensively without using non-null assertions.
+			if (relatedId && !selected.has(relatedId)) {
+				const relatedSkill = skillMap.get(relatedId);
+				if (relatedSkill) {
+					selected.set(relatedId, {
+						skill: relatedSkill,
+						reason: 'recommended-pairing',
+						rationale: `Commonly used together with ${skillId}`,
+					});
+				}
+			}
+		}
+	}
+
+	return selected;
+}
+
+/**
+ * Build execution steps from selected skills with proper ordering.
+ */
+function buildExecutionSteps(
+	selected: Map<
+		string,
+		{ skill: RegistryEntry; reason: SelectionReason; rationale?: string }
+	>,
+	registry: Registry,
+): ExecutionStep[] {
+	const skillIds = Array.from(selected.keys());
+	const ordered = topologicalSort(skillIds, registry);
+
+	const skillMap = new Map(registry.skills.map((s) => [s.id, s]));
+
+	return ordered.map((skillId, index) => {
+		const entry = selected.get(skillId);
+		if (!entry) throw new Error(`Selected skill ${skillId} not found`);
+
+		const skill = skillMap.get(skillId);
+		if (!skill) throw new Error(`Skill ${skillId} not in registry`);
+
+		const step: ExecutionStep = {
+			skillId,
+			order: index,
+			reason: entry.reason,
+			dependencies: skill.dependencies.filter((dep) => skillIds.includes(dep)),
+			// contextInputs deliberately omitted here — runtime supplies it.
+		};
+
+		if (entry.rationale !== undefined) {
+			// Only add rationale when present to avoid assigning `undefined`.
+			(step as ExecutionStep & { rationale: string }).rationale = entry.rationale;
+		}
+
+		return step;
+	});
+}
+
+// ============================================================================
+// Public Planner API
+// ============================================================================
+
+/**
+ * Generate a complete execution plan for user intent using the Skill Registry.
+ *
+ * Pure function — no side effects, deterministic output for a given input
+ * and registry state.
+ */
+export function generateExecutionPlan(intent: string, registry: Registry): ExecutionPlan {
+	if (!intent || intent.trim().length === 0) {
+		return {
+			intent: '',
+			requestedCapabilities: [],
+			capabilityMatches: [],
+			steps: [],
+			summary: 'No intent provided.',
+			complexity: 'simple',
+			notes: ['Empty or blank intent.'],
+		};
+	}
+
+	// Step 1: Analyze intent
+	const requestedCapabilities = analyzeIntent(intent);
+
+	if (requestedCapabilities.length === 0) {
+		return {
+			intent: intent.trim(),
+			requestedCapabilities: [],
+			capabilityMatches: [],
+			steps: [],
+			summary: 'Could not extract any capabilities from the provided intent.',
+			complexity: 'simple',
+			notes: ['Intent analysis yielded no matchable capabilities.'],
+		};
+	}
+
+	// Step 2: Match capabilities against registry
+	const capabilityMatches = requestedCapabilities.map((cap) =>
+		matchCapabilityAgainstRegistry(cap, registry),
+	);
+
+	const matchedCount = capabilityMatches.filter((m) => m.isMatched).length;
+	const totalRequested = requestedCapabilities.length;
+
+	if (matchedCount === 0) {
+		return {
+			intent: intent.trim(),
+			requestedCapabilities,
+			capabilityMatches,
+			steps: [],
+			summary: `No skills found that support the requested capabilities: ${requestedCapabilities.join(', ')}`,
+			complexity: 'simple',
+			notes: ['No capabilities could be matched against the skill registry.'],
+		};
+	}
+
+	// Step 3: Select skills
+	const selected = selectSkills(capabilityMatches, registry);
+
+	if (selected.size === 0) {
+		return {
+			intent: intent.trim(),
+			requestedCapabilities,
+			capabilityMatches,
+			steps: [],
+			summary:
+				'Matched capabilities but could not select any skills for execution. This may indicate incomplete registry data.',
+			complexity: 'simple',
+			notes: ['Skills matched capabilities but selection failed.'],
+		};
+	}
+
+	// Step 4: Build execution steps
+	const steps = buildExecutionSteps(selected, registry);
+
+	// Step 5: Determine complexity
+	const complexity: ExecutionPlan['complexity'] =
+		steps.length > 5 ? 'complex' : steps.length > 2 ? 'moderate' : 'simple';
+
+	// Step 6: Generate summary
+	const skillNames = steps.map((s) => s.skillId).join(', ');
+	const matchCoverage =
+		matchedCount === totalRequested
+			? 'All requested capabilities are covered'
+			: `${matchedCount} of ${totalRequested} requested capabilities are covered`;
+
+	const summary =
+		`Plan uses ${steps.length} skill${steps.length === 1 ? '' : 's'} to address user intent. ` +
+		`${matchCoverage}. Skills: ${skillNames}`;
+
+	// Step 7: Optional notes
+	const notes: string[] = [];
+	if (matchedCount < totalRequested) {
+		const unmatched = capabilityMatches
+			.filter((m) => !m.isMatched)
+			.map((m) => m.capability);
+		notes.push(`Could not match capabilities: ${unmatched.join(', ')}`);
+	}
+	if (steps.some((s) => s.dependencies.length > 0)) {
+		notes.push(
+			'Plan includes dependent skills that are required by other selections.',
+		);
+	}
+
+	const planResult: ExecutionPlan = {
+		intent: intent.trim(),
+		requestedCapabilities,
+		capabilityMatches,
+		steps,
+		summary,
+		complexity,
+	};
+	if (notes.length > 0) {
+		(planResult as ExecutionPlan & { notes: string[] }).notes = notes;
+	}
+	return planResult;
+}

--- a/packages/hr-skills-build/src/types.ts
+++ b/packages/hr-skills-build/src/types.ts
@@ -112,3 +112,75 @@ export interface Registry {
 	skillCount: number;
 	skills: RegistryEntry[];
 }
+
+// ---------------------------------------------------------------------------
+// Planner and validation types
+// ---------------------------------------------------------------------------
+
+export type SelectionReason =
+	| 'direct-capability-match'
+	| 'alias-match'
+	| 'domain-expert'
+	| 'dependency-requirement'
+	| 'recommended-pairing'
+	| 'related-skill';
+
+export interface ExecutionStep {
+	/** Skill ID (e.g. "hr-onboarding"). */
+	skillId: string;
+	/** Sequential position in the plan (0-indexed). */
+	order: number;
+	/** Why this skill was selected. */
+	reason: SelectionReason;
+	/** Optional explanation for complex reasoning. */
+	rationale?: string;
+	/** Skill IDs that must be executed before this one (if any). */
+	dependencies: string[];
+	/** Optional context that will be passed from previous steps. */
+	contextInputs?: Record<string, unknown>;
+}
+
+export interface CapabilityMatch {
+	/** The requested capability from user intent. */
+	capability: string;
+	/** Matched skills ranked by relevance. */
+	matches: Array<{
+		skillId: string;
+		matchType: 'direct' | 'partial' | 'related';
+		score: number; // 0.0 to 1.0
+		explanation: string;
+	}>;
+	/** Whether this capability has at least one match. */
+	isMatched: boolean;
+	/** Explanation if capability could not be matched. */
+	unmatchedReason?: string;
+}
+
+export interface ExecutionPlan {
+	/** User's original intent (normalized). */
+	intent: string;
+	/** Extracted capabilities from the intent. */
+	requestedCapabilities: string[];
+	/** How each capability matched against available skills. */
+	capabilityMatches: CapabilityMatch[];
+	/** Ordered list of skills to execute. */
+	steps: ExecutionStep[];
+	/** Summary of the plan for human review. */
+	summary: string;
+	/** Total estimated complexity (simple/moderate/complex). */
+	complexity: 'simple' | 'moderate' | 'complex';
+	/** Optional warnings or considerations. */
+	notes?: string[];
+}
+
+export interface PlanValidationIssue {
+	code: string;
+	severity: 'error' | 'warning' | 'info';
+	message: string;
+	context?: Record<string, unknown>;
+}
+
+export interface PlanValidationResult {
+	isValid: boolean;
+	issues: PlanValidationIssue[];
+}

--- a/packages/hr-skills-build/src/validate-planner.ts
+++ b/packages/hr-skills-build/src/validate-planner.ts
@@ -1,0 +1,283 @@
+/**
+ * Planner validation — checks execution plans for soundness.
+ *
+ * Validates:
+ *  - No circular skill dependencies
+ *  - No dangling skill references
+ *  - Capability coverage (at least one match per requested capability)
+ *  - Execution order respects dependencies
+ *  - No duplicate steps
+ *
+ * All validations are deterministic and produce clear, actionable diagnostics.
+ */
+
+import type {
+	ExecutionPlan,
+	PlanValidationIssue,
+	PlanValidationResult,
+	Registry,
+} from './types.js';
+
+/**
+ * Validate an execution plan against the registry and detect common issues.
+ */
+export function validateExecutionPlan(
+	plan: ExecutionPlan,
+	registry: Registry,
+): PlanValidationResult {
+	const issues: PlanValidationIssue[] = [];
+	const skillMap = new Map(registry.skills.map((s) => [s.id, s]));
+	const stepSkillIds = new Set(plan.steps.map((s) => s.skillId));
+
+	// =========================================================================
+	// Check 1: No duplicate steps
+	// =========================================================================
+	const stepOrder = new Map<string, number>();
+	for (const step of plan.steps) {
+		if (stepOrder.has(step.skillId)) {
+			issues.push({
+				code: 'DUPLICATE_STEP',
+				severity: 'error',
+				message: `Skill "${step.skillId}" appears multiple times in execution plan`,
+				context: { skillId: step.skillId },
+			});
+		}
+		stepOrder.set(step.skillId, step.order);
+	}
+
+	// =========================================================================
+	// Check 2: No dangling skill references
+	// =========================================================================
+	for (const step of plan.steps) {
+		const skill = skillMap.get(step.skillId);
+		if (!skill) {
+			issues.push({
+				code: 'DANGLING_SKILL_REFERENCE',
+				severity: 'error',
+				message: `Execution step references skill "${step.skillId}" which is not in the registry`,
+				context: { skillId: step.skillId },
+			});
+		}
+
+		// Check dependencies reference valid skills
+		for (const depId of step.dependencies) {
+			if (!stepSkillIds.has(depId)) {
+				issues.push({
+					code: 'MISSING_DEPENDENCY',
+					severity: 'error',
+					message: `Skill "${step.skillId}" depends on "${depId}" but it is not in the execution plan`,
+					context: { skillId: step.skillId, dependency: depId },
+				});
+			}
+		}
+	}
+
+	// =========================================================================
+	// Check 3: Execution order respects dependencies
+	// =========================================================================
+	for (const step of plan.steps) {
+		for (const depId of step.dependencies) {
+			const depStep = plan.steps.find((s) => s.skillId === depId);
+			if (depStep && depStep.order >= step.order) {
+				issues.push({
+					code: 'DEPENDENCY_ORDER_VIOLATION',
+					severity: 'error',
+					message: `Skill "${step.skillId}" (order ${step.order}) depends on "${depId}" (order ${depStep.order}), but dependencies must execute first`,
+					context: {
+						skillId: step.skillId,
+						skillOrder: step.order,
+						dependency: depId,
+						depOrder: depStep.order,
+					},
+				});
+			}
+		}
+	}
+
+	// =========================================================================
+	// Check 4: No circular dependencies among selected skills
+	// =========================================================================
+	const hasCircularDep = detectCircularDependencies(Array.from(stepSkillIds), registry);
+	if (hasCircularDep.isCircular) {
+		issues.push({
+			code: 'CIRCULAR_DEPENDENCY',
+			severity: 'error',
+			message: `Execution plan contains circular skill dependencies: ${hasCircularDep.cycle?.join(' -> ')}`,
+			context: { cycle: hasCircularDep.cycle },
+		});
+	}
+
+	// =========================================================================
+	// Check 5: Capability coverage warnings
+	// =========================================================================
+	const unmatchedCaps = plan.capabilityMatches
+		.filter((m) => !m.isMatched)
+		.map((m) => m.capability);
+
+	if (unmatchedCaps.length > 0) {
+		issues.push({
+			code: 'UNMATCHED_CAPABILITIES',
+			severity: 'warning',
+			message: `${unmatchedCaps.length} requested capability(ies) could not be matched: ${unmatchedCaps.join(', ')}`,
+			context: { unmatchedCapabilities: unmatchedCaps },
+		});
+	}
+
+	// =========================================================================
+	// Check 6: Empty plan warning
+	// =========================================================================
+	if (plan.steps.length === 0) {
+		issues.push({
+			code: 'EMPTY_PLAN',
+			severity: 'warning',
+			message: 'Execution plan contains no steps',
+		});
+	}
+
+	// =========================================================================
+	// Check 7: Order field consistency
+	// =========================================================================
+	const orderValues = plan.steps.map((s) => s.order).sort((a, b) => a - b);
+	const expectedOrder = Array.from({ length: orderValues.length }, (_, i) => i);
+	if (JSON.stringify(orderValues) !== JSON.stringify(expectedOrder)) {
+		issues.push({
+			code: 'ORDER_FIELD_INCONSISTENT',
+			severity: 'error',
+			message: `Execution step order fields are inconsistent. Expected [0..${plan.steps.length - 1}], got [${orderValues.join(', ')}]`,
+			context: { expectedOrder, actualOrder: orderValues },
+		});
+	}
+
+	return {
+		isValid: issues.filter((i) => i.severity === 'error').length === 0,
+		issues,
+	};
+}
+
+/**
+ * Detect circular dependencies using depth-first search.
+ *
+ * Returns an object indicating whether a cycle was found, and if so, the
+ * cycle path.
+ */
+function detectCircularDependencies(
+	skillIds: string[],
+	registry: Registry,
+): { isCircular: boolean; cycle?: string[] } {
+	const skillMap = new Map(registry.skills.map((s) => [s.id, s]));
+
+	for (const startId of skillIds) {
+		const visited = new Set<string>();
+		const path: string[] = [];
+
+		if (hasCycleDFS(startId, visited, path, skillMap, skillIds)) {
+			return { isCircular: true, cycle: path };
+		}
+	}
+
+	return { isCircular: false };
+}
+
+/**
+ * Depth-first search helper for cycle detection.
+ */
+function hasCycleDFS(
+	skillId: string,
+	visited: Set<string>,
+	path: string[],
+	skillMap: Map<string, { id: string; dependencies: string[] }>,
+	scopeSkillIds: string[],
+): boolean {
+	if (!scopeSkillIds.includes(skillId)) {
+		return false;
+	}
+
+	if (visited.has(skillId)) {
+		// Found cycle if this node is already in current path
+		if (path.includes(skillId)) {
+			const cycleStart = path.indexOf(skillId);
+			path.splice(cycleStart);
+			path.push(skillId); // Close the cycle
+			return true;
+		}
+		return false;
+	}
+
+	visited.add(skillId);
+	path.push(skillId);
+
+	const skill = skillMap.get(skillId);
+	if (skill) {
+		for (const depId of skill.dependencies) {
+			if (hasCycleDFS(depId, visited, path, skillMap, scopeSkillIds)) {
+				return true;
+			}
+		}
+	}
+
+	path.pop();
+	return false;
+}
+
+/**
+ * Suggest improvements to an execution plan.
+ *
+ * Non-binding suggestions for better organization or coverage.
+ */
+export function suggestPlanImprovements(
+	plan: ExecutionPlan,
+	_registry: Registry,
+): string[] {
+	const suggestions: string[] = [];
+
+	if (plan.steps.length === 0) {
+		suggestions.push(
+			'Plan is empty — consider requesting capabilities that the registry can support.',
+		);
+	}
+
+	if (plan.steps.length === 1) {
+		const firstStep = plan.steps[0];
+		if (firstStep) {
+			suggestions.push(
+				`Only one skill selected. Consider whether related skills from the "${firstStep.skillId}" domain might help achieve the goal more completely.`,
+			);
+		}
+	}
+
+	if (plan.complexity === 'complex' && plan.steps.length > 8) {
+		suggestions.push(
+			`Plan is complex (${plan.steps.length} skills). Consider breaking the request into simpler, sequential sub-requests to improve maintainability.`,
+		);
+	}
+
+	const unmatchedCaps = plan.capabilityMatches.filter((m) => !m.isMatched);
+	if (
+		unmatchedCaps.length > 0 &&
+		unmatchedCaps.length < plan.requestedCapabilities.length
+	) {
+		const matched = plan.capabilityMatches
+			.filter((m) => m.isMatched && m.matches.length > 0)
+			.map((m) => m.matches[0]?.skillId);
+		const uniqueMatched = new Set(matched);
+
+		if (uniqueMatched.size === 1) {
+			suggestions.push(
+				`All matched capabilities use the same skill. The unmatched capabilities may require a more specific intent or a skill not yet in the registry.`,
+			);
+		}
+	}
+
+	if (plan.steps.some((s) => !s.dependencies || s.dependencies.length === 0)) {
+		const independentCount = plan.steps.filter(
+			(s) => !s.dependencies || s.dependencies.length === 0,
+		).length;
+		if (independentCount > 1 && plan.steps.length > 1) {
+			suggestions.push(
+				`${independentCount} independent skills could potentially be parallelized in a real workflow runtime, but are listed sequentially here for clarity.`,
+			);
+		}
+	}
+
+	return suggestions;
+}

--- a/packages/hr-skills-build/test/planner-integration.test.ts
+++ b/packages/hr-skills-build/test/planner-integration.test.ts
@@ -20,200 +20,191 @@ describe('Skill Planner Integration', () => {
 	let registry: Awaited<ReturnType<typeof buildRegistry>>;
 
 	// Load registry once for all tests
-	describe.only.if(process.env['SKIP_INTEGRATION'] !== 'true')(
-		'with real registry',
-		() => {
-			it('should load registry', async () => {
-				registry = await buildRegistry();
-				expect(registry.skillCount).toBeGreaterThan(0);
-				expect(registry.skills.length).toBe(registry.skillCount);
-			});
+	describe.if(process.env['SKIP_INTEGRATION'] !== 'true')('with real registry', () => {
+		it('should load registry', async () => {
+			registry = await buildRegistry();
+			expect(registry.skillCount).toBeGreaterThan(0);
+			expect(registry.skills.length).toBe(registry.skillCount);
+		});
 
-			it('should generate valid plan for recruiting intent', async () => {
-				if (!registry) return;
+		it('should generate valid plan for recruiting intent', async () => {
+			if (!registry) return;
 
-				const plan = generateExecutionPlan(
-					'create interview questions for a senior manager',
-					registry,
-				);
+			const plan = generateExecutionPlan(
+				'create interview questions for a senior manager',
+				registry,
+			);
 
-				expect(plan.intent).toBeTruthy();
-				expect(plan.requestedCapabilities.length).toBeGreaterThan(0);
-				expect(plan.capabilityMatches.length).toBeGreaterThan(0);
-				expect(plan.summary).toBeTruthy();
+			expect(plan.intent).toBeTruthy();
+			expect(plan.requestedCapabilities.length).toBeGreaterThan(0);
+			expect(plan.capabilityMatches.length).toBeGreaterThan(0);
+			expect(plan.summary).toBeTruthy();
 
-				// At least some capabilities should be matched
-				const matchedCount = plan.capabilityMatches.filter(
-					(m) => m.isMatched,
-				).length;
-				expect(matchedCount).toBeGreaterThan(0);
+			// At least some capabilities should be matched
+			const matchedCount = plan.capabilityMatches.filter((m) => m.isMatched).length;
+			expect(matchedCount).toBeGreaterThan(0);
 
-				// Validate the plan
-				const validation = validateExecutionPlan(plan, registry);
-				expect(
-					validation.issues.filter((i) => i.severity === 'error'),
-				).toHaveLength(0);
-			});
+			// Validate the plan
+			const validation = validateExecutionPlan(plan, registry);
+			expect(validation.issues.filter((i) => i.severity === 'error')).toHaveLength(
+				0,
+			);
+		});
 
-			it('should generate plan for onboarding intent', async () => {
-				if (!registry) return;
+		it('should generate plan for onboarding intent', async () => {
+			if (!registry) return;
 
-				const plan = generateExecutionPlan(
-					'design an onboarding program and checklist',
-					registry,
-				);
+			const plan = generateExecutionPlan(
+				'design an onboarding program and checklist',
+				registry,
+			);
 
-				expect(plan.steps.length).toBeGreaterThan(0);
+			expect(plan.steps.length).toBeGreaterThan(0);
 
-				// Check execution steps are properly ordered
-				for (let i = 0; i < plan.steps.length; i++) {
-					expect(plan.steps[i]?.order).toBe(i);
+			// Check execution steps are properly ordered
+			for (let i = 0; i < plan.steps.length; i++) {
+				expect(plan.steps[i]?.order).toBe(i);
+			}
+
+			// Validate the plan
+			const validation = validateExecutionPlan(plan, registry);
+			expect(validation.isValid).toBe(true);
+		});
+
+		it('should generate plan for compensation intent', async () => {
+			if (!registry) return;
+
+			const plan = generateExecutionPlan(
+				'develop a compensation strategy and benefits package',
+				registry,
+			);
+
+			expect(plan.requestedCapabilities.length).toBeGreaterThan(0);
+			expect(plan.complexity).toBeDefined();
+
+			// Validate the plan
+			const validation = validateExecutionPlan(plan, registry);
+			const errors = validation.issues.filter((i) => i.severity === 'error');
+			expect(errors).toHaveLength(0);
+		});
+
+		it('should handle complex HR workflow intent', async () => {
+			if (!registry) return;
+
+			const intent =
+				'create job descriptions, write interview questions, develop competency models, and design onboarding';
+			const plan = generateExecutionPlan(intent, registry);
+
+			expect(plan.requestedCapabilities.length).toBeGreaterThan(2);
+			expect(plan.steps.length).toBeGreaterThan(0);
+
+			// Complex plan should have complexity >= moderate
+			if (plan.steps.length > 2) {
+				expect(['moderate', 'complex']).toContain(plan.complexity);
+			}
+
+			// All steps should have valid dependencies
+			for (const step of plan.steps) {
+				for (const dep of step.dependencies) {
+					const depExists = plan.steps.some((s) => s.skillId === dep);
+					expect(depExists).toBe(true);
 				}
+			}
+		});
 
-				// Validate the plan
-				const validation = validateExecutionPlan(plan, registry);
-				expect(validation.isValid).toBe(true);
-			});
+		it('should provide improvement suggestions for overcomplicated plan', async () => {
+			if (!registry) return;
 
-			it('should generate plan for compensation intent', async () => {
-				if (!registry) return;
+			// Request many things to create a complex plan
+			const capabilities = Array.from(
+				{ length: 15 },
+				(_, i) => `capability ${i}`,
+			).join(', ');
+			const plan = generateExecutionPlan(capabilities, registry);
 
-				const plan = generateExecutionPlan(
-					'develop a compensation strategy and benefits package',
-					registry,
-				);
+			const suggestions = suggestPlanImprovements(plan, registry);
+			// Complex plans should get at least some suggestions
+			if (plan.complexity === 'complex') {
+				expect(suggestions.length).toBeGreaterThanOrEqual(0);
+			}
+		});
 
-				expect(plan.requestedCapabilities.length).toBeGreaterThan(0);
-				expect(plan.complexity).toBeDefined();
+		it('should handle unmatched capabilities gracefully', async () => {
+			if (!registry) return;
 
-				// Validate the plan
-				const validation = validateExecutionPlan(plan, registry);
-				const errors = validation.issues.filter((i) => i.severity === 'error');
-				expect(errors).toHaveLength(0);
-			});
+			const plan = generateExecutionPlan(
+				'generate holographic employee avatars and quantum recruit analysis',
+				registry,
+			);
 
-			it('should handle complex HR workflow intent', async () => {
-				if (!registry) return;
+			// These capabilities don't exist, so plan should be empty or very minimal
+			const unmatchedCount = plan.capabilityMatches.filter(
+				(m) => !m.isMatched,
+			).length;
+			expect(unmatchedCount).toBeGreaterThan(0);
 
-				const intent =
-					'create job descriptions, write interview questions, develop competency models, and design onboarding';
+			// Validation should still pass (no errors, though might have warnings)
+			const validation = validateExecutionPlan(plan, registry);
+			const errors = validation.issues.filter((i) => i.severity === 'error');
+			expect(errors).toHaveLength(0);
+		});
+
+		it('should respect skill dependencies in plan ordering', async () => {
+			if (!registry) return;
+
+			// Find a skill with dependencies
+			const skillWithDeps = registry.skills.find((s) => s.dependencies.length > 0);
+			if (!skillWithDeps) return; // Skip if no skills have deps
+
+			// Request something that would trigger skill with dependencies
+			const plan = generateExecutionPlan(
+				skillWithDeps.capabilities[0] || skillWithDeps.description,
+				registry,
+			);
+
+			// If the dependent skill is in the plan, its dependencies should come first
+			const stepMap = new Map(plan.steps.map((s) => [s.skillId, s.order]));
+
+			for (const step of plan.steps) {
+				for (const dep of step.dependencies) {
+					const depOrder = stepMap.get(dep);
+					expect(depOrder).toBeLessThan(step.order);
+				}
+			}
+		});
+
+		it('should generate deterministic plans for same intent', async () => {
+			if (!registry) return;
+
+			const intent = 'help with succession planning and talent development';
+
+			const plan1 = generateExecutionPlan(intent, registry);
+			const plan2 = generateExecutionPlan(intent, registry);
+
+			// Same intent should produce identical plans
+			expect(JSON.stringify(plan1.steps)).toBe(JSON.stringify(plan2.steps));
+			expect(plan1.summary).toBe(plan2.summary);
+			expect(plan1.complexity).toBe(plan2.complexity);
+		});
+
+		it('should validate all generated plans', async () => {
+			if (!registry) return;
+
+			const intents = [
+				'write a job description',
+				'design a benefits package',
+				'create an onboarding checklist',
+				'develop interview questions',
+				'build a performance management process',
+			];
+
+			for (const intent of intents) {
 				const plan = generateExecutionPlan(intent, registry);
-
-				expect(plan.requestedCapabilities.length).toBeGreaterThan(2);
-				expect(plan.steps.length).toBeGreaterThan(0);
-
-				// Complex plan should have complexity >= moderate
-				if (plan.steps.length > 2) {
-					expect(['moderate', 'complex']).toContain(plan.complexity);
-				}
-
-				// All steps should have valid dependencies
-				for (const step of plan.steps) {
-					for (const dep of step.dependencies) {
-						const depExists = plan.steps.some((s) => s.skillId === dep);
-						expect(depExists).toBe(true);
-					}
-				}
-			});
-
-			it('should provide improvement suggestions for overcomplicated plan', async () => {
-				if (!registry) return;
-
-				// Request many things to create a complex plan
-				const capabilities = Array.from(
-					{ length: 15 },
-					(_, i) => `capability ${i}`,
-				).join(', ');
-				const plan = generateExecutionPlan(capabilities, registry);
-
-				const suggestions = suggestPlanImprovements(plan, registry);
-				// Complex plans should get at least some suggestions
-				if (plan.complexity === 'complex') {
-					expect(suggestions.length).toBeGreaterThanOrEqual(0);
-				}
-			});
-
-			it('should handle unmatched capabilities gracefully', async () => {
-				if (!registry) return;
-
-				const plan = generateExecutionPlan(
-					'generate holographic employee avatars and quantum recruit analysis',
-					registry,
-				);
-
-				// These capabilities don't exist, so plan should be empty or very minimal
-				const unmatchedCount = plan.capabilityMatches.filter(
-					(m) => !m.isMatched,
-				).length;
-				expect(unmatchedCount).toBeGreaterThan(0);
-
-				// Validation should still pass (no errors, though might have warnings)
 				const validation = validateExecutionPlan(plan, registry);
+
 				const errors = validation.issues.filter((i) => i.severity === 'error');
 				expect(errors).toHaveLength(0);
-			});
-
-			it('should respect skill dependencies in plan ordering', async () => {
-				if (!registry) return;
-
-				// Find a skill with dependencies
-				const skillWithDeps = registry.skills.find(
-					(s) => s.dependencies.length > 0,
-				);
-				if (!skillWithDeps) return; // Skip if no skills have deps
-
-				// Request something that would trigger skill with dependencies
-				const plan = generateExecutionPlan(
-					skillWithDeps.capabilities[0] || skillWithDeps.description,
-					registry,
-				);
-
-				// If the dependent skill is in the plan, its dependencies should come first
-				const stepMap = new Map(plan.steps.map((s) => [s.skillId, s.order]));
-
-				for (const step of plan.steps) {
-					for (const dep of step.dependencies) {
-						const depOrder = stepMap.get(dep);
-						expect(depOrder).toBeLessThan(step.order);
-					}
-				}
-			});
-
-			it('should generate deterministic plans for same intent', async () => {
-				if (!registry) return;
-
-				const intent = 'help with succession planning and talent development';
-
-				const plan1 = generateExecutionPlan(intent, registry);
-				const plan2 = generateExecutionPlan(intent, registry);
-
-				// Same intent should produce identical plans
-				expect(JSON.stringify(plan1.steps)).toBe(JSON.stringify(plan2.steps));
-				expect(plan1.summary).toBe(plan2.summary);
-				expect(plan1.complexity).toBe(plan2.complexity);
-			});
-
-			it('should validate all generated plans', async () => {
-				if (!registry) return;
-
-				const intents = [
-					'write a job description',
-					'design a benefits package',
-					'create an onboarding checklist',
-					'develop interview questions',
-					'build a performance management process',
-				];
-
-				for (const intent of intents) {
-					const plan = generateExecutionPlan(intent, registry);
-					const validation = validateExecutionPlan(plan, registry);
-
-					const errors = validation.issues.filter(
-						(i) => i.severity === 'error',
-					);
-					expect(errors).toHaveLength(0);
-				}
-			});
-		},
-	);
+			}
+		});
+	});
 });

--- a/packages/hr-skills-build/test/planner-integration.test.ts
+++ b/packages/hr-skills-build/test/planner-integration.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'bun:test';
+import { generateExecutionPlan } from '../src/planner.js';
+import { buildRegistry } from '../src/registry.js';
+import {
+	suggestPlanImprovements,
+	validateExecutionPlan,
+} from '../src/validate-planner.js';
+
+/**
+ * Integration tests for the complete planning pipeline.
+ *
+ * These tests use the actual Skill Registry to verify that:
+ * 1. Intent analysis extracts meaningful capabilities
+ * 2. Registry matching works with real skills
+ * 3. Execution plans are valid and complete
+ * 4. Validation catches issues
+ */
+
+describe('Skill Planner Integration', () => {
+	let registry: Awaited<ReturnType<typeof buildRegistry>>;
+
+	// Load registry once for all tests
+	describe.only.if(process.env['SKIP_INTEGRATION'] !== 'true')(
+		'with real registry',
+		() => {
+			it('should load registry', async () => {
+				registry = await buildRegistry();
+				expect(registry.skillCount).toBeGreaterThan(0);
+				expect(registry.skills.length).toBe(registry.skillCount);
+			});
+
+			it('should generate valid plan for recruiting intent', async () => {
+				if (!registry) return;
+
+				const plan = generateExecutionPlan(
+					'create interview questions for a senior manager',
+					registry,
+				);
+
+				expect(plan.intent).toBeTruthy();
+				expect(plan.requestedCapabilities.length).toBeGreaterThan(0);
+				expect(plan.capabilityMatches.length).toBeGreaterThan(0);
+				expect(plan.summary).toBeTruthy();
+
+				// At least some capabilities should be matched
+				const matchedCount = plan.capabilityMatches.filter(
+					(m) => m.isMatched,
+				).length;
+				expect(matchedCount).toBeGreaterThan(0);
+
+				// Validate the plan
+				const validation = validateExecutionPlan(plan, registry);
+				expect(
+					validation.issues.filter((i) => i.severity === 'error'),
+				).toHaveLength(0);
+			});
+
+			it('should generate plan for onboarding intent', async () => {
+				if (!registry) return;
+
+				const plan = generateExecutionPlan(
+					'design an onboarding program and checklist',
+					registry,
+				);
+
+				expect(plan.steps.length).toBeGreaterThan(0);
+
+				// Check execution steps are properly ordered
+				for (let i = 0; i < plan.steps.length; i++) {
+					expect(plan.steps[i]?.order).toBe(i);
+				}
+
+				// Validate the plan
+				const validation = validateExecutionPlan(plan, registry);
+				expect(validation.isValid).toBe(true);
+			});
+
+			it('should generate plan for compensation intent', async () => {
+				if (!registry) return;
+
+				const plan = generateExecutionPlan(
+					'develop a compensation strategy and benefits package',
+					registry,
+				);
+
+				expect(plan.requestedCapabilities.length).toBeGreaterThan(0);
+				expect(plan.complexity).toBeDefined();
+
+				// Validate the plan
+				const validation = validateExecutionPlan(plan, registry);
+				const errors = validation.issues.filter((i) => i.severity === 'error');
+				expect(errors).toHaveLength(0);
+			});
+
+			it('should handle complex HR workflow intent', async () => {
+				if (!registry) return;
+
+				const intent =
+					'create job descriptions, write interview questions, develop competency models, and design onboarding';
+				const plan = generateExecutionPlan(intent, registry);
+
+				expect(plan.requestedCapabilities.length).toBeGreaterThan(2);
+				expect(plan.steps.length).toBeGreaterThan(0);
+
+				// Complex plan should have complexity >= moderate
+				if (plan.steps.length > 2) {
+					expect(['moderate', 'complex']).toContain(plan.complexity);
+				}
+
+				// All steps should have valid dependencies
+				for (const step of plan.steps) {
+					for (const dep of step.dependencies) {
+						const depExists = plan.steps.some((s) => s.skillId === dep);
+						expect(depExists).toBe(true);
+					}
+				}
+			});
+
+			it('should provide improvement suggestions for overcomplicated plan', async () => {
+				if (!registry) return;
+
+				// Request many things to create a complex plan
+				const capabilities = Array.from(
+					{ length: 15 },
+					(_, i) => `capability ${i}`,
+				).join(', ');
+				const plan = generateExecutionPlan(capabilities, registry);
+
+				const suggestions = suggestPlanImprovements(plan, registry);
+				// Complex plans should get at least some suggestions
+				if (plan.complexity === 'complex') {
+					expect(suggestions.length).toBeGreaterThanOrEqual(0);
+				}
+			});
+
+			it('should handle unmatched capabilities gracefully', async () => {
+				if (!registry) return;
+
+				const plan = generateExecutionPlan(
+					'generate holographic employee avatars and quantum recruit analysis',
+					registry,
+				);
+
+				// These capabilities don't exist, so plan should be empty or very minimal
+				const unmatchedCount = plan.capabilityMatches.filter(
+					(m) => !m.isMatched,
+				).length;
+				expect(unmatchedCount).toBeGreaterThan(0);
+
+				// Validation should still pass (no errors, though might have warnings)
+				const validation = validateExecutionPlan(plan, registry);
+				const errors = validation.issues.filter((i) => i.severity === 'error');
+				expect(errors).toHaveLength(0);
+			});
+
+			it('should respect skill dependencies in plan ordering', async () => {
+				if (!registry) return;
+
+				// Find a skill with dependencies
+				const skillWithDeps = registry.skills.find(
+					(s) => s.dependencies.length > 0,
+				);
+				if (!skillWithDeps) return; // Skip if no skills have deps
+
+				// Request something that would trigger skill with dependencies
+				const plan = generateExecutionPlan(
+					skillWithDeps.capabilities[0] || skillWithDeps.description,
+					registry,
+				);
+
+				// If the dependent skill is in the plan, its dependencies should come first
+				const stepMap = new Map(plan.steps.map((s) => [s.skillId, s.order]));
+
+				for (const step of plan.steps) {
+					for (const dep of step.dependencies) {
+						const depOrder = stepMap.get(dep);
+						expect(depOrder).toBeLessThan(step.order);
+					}
+				}
+			});
+
+			it('should generate deterministic plans for same intent', async () => {
+				if (!registry) return;
+
+				const intent = 'help with succession planning and talent development';
+
+				const plan1 = generateExecutionPlan(intent, registry);
+				const plan2 = generateExecutionPlan(intent, registry);
+
+				// Same intent should produce identical plans
+				expect(JSON.stringify(plan1.steps)).toBe(JSON.stringify(plan2.steps));
+				expect(plan1.summary).toBe(plan2.summary);
+				expect(plan1.complexity).toBe(plan2.complexity);
+			});
+
+			it('should validate all generated plans', async () => {
+				if (!registry) return;
+
+				const intents = [
+					'write a job description',
+					'design a benefits package',
+					'create an onboarding checklist',
+					'develop interview questions',
+					'build a performance management process',
+				];
+
+				for (const intent of intents) {
+					const plan = generateExecutionPlan(intent, registry);
+					const validation = validateExecutionPlan(plan, registry);
+
+					const errors = validation.issues.filter(
+						(i) => i.severity === 'error',
+					);
+					expect(errors).toHaveLength(0);
+				}
+			});
+		},
+	);
+});

--- a/packages/hr-skills-build/test/planner.test.ts
+++ b/packages/hr-skills-build/test/planner.test.ts
@@ -73,10 +73,10 @@ describe('analyzeIntent', () => {
 
 	it('should filter out filler words', () => {
 		const result = analyzeIntent('create an onboarding plan for the company');
-		const joined = result.join(' ');
-		expect(joined).not.toContain('an');
-		expect(joined).not.toContain('the');
-		expect(joined).not.toContain('for');
+		const joined = ` ${result.join(' ')} `;
+		expect(joined).not.toContain(' an ');
+		expect(joined).not.toContain(' the ');
+		expect(joined).not.toContain(' for ');
 	});
 });
 

--- a/packages/hr-skills-build/test/planner.test.ts
+++ b/packages/hr-skills-build/test/planner.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it } from 'bun:test';
+
+import { analyzeIntent, generateExecutionPlan } from '../src/planner.js';
+import type { ExecutionPlan, Registry, RegistryEntry } from '../src/types.js';
+import {
+	suggestPlanImprovements,
+	validateExecutionPlan,
+} from '../src/validate-planner.js';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+const createMockSkill = (overrides: Partial<RegistryEntry> = {}): RegistryEntry => ({
+	id: 'hr-test-skill',
+	name: 'hr-test-skill',
+	version: '1.0.0',
+	description: 'A test skill',
+	tier: 'full',
+	domain: 'onboarding-offboarding',
+	tags: [],
+	aliases: ['test-skill'],
+	capabilities: ['Testing basic capabilities'],
+	triggerPhrases: ['test this skill'],
+	paths: { content: true, prompts: true, examples: true },
+	dependencies: [],
+	relatedSkills: [],
+	...overrides,
+});
+
+const createMockRegistry = (skills: RegistryEntry[] = []): Registry => ({
+	schemaVersion: 1,
+	generatedAt: '2026-07-23',
+	skillCount: skills.length,
+	skills,
+});
+
+// ============================================================================
+// Intent Analysis Tests
+// ============================================================================
+
+describe('analyzeIntent', () => {
+	it('should extract single capability', () => {
+		const result = analyzeIntent('create an onboarding plan');
+		expect(result).toContain('create onboarding plan');
+	});
+
+	it('should extract multiple capabilities separated by commas', () => {
+		const result = analyzeIntent('create interview questions, write offer letters');
+		expect(result.length).toBe(2);
+		expect(result).toContain('create interview questions');
+		expect(result).toContain('write offer letters');
+	});
+
+	it('should extract capabilities separated by "and"', () => {
+		const result = analyzeIntent(
+			'develop succession planning and talent development',
+		);
+		expect(result.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('should normalize to lowercase', () => {
+		const result = analyzeIntent('CREATE ONBOARDING PLAN');
+		const first = result[0];
+		expect(first).toBeDefined();
+		expect(first).toBe(first?.toLowerCase());
+	});
+
+	it('should handle empty intent', () => {
+		expect(analyzeIntent('')).toEqual([]);
+		expect(analyzeIntent('   ')).toEqual([]);
+	});
+
+	it('should filter out filler words', () => {
+		const result = analyzeIntent('create an onboarding plan for the company');
+		const joined = result.join(' ');
+		expect(joined).not.toContain('an');
+		expect(joined).not.toContain('the');
+		expect(joined).not.toContain('for');
+	});
+});
+
+// ============================================================================
+// Execution Plan Generation Tests
+// ============================================================================
+
+describe('generateExecutionPlan', () => {
+	it('should handle empty intent', () => {
+		const registry = createMockRegistry();
+		const plan = generateExecutionPlan('', registry);
+
+		expect(plan.intent).toBe('');
+		expect(plan.requestedCapabilities).toHaveLength(0);
+		expect(plan.steps).toHaveLength(0);
+		expect(plan.summary).toContain('No intent');
+	});
+
+	it('should generate plan with matching capability', () => {
+		const skill = createMockSkill({
+			id: 'hr-onboarding',
+			capabilities: ['Creating onboarding plans'],
+		});
+		const registry = createMockRegistry([skill]);
+
+		const plan = generateExecutionPlan('create an onboarding plan', registry);
+
+		expect(plan.requestedCapabilities.length).toBeGreaterThan(0);
+		expect(plan.steps.length).toBeGreaterThan(0);
+		expect(plan.steps[0]?.skillId).toBe('hr-onboarding');
+	});
+
+	it('should mark unmatched capabilities', () => {
+		const registry = createMockRegistry([]);
+		const plan = generateExecutionPlan('create an onboarding plan', registry);
+
+		expect(plan.capabilityMatches.length).toBeGreaterThan(0);
+		const allUnmatched = plan.capabilityMatches.every((m) => !m.isMatched);
+		expect(allUnmatched).toBe(true);
+	});
+
+	it('should determine complexity based on step count', () => {
+		const skill = createMockSkill({ id: 'hr-onboarding' });
+		const registry = createMockRegistry([skill]);
+		const plan = generateExecutionPlan('create an onboarding plan', registry);
+
+		if (plan.steps.length <= 2) {
+			expect(plan.complexity).toBe('simple');
+		}
+	});
+
+	it('should include dependencies in steps', () => {
+		const dependent = createMockSkill({
+			id: 'hr-recruiting',
+			capabilities: ['Recruiting'],
+		});
+		const dependency = createMockSkill({
+			id: 'hr-job-description',
+			capabilities: ['Job descriptions'],
+		});
+
+		const tech = createMockSkill({
+			id: 'hr-backend',
+			domain: 'technical-hiring',
+			capabilities: ['Backend recruiting'],
+			dependencies: ['hr-recruiting'],
+		});
+
+		const registry = createMockRegistry([dependent, dependency, tech]);
+		const plan = generateExecutionPlan('recruit a backend engineer', registry);
+
+		// If backend skill is selected, recruiting should also be included
+		const skillIds = new Set(plan.steps.map((s) => s.skillId));
+		if (skillIds.has('hr-backend')) {
+			expect(skillIds.has('hr-recruiting')).toBe(true);
+		}
+	});
+
+	it('should set proper order fields', () => {
+		const skill = createMockSkill({ id: 'hr-test' });
+		const registry = createMockRegistry([skill]);
+		const plan = generateExecutionPlan('test this', registry);
+
+		if (plan.steps.length > 0) {
+			for (let i = 0; i < plan.steps.length; i++) {
+				expect(plan.steps[i]?.order).toBe(i);
+			}
+		}
+	});
+});
+
+// ============================================================================
+// Plan Validation Tests
+// ============================================================================
+
+describe('validateExecutionPlan', () => {
+	it('should validate a correct plan', () => {
+		const skill = createMockSkill({ id: 'hr-onboarding' });
+		const registry = createMockRegistry([skill]);
+		const plan: ExecutionPlan = {
+			intent: 'create onboarding',
+			requestedCapabilities: ['create onboarding'],
+			capabilityMatches: [
+				{
+					capability: 'create onboarding',
+					matches: [
+						{
+							skillId: 'hr-onboarding',
+							matchType: 'direct',
+							score: 1.0,
+							explanation: 'Direct match',
+						},
+					],
+					isMatched: true,
+				},
+			],
+			steps: [
+				{
+					skillId: 'hr-onboarding',
+					order: 0,
+					reason: 'direct-capability-match',
+					dependencies: [],
+				},
+			],
+			summary: 'Valid plan',
+			complexity: 'simple',
+		};
+
+		const result = validateExecutionPlan(plan, registry);
+		const errors = result.issues.filter((i) => i.severity === 'error');
+		expect(errors).toHaveLength(0);
+	});
+
+	it('should detect duplicate steps', () => {
+		const skill = createMockSkill({ id: 'hr-test' });
+		const registry = createMockRegistry([skill]);
+		const plan: ExecutionPlan = {
+			intent: 'test',
+			requestedCapabilities: [],
+			capabilityMatches: [],
+			steps: [
+				{
+					skillId: 'hr-test',
+					order: 0,
+					reason: 'direct-capability-match',
+					dependencies: [],
+				},
+				{
+					skillId: 'hr-test',
+					order: 1,
+					reason: 'direct-capability-match',
+					dependencies: [],
+				},
+			],
+			summary: 'Duplicate plan',
+			complexity: 'simple',
+		};
+
+		const result = validateExecutionPlan(plan, registry);
+		const duplicateIssues = result.issues.filter((i) => i.code === 'DUPLICATE_STEP');
+		expect(duplicateIssues.length).toBeGreaterThan(0);
+	});
+
+	it('should detect dangling skill references', () => {
+		const registry = createMockRegistry([]);
+		const plan: ExecutionPlan = {
+			intent: 'test',
+			requestedCapabilities: [],
+			capabilityMatches: [],
+			steps: [
+				{
+					skillId: 'hr-nonexistent',
+					order: 0,
+					reason: 'direct-capability-match',
+					dependencies: [],
+				},
+			],
+			summary: 'Invalid plan',
+			complexity: 'simple',
+		};
+
+		const result = validateExecutionPlan(plan, registry);
+		const danglingIssues = result.issues.filter(
+			(i) => i.code === 'DANGLING_SKILL_REFERENCE',
+		);
+		expect(danglingIssues.length).toBeGreaterThan(0);
+	});
+
+	it('should detect dependency order violations', () => {
+		const skill1 = createMockSkill({ id: 'hr-skill1' });
+		const skill2 = createMockSkill({
+			id: 'hr-skill2',
+			dependencies: ['hr-skill1'],
+		});
+		const registry = createMockRegistry([skill1, skill2]);
+
+		const plan: ExecutionPlan = {
+			intent: 'test',
+			requestedCapabilities: [],
+			capabilityMatches: [],
+			steps: [
+				// skill2 (depends on skill1) comes before skill1
+				{
+					skillId: 'hr-skill2',
+					order: 0,
+					reason: 'direct-capability-match',
+					dependencies: ['hr-skill1'],
+				},
+				{
+					skillId: 'hr-skill1',
+					order: 1,
+					reason: 'direct-capability-match',
+					dependencies: [],
+				},
+			],
+			summary: 'Order violation',
+			complexity: 'simple',
+		};
+
+		const result = validateExecutionPlan(plan, registry);
+		const orderIssues = result.issues.filter(
+			(i) => i.code === 'DEPENDENCY_ORDER_VIOLATION',
+		);
+		expect(orderIssues.length).toBeGreaterThan(0);
+	});
+
+	it('should warn on empty plan', () => {
+		const registry = createMockRegistry([]);
+		const plan: ExecutionPlan = {
+			intent: 'test',
+			requestedCapabilities: [],
+			capabilityMatches: [],
+			steps: [],
+			summary: 'Empty plan',
+			complexity: 'simple',
+		};
+
+		const result = validateExecutionPlan(plan, registry);
+		const emptyIssues = result.issues.filter((i) => i.code === 'EMPTY_PLAN');
+		expect(emptyIssues.length).toBeGreaterThan(0);
+	});
+});
+
+// ============================================================================
+// Planner Improvements Tests
+// ============================================================================
+
+describe('suggestPlanImprovements', () => {
+	it('should suggest on empty plan', () => {
+		const registry = createMockRegistry([]);
+		const plan: ExecutionPlan = {
+			intent: 'test',
+			requestedCapabilities: [],
+			capabilityMatches: [],
+			steps: [],
+			summary: 'Empty',
+			complexity: 'simple',
+		};
+
+		const suggestions = suggestPlanImprovements(plan, registry);
+		expect(suggestions.length).toBeGreaterThan(0);
+	});
+
+	it('should suggest on complex plan', () => {
+		const skills = Array.from({ length: 10 }).map((_, i) =>
+			createMockSkill({ id: `hr-skill-${i}` }),
+		);
+		const registry = createMockRegistry(skills);
+
+		const plan: ExecutionPlan = {
+			intent: 'complex request',
+			requestedCapabilities: Array.from(
+				{ length: 10 },
+				(_, i) => `capability-${i}`,
+			),
+			capabilityMatches: Array.from({ length: 10 }, (_, i) => ({
+				capability: `capability-${i}`,
+				matches: [
+					{
+						skillId: `hr-skill-${i}`,
+						matchType: 'direct',
+						score: 1.0,
+						explanation: 'Match',
+					},
+				],
+				isMatched: true,
+			})),
+			steps: Array.from({ length: 10 }, (_, i) => ({
+				skillId: `hr-skill-${i}`,
+				order: i,
+				reason: 'direct-capability-match' as const,
+				dependencies: [],
+			})),
+			summary: 'Complex plan',
+			complexity: 'complex',
+		};
+
+		const suggestions = suggestPlanImprovements(plan, registry);
+		const complexSuggestions = suggestions.filter((s) => s.includes('complex'));
+		expect(complexSuggestions.length).toBeGreaterThan(0);
+	});
+});

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -33,6 +33,10 @@
 		"registry": {
 			"cache": false,
 			"outputs": ["registry/skills.json"]
+		},
+		"plan": {
+			"cache": false,
+			"outputs": ["execution-plan.json"]
 		}
 	}
 }


### PR DESCRIPTION
Introduces a deterministic Skill Planner built on top of the Skill Registry (Phase 4.1). The planner transforms user intent into an explainable, dependency-aware execution plan without executing any skills itself.

## Architecture

The planner operates as a pure pipeline with no side effects:

  User Intent
    -> analyzeIntent()         -- extract capabilities from natural language
    -> matchCapability()       -- Jaccard similarity scoring against registry
    -> selectSkills()          -- greedy top-match + recursive dependencies
    -> topologicalSort()       -- Kahn's algorithm, dependencies first
    -> validateExecutionPlan() -- 8 checks, circular dep detection (DFS)
    -> ExecutionPlan

## New files

- packages/hr-skills-build/src/planner.ts Core planner: intent analysis, capability matching, skill selection, dependency ordering, execution plan generation.

- packages/hr-skills-build/src/validate-planner.ts Plan validation (DUPLICATE_STEP, DANGLING_SKILL_REFERENCE, MISSING_DEPENDENCY, DEPENDENCY_ORDER_VIOLATION, CIRCULAR_DEPENDENCY, ORDER_FIELD_INCONSISTENT, UNMATCHED_CAPABILITIES, EMPTY_PLAN) and improvement suggestions.

- packages/hr-skills-build/src/generate-plan.ts CLI entry point: bun run plan "<intent>" Outputs capability matches, ordered steps, validation, suggestions, and writes execution-plan.json.

- packages/hr-skills-build/test/planner.test.ts Unit tests: intent analysis, capability matching, plan generation, validation, improvement suggestions.

- packages/hr-skills-build/test/planner-integration.test.ts Integration tests against the real Skill Registry: HR scenarios, determinism, dependency ordering, edge cases.

- docs/planner.md Architecture guide, algorithm explanations, API reference, CLI and programmatic usage, extension guidelines, future improvements.

## Modified files

- packages/hr-skills-build/package.json -- add plan script
- package.json -- add plan script (turbo filter)
- turbo.jsonc -- add plan task (cache: false)
- AGENTS.md -- document bun run plan command
- docs/ROADMAP.md -- mark Phase 4.2 complete, link docs/planner.md

## Design principles

- Registry-first: consumes only registry/skills.json, never SKILL.md
- Pure functions: no side effects, fully deterministic
- Explainable: every ExecutionStep carries a SelectionReason
- Separated: planner decides what; runtime (Phase 4.3) executes how
- Minimal: simple heuristics (Jaccard) over ML or black-box scoring