### PR TITLE
feat(hr-skills-build): implement phase 4.3 workflow runtime

### DIFF
--- a/.changeset/workflow-runtime-foundation.md
+++ b/.changeset/workflow-runtime-foundation.md
@@ -1,0 +1,5 @@
+---
+"hr-skills-build": minor
+---
+
+Added Phase 4.3 workflow runtime that deterministically executes execution plans produced by the skill planner. This introduces a WorkflowExecutor with context propagation between steps, configurable retry policies, structured failure handling, execution events, and execution tracing, plus a new `bun run execute` CLI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ bun run validate     # Validate all skill SKILL.md files
 bun run matrix       # Generate docs/skill-matrix.md — snapshot of every skill's maturity tier
 bun run registry     # Generate registry/skills.json — machine-readable skill registry (see docs/registry.md)
 bun run plan "<intent>"  # Generate execution plan for a user intent (see docs/planner.md)
+bun run execute "<intent>"  # Generate a plan and run it through the Workflow Runtime (see docs/runtime.md)
 bun run test         # Run tests across workspace packages
 bun run typecheck    # Run type-checking across workspace packages
 bun run build        # Run all workspace build tasks through Turborepo

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -251,13 +251,29 @@ See [`docs/planner.md`](planner.md) for detailed architecture and usage.
 
 Build a deterministic runtime responsible for executing workflow plans.
 
-* Execution engine
-* Workflow state management
-* Context propagation
-* Retry and failure handling
-* Execution events
-* Execution tracing
-* Deterministic workflow execution
+> Implemented — see [docs/runtime.md](runtime.md) for the architecture,
+> execution lifecycle, and extension points.
+
+Completed:
+
+* Execution engine (`WorkflowExecutor` / `executeWorkflow`) — consumes Planner
+  output directly, executes steps in plan order
+* Workflow state management — pending/running/completed/failed/skipped
+  tracking via `RuntimeStateTracker`
+* Context propagation — explicit `RuntimeContext` threading step outputs
+  between steps
+* Retry handling — pluggable `RetryPolicy` (`noRetryPolicy`,
+  `fixedRetryPolicy`, `exponentialRetryPolicy`), deterministic (no real
+  waiting)
+* Failure handling — structured, JSON-serializable `RuntimeError`;
+  dependency-aware skipping of downstream steps
+* Execution events — `EventDispatcher` with a logical clock for deterministic
+  event ordering
+* Execution tracing — `TraceCollector` pairing each event with a state
+  snapshot
+* CLI tool (`bun run execute`) — generate a plan and run it through the
+  Runtime with a stub step executor
+* Comprehensive documentation and tests
 
 #### 4.4 Quality & Evaluation
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,237 @@
+# Workflow Runtime
+
+> Phase 4.3 of the [roadmap](ROADMAP.md) — deterministic execution of plans produced by the [Skill Planner](planner.md).
+
+## What it is
+
+The Workflow Runtime **executes** an `ExecutionPlan` (see [`docs/planner.md`](planner.md)) that the Planner already produced. It is responsible for:
+
+- Running workflow steps in the order the Planner already computed
+- Propagating context (each step's output) to later steps
+- Tracking execution state (pending, running, completed, failed, skipped)
+- Retrying failed steps according to a configurable policy
+- Handling failures cleanly, including skipping downstream dependents
+- Emitting execution events
+- Producing a deterministic execution trace for debugging
+
+The Runtime is **NOT** responsible for:
+
+- Intent analysis
+- Capability matching
+- Skill discovery
+- Workflow planning
+
+Those belong to the Skill Planner (Phase 4.2). The Runtime begins only after a validated `ExecutionPlan` exists.
+
+The Runtime is also deliberately agnostic about **what a step does**. It does not invoke skills, call a model, or run tools itself — callers supply a `StepExecutorFn` that performs the real work. This keeps the Runtime a pure sequencing and state-management engine, independent of any particular execution backend, which is what makes it deterministic and easy to unit test with a stub executor.
+
+## Architecture
+
+```text
+ExecutionPlan (from Planner)
+        |
+        v
+  WorkflowExecutor.run(plan, executeStep)
+        |
+        |-- RuntimeStateTracker   (pending / running / completed / failed / skipped)
+        |-- RuntimeContext        (context propagation between steps)
+        |-- RetryPolicy           (deterministic retry behavior)
+        |-- EventDispatcher       (execution events, logical clock)
+        |-- TraceCollector        (execution trace: event + state snapshot)
+        |
+        v
+   WorkflowResult (status, outputs, steps, events, trace, state)
+```
+
+| Component | File | Responsibility |
+|---|---|---|
+| `WorkflowExecutor` / `executeWorkflow` | `runtime.ts` | Orchestrates a single plan run: iterates steps, applies retries, decides skip/stop behavior, assembles the final result. |
+| `RuntimeContext` | `runtime-context.ts` | Explicit, mutable store of step outputs keyed by skill ID — how later steps read earlier steps' results. |
+| `RuntimeStateTracker` | `runtime-state.ts` | Tracks which bucket (pending/running/completed/failed/skipped) each skill ID is currently in. |
+| `RetryPolicy` | `runtime-retry.ts` | Decides how many times to retry a failed step and what logical delay to record. Ships with `noRetryPolicy`, `fixedRetryPolicy`, and `exponentialRetryPolicy`. |
+| `EventDispatcher` | `runtime-events.ts` | Assigns each event a monotonically increasing logical `order` and notifies an optional `onEvent` callback. |
+| `TraceCollector` | `runtime-trace.ts` | Pairs each event with a state snapshot to build the execution trace. |
+| `RuntimeError` | `runtime-errors.ts` | Structured, JSON-serializable failure information (code, skill ID, attempt, cause). |
+
+All shared type definitions (`RuntimeContext`, `RuntimeStateSnapshot`, `RuntimeEvent`, `TraceEntry`, `WorkflowResult`, and so on) live in `src/types.ts`, alongside the Planner's types, to keep the shared interfaces used across the Planner, Runtime, and their tests in one place.
+
+## Execution lifecycle
+
+For a plan with steps `[s1, s2, s3, ...]` (already topologically ordered by the Planner):
+
+1. `workflow-started` is emitted.
+2. For each step, in plan order:
+   - If any of its `dependencies` are in the `failed` or `skipped` bucket, the step is marked `skipped` (a `step-skipped` event is emitted) and the Runtime moves to the next step.
+   - Otherwise the step is marked `running` (`step-started` is emitted) and executed via `executeStep(step, context)`.
+     - On success: the output is written to the `RuntimeContext`, the step is marked `completed`, and `step-completed` is emitted.
+     - On failure: the `RetryPolicy` is consulted. If a retry is allowed, `step-retry` is emitted and the step runs again. Once retries are exhausted (or `shouldRetry` declines), the step is marked `failed`, a `RuntimeError` is built, and `step-failed` is emitted.
+   - If the step failed and `stopOnFailure` is `true` (the default), every remaining `pending` step is marked `skipped` and the loop ends.
+3. `workflow-completed` is emitted if no step failed, otherwise `workflow-failed`.
+
+The Runtime never reorders steps — ordering is entirely the Planner's responsibility (topological sort over dependencies). The Runtime only decides, for the order it's given, whether each step runs, retries, or is skipped.
+
+## Execution model
+
+`executeWorkflow` is the primary entry point:
+
+```typescript
+import { executeWorkflow } from './runtime.js';
+import { generateExecutionPlan } from './planner.js';
+import { buildRegistry } from './registry.js';
+
+const registry = await buildRegistry();
+const plan = generateExecutionPlan('create an onboarding plan', registry);
+
+const result = await executeWorkflow(plan, async (step, context) => {
+  // Perform the actual work for this step — load the skill, call a model,
+  // run a tool, etc. `context.get(id)` reads any previous step's output.
+  return await runSkill(step.skillId, context.toObject());
+});
+
+console.log(result.status);   // 'completed' | 'failed'
+console.log(result.outputs);  // { [skillId]: output }
+console.log(result.steps);    // per-step StepResult[]
+console.log(result.events);   // RuntimeEvent[]
+console.log(result.trace);    // TraceEntry[]
+```
+
+For more control (custom retry policy, live event handling, or reusing the same configuration across multiple plans), use the `WorkflowExecutor` class directly:
+
+```typescript
+import { WorkflowExecutor } from './runtime.js';
+import { exponentialRetryPolicy } from './runtime-retry.js';
+
+const executor = new WorkflowExecutor({
+  retryPolicy: exponentialRetryPolicy({ maxRetries: 3, baseDelayMs: 100 }),
+  onEvent: (event) => console.log(event.order, event.type, event.skillId),
+  stopOnFailure: false,
+});
+
+const result = await executor.run(plan, executeStep);
+```
+
+## State management
+
+`RuntimeStateTracker` maintains five disjoint buckets — `pending`, `running`, `completed`, `failed`, `skipped` — that always partition the full set of skill IDs in the plan. A skill ID moves through exactly one path:
+
+```text
+pending -> running -> completed
+pending -> running -> failed
+pending -> skipped   (dependency failed/skipped, or a prior step failed with stopOnFailure)
+```
+
+`WorkflowResult.state` is a plain-object snapshot (`RuntimeStateSnapshot`) of the final buckets. Intermediate snapshots are also captured in the trace (see below), so the full history of state transitions is recoverable even though the tracker itself is mutable and internal to a single run.
+
+The bucket model is intentionally simple so it's easy to extend — for example, a future `blocked` bucket for steps waiting on an external resource would only require adding one more `Set` and one more transition method.
+
+## Context propagation
+
+`RuntimeContext` is created once per run (`createRuntimeContext(plan.intent)`) and passed to every step's executor call:
+
+- `context.get(skillId)` — read a previous step's output, or `undefined` if it hasn't produced one.
+- `context.set(skillId, value)` — record a step's output (the Runtime calls this automatically after a successful step; step executors don't need to call it themselves).
+- `context.has(skillId)` — check whether a skill has produced output yet.
+- `context.toObject()` — a plain-object snapshot of every recorded output, keyed by skill ID.
+- `context.intent` — the plan's original intent string, for step executors that want it.
+
+Context is explicit and passed by reference through the call chain — there is no global or module-level state — which keeps propagation easy to reason about and makes the Runtime safe to run concurrently for independent plans.
+
+## Retry handling
+
+A `RetryPolicy` has:
+
+```typescript
+interface RetryPolicy {
+  readonly maxRetries: number;
+  delayForAttempt(attempt: number): number; // logical delay in ms, 1-indexed attempt
+  shouldRetry?(error: unknown, attempt: number): boolean; // optional, defaults to always retry
+}
+```
+
+Three built-in policies (`runtime-retry.ts`):
+
+| Policy | Behavior |
+|---|---|
+| `noRetryPolicy()` | `maxRetries: 0` — fail on the first error. This is the default when no policy is supplied. |
+| `fixedRetryPolicy({ maxRetries, delayMs? })` | Retries up to `maxRetries` times with a constant logical delay. |
+| `exponentialRetryPolicy({ maxRetries, baseDelayMs?, maxDelayMs? })` | Retries with `delay = baseDelayMs * 2^(attempt - 1)`, capped at `maxDelayMs`. |
+
+**The Runtime never actually sleeps.** `delayForAttempt` returns a number that's recorded on the `step-retry` event and trace entry — real waiting would make execution non-deterministic and slow down tests. Callers that need real backoff (for example, a step executor calling a rate-limited API) can read the recorded delay and implement their own wait inside the `StepExecutorFn`, or wrap the Runtime with their own scheduler.
+
+`shouldRetry(error, attempt)` lets a policy decline to retry specific errors (for example, a validation error that will never succeed on retry) even if `maxRetries` hasn't been reached.
+
+## Failure handling
+
+When a step exhausts its retries, the Runtime builds a `RuntimeError` (`runtime-errors.ts`) with:
+
+- `code` — currently `STEP_EXECUTION_FAILED` (reserved: `STEP_DEPENDENCY_FAILED`, `STEP_DEPENDENCY_SKIPPED` for future use by callers that want to raise those explicitly)
+- `skillId` — which step failed
+- `attempt` — which attempt it failed on
+- `cause` — a normalized, human-readable description of whatever the step executor threw (works for `Error` instances, strings, and arbitrary thrown values)
+
+`RuntimeError.toInfo()` converts this into a plain `RuntimeErrorInfo` object, which is what actually appears on `StepResult.error` and `TraceEntry.error` — this keeps `WorkflowResult` fully JSON-serializable (an `Error` instance would not survive `JSON.stringify`/`JSON.parse`).
+
+By default (`stopOnFailure: true`), a step failure halts the workflow: every remaining pending step is marked `skipped`. With `stopOnFailure: false`, only steps that depend (directly or transitively, since a skipped step also blocks its own dependents) on the failed step are skipped — independent steps still run to completion.
+
+## Execution events
+
+Every event (`RuntimeEvent`) has a monotonically increasing `order` (a logical clock assigned by `EventDispatcher`), not a wall-clock timestamp — this is what makes two runs of the same plan against the same executor produce identical event streams.
+
+| Event type | When |
+|---|---|
+| `workflow-started` | Once, before the first step. |
+| `step-started` | Before a step's first attempt. |
+| `step-retry` | After a failed attempt that will be retried. |
+| `step-completed` | After a step succeeds. |
+| `step-failed` | After a step exhausts its retries. |
+| `step-skipped` | When a step is skipped (dependency failed/skipped, or the workflow stopped early). |
+| `workflow-completed` | Once, if no step failed. |
+| `workflow-failed` | Once, if any step failed. |
+
+Pass `onEvent` in `RuntimeOptions` to observe events as they happen (for progress UIs, logging, and so on); `WorkflowResult.events` also contains the full ordered list after the run finishes.
+
+## Execution tracing
+
+`WorkflowResult.trace` is an array of `TraceEntry`, one per event, each carrying:
+
+- `order`, `type`, `skillId?`, `attempt?` — mirrors the corresponding event
+- `state` — a full `RuntimeStateSnapshot` immediately after that event was applied
+- `result?` — the step's output, present on `step-completed` entries
+- `error?` — the structured `RuntimeErrorInfo`, present on `step-failed` entries
+
+Because entries are keyed off the same logical clock as events, and because `Set` iteration in `RuntimeStateTracker` preserves insertion order, a trace is fully deterministic and reproducible: replaying it reconstructs exactly what happened, in what order, without needing wall-clock timestamps.
+
+## Extension points
+
+- **New retry strategies** — implement the `RetryPolicy` interface (`runtime-retry.ts`) and pass it via `RuntimeOptions.retryPolicy`. No changes to `runtime.ts` are needed.
+- **New state buckets** — add a bucket to `RuntimeStateTracker` (`runtime-state.ts`) and a transition method; `RuntimeStateSnapshot` in `types.ts` would need the matching field.
+- **New event/trace consumers** — subscribe via `RuntimeOptions.onEvent`, or post-process `WorkflowResult.trace`/`.events` after a run. Both are plain data, so they work equally well for logging, persistence, or replay tooling.
+- **Real step execution** — implement a `StepExecutorFn` that loads a skill's `SKILL.md`, builds a prompt from `context`, calls a model, and returns its output. `src/execute-plan.ts` ships a stub executor as a CLI demonstration; production integrations should replace it.
+
+## CLI
+
+```bash
+bun run execute "<user intent>"
+```
+
+Generates a plan for the given intent via the Planner, runs it through the Runtime using a stub step executor (for demonstration — it does not call a model), prints step results and events, and writes the full `WorkflowResult` to `execution-result.json`.
+
+## Testing
+
+`test/runtime.test.ts` covers:
+
+- Successful execution and exact step ordering
+- Deterministic output across repeated runs of the same plan
+- Context propagation between steps, including `context.toObject()` and `context.intent`
+- Retry behavior: eventual success, exhausted retries, no-retry default, `shouldRetry`, and deterministic backoff values
+- Failure handling: default stop-on-failure, dependency-based skipping with `stopOnFailure: false`, and structured/serializable errors
+- State transitions and the final state snapshot
+- Event ordering, the `onEvent` callback, and `workflow-failed` vs `workflow-completed`
+- Trace generation, including recorded results/errors and state-at-event correctness
+- The `WorkflowExecutor` class with async step executors, and an empty-plan edge case
+
+Run with:
+
+```bash
+bun run test
+```

--- a/packages/hr-skills-build/package.json
+++ b/packages/hr-skills-build/package.json
@@ -27,6 +27,7 @@
 		"matrix": "bun src/generate-skill-matrix.ts",
 		"registry": "bun src/generate-registry.ts",
 		"plan": "bun src/generate-plan.ts",
+		"execute": "bun src/execute-plan.ts",
 		"test": "bun test",
 		"dev": "bun --watch src/validate.ts",
 		"typecheck": "tsc --noEmit"

--- a/packages/hr-skills-build/src/execute-plan.ts
+++ b/packages/hr-skills-build/src/execute-plan.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+
+/**
+ * CLI: Generate an execution plan for a given intent and run it through the
+ * Workflow Runtime (Phase 4.3).
+ *
+ * This CLI uses a stub step executor — it does not call any model or invoke
+ * real skill content. Its purpose is to demonstrate and smoke-test the
+ * Runtime's sequencing, context propagation, retries, events, and tracing
+ * against a real plan produced by the Planner. Callers embedding the Runtime
+ * in an actual agent should supply their own `StepExecutorFn`.
+ *
+ * Usage:
+ *   bun src/execute-plan.ts "create an onboarding checklist"
+ *   bun src/execute-plan.ts "help with succession planning and talent development"
+ */
+
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as p from '@clack/prompts';
+import { generateExecutionPlan } from './planner.js';
+import { buildRegistry } from './registry.js';
+import { executeWorkflow } from './runtime.js';
+import type { ExecutionStep, RuntimeContext } from './types.js';
+
+/**
+ * A stub step executor for CLI demonstration purposes. Real integrations
+ * should replace this with logic that actually invokes the skill (for
+ * example, loading its SKILL.md and prompting a model).
+ */
+const stubStepExecutor = (step: ExecutionStep, context: RuntimeContext): unknown => {
+	return {
+		skillId: step.skillId,
+		note: `Stub output for ${step.skillId}`,
+		precedingSteps: Object.keys(context.toObject()),
+	};
+};
+
+async function main() {
+	const intent = process.argv[2];
+
+	if (!intent) {
+		p.log.error('Usage: bun src/execute-plan.ts "<user intent>"');
+		p.log.info('Example:');
+		p.log.message(
+			'  bun src/execute-plan.ts "Create interview questions for a senior manager"',
+		);
+		process.exit(1);
+	}
+
+	p.intro('Workflow Runtime');
+
+	const spinner = p.spinner();
+
+	spinner.start('Building Skill Registry...');
+	const registry = await buildRegistry();
+	spinner.stop(`Registry ready (${registry.skillCount} skills)`);
+
+	spinner.start(`Generating plan for: "${intent}"`);
+	const plan = generateExecutionPlan(intent, registry);
+	spinner.stop(
+		`Plan generated (${plan.steps.length} step${plan.steps.length === 1 ? '' : 's'})`,
+	);
+
+	if (plan.steps.length === 0) {
+		p.log.warn('Plan has no steps — nothing to execute.');
+		p.outro('Done');
+		process.exit(0);
+	}
+
+	spinner.start('Executing workflow...');
+	const result = await executeWorkflow(plan, stubStepExecutor);
+	spinner.stop(`Execution ${result.status}`);
+
+	p.note(
+		result.steps
+			.map((step) => {
+				const icon =
+					step.status === 'completed'
+						? '✓'
+						: step.status === 'failed'
+							? '✗'
+							: '○';
+				return `${icon} [${step.status}] ${step.skillId} (attempts: ${step.attempts})`;
+			})
+			.join('\n'),
+		'STEP RESULTS',
+	);
+
+	p.note(
+		result.events
+			.map(
+				(event) =>
+					`[${event.order}] ${event.type}${event.skillId ? ` — ${event.skillId}` : ''}`,
+			)
+			.join('\n'),
+		'EVENTS',
+	);
+
+	const outputPath = join(process.cwd(), 'execution-result.json');
+	writeFileSync(outputPath, JSON.stringify(result, null, 2));
+	p.log.success(`Execution result saved to: ${outputPath}`);
+
+	p.outro(result.status === 'completed' ? 'Done' : 'Completed with failures');
+
+	process.exit(result.status === 'completed' ? 0 : 1);
+}
+
+main().catch((err) => {
+	p.log.error(`Error: ${err.message}`);
+	process.exit(1);
+});

--- a/packages/hr-skills-build/src/runtime-context.ts
+++ b/packages/hr-skills-build/src/runtime-context.ts
@@ -1,0 +1,41 @@
+/**
+ * Runtime context propagation — Phase 4.3.
+ *
+ * `RuntimeContextImpl` is the concrete, mutable implementation of the
+ * `RuntimeContext` interface. It's a thin wrapper over a `Map` keyed by
+ * skill ID, deliberately explicit rather than relying on closures or
+ * module-level state, so context threading stays easy to reason about and
+ * to unit test in isolation from the executor.
+ */
+
+import type { RuntimeContext } from './types.js';
+
+class RuntimeContextImpl implements RuntimeContext {
+	readonly intent: string;
+	private readonly outputs = new Map<string, unknown>();
+
+	constructor(intent: string) {
+		this.intent = intent;
+	}
+
+	get(skillId: string): unknown {
+		return this.outputs.get(skillId);
+	}
+
+	set(skillId: string, value: unknown): void {
+		this.outputs.set(skillId, value);
+	}
+
+	has(skillId: string): boolean {
+		return this.outputs.has(skillId);
+	}
+
+	toObject(): Record<string, unknown> {
+		return Object.fromEntries(this.outputs);
+	}
+}
+
+/** Create a fresh, empty runtime context for the given plan intent. */
+export function createRuntimeContext(intent: string): RuntimeContext {
+	return new RuntimeContextImpl(intent);
+}

--- a/packages/hr-skills-build/src/runtime-errors.ts
+++ b/packages/hr-skills-build/src/runtime-errors.ts
@@ -1,0 +1,62 @@
+/**
+ * Structured runtime errors — Phase 4.3.
+ *
+ * A `RuntimeError` wraps whatever a step executor threw with the context
+ * needed to produce a useful diagnostic: which skill failed, which attempt
+ * it was, and a machine-readable code for programmatic handling.
+ */
+
+import type { RuntimeErrorInfo } from './types.js';
+
+export type RuntimeErrorCode =
+	| 'STEP_EXECUTION_FAILED'
+	| 'STEP_DEPENDENCY_FAILED'
+	| 'STEP_DEPENDENCY_SKIPPED';
+
+export class RuntimeError extends Error {
+	readonly code: RuntimeErrorCode;
+	readonly skillId: string;
+	readonly attempt: number;
+	override readonly cause?: unknown;
+
+	constructor(
+		code: RuntimeErrorCode,
+		message: string,
+		options: { skillId: string; attempt: number; cause?: unknown },
+	) {
+		super(message);
+		this.name = 'RuntimeError';
+		this.code = code;
+		this.skillId = options.skillId;
+		this.attempt = options.attempt;
+		this.cause = options.cause;
+	}
+
+	/** Convert to a plain, JSON-serializable shape for traces and results. */
+	toInfo(): RuntimeErrorInfo {
+		const info: RuntimeErrorInfo = {
+			code: this.code,
+			message: this.message,
+			skillId: this.skillId,
+			attempt: this.attempt,
+		};
+		if (this.cause !== undefined) {
+			info.cause = describeCause(this.cause);
+		}
+		return info;
+	}
+}
+
+/**
+ * Normalize an unknown thrown value (from a step executor) into a
+ * human-readable message, without assuming it's an `Error` instance.
+ */
+export function describeCause(cause: unknown): string {
+	if (cause instanceof Error) return cause.message;
+	if (typeof cause === 'string') return cause;
+	try {
+		return JSON.stringify(cause);
+	} catch {
+		return String(cause);
+	}
+}

--- a/packages/hr-skills-build/src/runtime-events.ts
+++ b/packages/hr-skills-build/src/runtime-events.ts
@@ -1,0 +1,44 @@
+/**
+ * Execution events — Phase 4.3.
+ *
+ * `EventDispatcher` assigns each event a monotonically increasing `order`
+ * (a logical clock) instead of a wall-clock timestamp. Two runs of the same
+ * plan against the same step executor therefore produce byte-identical
+ * event streams, which is what "deterministic execution" means in
+ * practice — timestamps would make every run different even when nothing
+ * about the outcome changed.
+ */
+
+import type { RuntimeEvent, RuntimeEventType } from './types.js';
+
+export class EventDispatcher {
+	private readonly events: RuntimeEvent[] = [];
+	private nextOrder = 0;
+	private readonly onEvent: ((event: RuntimeEvent) => void) | undefined;
+
+	constructor(onEvent?: (event: RuntimeEvent) => void) {
+		this.onEvent = onEvent;
+	}
+
+	emit(
+		type: RuntimeEventType,
+		details: {
+			skillId?: string;
+			attempt?: number;
+			data?: Record<string, unknown>;
+		} = {},
+	): RuntimeEvent {
+		const event: RuntimeEvent = { order: this.nextOrder++, type };
+		if (details.skillId !== undefined) event.skillId = details.skillId;
+		if (details.attempt !== undefined) event.attempt = details.attempt;
+		if (details.data !== undefined) event.data = details.data;
+
+		this.events.push(event);
+		this.onEvent?.(event);
+		return event;
+	}
+
+	all(): RuntimeEvent[] {
+		return [...this.events];
+	}
+}

--- a/packages/hr-skills-build/src/runtime-retry.ts
+++ b/packages/hr-skills-build/src/runtime-retry.ts
@@ -1,0 +1,47 @@
+/**
+ * Retry policies — Phase 4.3.
+ *
+ * Policies decide how many times a failed step should be retried and what
+ * logical delay to record for each attempt. The runtime never actually
+ * waits for the returned delay — real waiting would make execution
+ * non-deterministic and slow down tests — but the value is still useful for
+ * a caller that wants to honor it (for example, a step executor calling a
+ * real API might read `context` or a wrapping scheduler might sleep).
+ */
+
+import type { RetryPolicy } from './types.js';
+
+/** No retries: fail immediately on the first error. */
+export function noRetryPolicy(): RetryPolicy {
+	return {
+		maxRetries: 0,
+		delayForAttempt: () => 0,
+	};
+}
+
+/** Retry a fixed number of times with a constant logical delay. */
+export function fixedRetryPolicy(options: {
+	maxRetries: number;
+	delayMs?: number;
+}): RetryPolicy {
+	const delayMs = options.delayMs ?? 0;
+	return {
+		maxRetries: options.maxRetries,
+		delayForAttempt: () => delayMs,
+	};
+}
+
+/** Retry with exponential backoff: delay = baseDelayMs * 2^(attempt - 1). */
+export function exponentialRetryPolicy(options: {
+	maxRetries: number;
+	baseDelayMs?: number;
+	maxDelayMs?: number;
+}): RetryPolicy {
+	const baseDelayMs = options.baseDelayMs ?? 100;
+	const maxDelayMs = options.maxDelayMs ?? Number.POSITIVE_INFINITY;
+	return {
+		maxRetries: options.maxRetries,
+		delayForAttempt: (attempt: number) =>
+			Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs),
+	};
+}

--- a/packages/hr-skills-build/src/runtime-state.ts
+++ b/packages/hr-skills-build/src/runtime-state.ts
@@ -1,0 +1,85 @@
+/**
+ * Execution state management — Phase 4.3.
+ *
+ * `RuntimeStateTracker` is the single source of truth for where each skill
+ * ID currently sits in its lifecycle (`pending -> running -> completed |
+ * failed | skipped`). Every mutation moves an ID out of exactly one bucket
+ * and into exactly one other, so the buckets always partition the full set
+ * of skill IDs in the plan — a skill can never be "lost" or double-counted.
+ *
+ * The tracker is intentionally dumb: it doesn't know about retries, events,
+ * or execution order. It only tracks membership, which keeps it easy to
+ * extend with future buckets (e.g. 'blocked') without touching the executor.
+ */
+
+import type { RuntimeStateSnapshot, StepStatus } from './types.js';
+
+export class RuntimeStateTracker {
+	private readonly pending = new Set<string>();
+	private readonly running = new Set<string>();
+	private readonly completed = new Set<string>();
+	private readonly failed = new Set<string>();
+	private readonly skipped = new Set<string>();
+
+	private readonly buckets: Record<StepStatus, Set<string>>;
+
+	constructor(skillIds: readonly string[]) {
+		this.buckets = {
+			pending: this.pending,
+			running: this.running,
+			completed: this.completed,
+			failed: this.failed,
+			skipped: this.skipped,
+		};
+		for (const id of skillIds) {
+			this.pending.add(id);
+		}
+	}
+
+	statusOf(skillId: string): StepStatus | undefined {
+		for (const [status, bucket] of Object.entries(this.buckets) as Array<
+			[StepStatus, Set<string>]
+		>) {
+			if (bucket.has(skillId)) return status;
+		}
+		return undefined;
+	}
+
+	/** Move a skill ID from its current bucket into `next`. */
+	private transition(skillId: string, next: StepStatus): void {
+		for (const bucket of Object.values(this.buckets)) {
+			bucket.delete(skillId);
+		}
+		this.buckets[next].add(skillId);
+	}
+
+	start(skillId: string): void {
+		this.transition(skillId, 'running');
+	}
+
+	complete(skillId: string): void {
+		this.transition(skillId, 'completed');
+	}
+
+	fail(skillId: string): void {
+		this.transition(skillId, 'failed');
+	}
+
+	skip(skillId: string): void {
+		this.transition(skillId, 'skipped');
+	}
+
+	isPending(skillId: string): boolean {
+		return this.pending.has(skillId);
+	}
+
+	snapshot(): RuntimeStateSnapshot {
+		return {
+			pending: Array.from(this.pending).sort(),
+			running: Array.from(this.running).sort(),
+			completed: Array.from(this.completed),
+			failed: Array.from(this.failed),
+			skipped: Array.from(this.skipped),
+		};
+	}
+}

--- a/packages/hr-skills-build/src/runtime-trace.ts
+++ b/packages/hr-skills-build/src/runtime-trace.ts
@@ -1,0 +1,44 @@
+/**
+ * Execution tracing — Phase 4.3.
+ *
+ * `TraceCollector` builds the debugging artifact for a workflow run: one
+ * `TraceEntry` per event, each carrying a snapshot of runtime state
+ * immediately after that event was applied. Replaying a trace in order
+ * reconstructs the entire execution — which steps ran, in what order, what
+ * they returned, what failed, and how many retries occurred — without
+ * needing to re-run anything.
+ */
+
+import type {
+	RuntimeErrorInfo,
+	RuntimeEvent,
+	RuntimeStateSnapshot,
+	TraceEntry,
+} from './types.js';
+
+export class TraceCollector {
+	private readonly entries: TraceEntry[] = [];
+
+	record(
+		event: RuntimeEvent,
+		state: RuntimeStateSnapshot,
+		extras: { result?: unknown; error?: RuntimeErrorInfo } = {},
+	): TraceEntry {
+		const entry: TraceEntry = {
+			order: event.order,
+			type: event.type,
+			state,
+		};
+		if (event.skillId !== undefined) entry.skillId = event.skillId;
+		if (event.attempt !== undefined) entry.attempt = event.attempt;
+		if (extras.result !== undefined) entry.result = extras.result;
+		if (extras.error !== undefined) entry.error = extras.error;
+
+		this.entries.push(entry);
+		return entry;
+	}
+
+	all(): TraceEntry[] {
+		return [...this.entries];
+	}
+}

--- a/packages/hr-skills-build/src/runtime.ts
+++ b/packages/hr-skills-build/src/runtime.ts
@@ -1,0 +1,271 @@
+/**
+ * Deterministic Workflow Runtime — Phase 4.3
+ *
+ * The Workflow Runtime executes an `ExecutionPlan` produced by the Skill
+ * Planner (Phase 4.2). It is responsible for:
+ *
+ *  - Executing workflow steps in the order the Planner already computed
+ *  - Propagating context (step outputs) between steps
+ *  - Tracking execution state (pending / running / completed / failed / skipped)
+ *  - Retrying failed steps according to a configurable RetryPolicy
+ *  - Handling failures cleanly, including skipping downstream dependents
+ *  - Emitting execution events and building a debuggable execution trace
+ *
+ * The Runtime is explicitly NOT responsible for intent analysis, capability
+ * matching, skill discovery, or workflow planning — those are the Planner's
+ * job (see planner.ts). The Runtime also does not decide *what* a step does:
+ * callers supply a `StepExecutorFn` that performs the actual work (invoking
+ * a skill, calling a model, running a tool, and so on). This keeps the
+ * Runtime a pure sequencing/state engine, independent of any particular
+ * execution backend — which is also what makes it deterministic and easy
+ * to test with a stub executor.
+ */
+
+import { createRuntimeContext } from './runtime-context.js';
+import { describeCause, RuntimeError } from './runtime-errors.js';
+import { EventDispatcher } from './runtime-events.js';
+import { noRetryPolicy } from './runtime-retry.js';
+import { RuntimeStateTracker } from './runtime-state.js';
+import { TraceCollector } from './runtime-trace.js';
+import type {
+	ExecutionPlan,
+	ExecutionStep,
+	RetryPolicy,
+	RuntimeContext,
+	RuntimeOptions,
+	StepExecutorFn,
+	StepResult,
+	WorkflowResult,
+} from './types.js';
+
+// ============================================================================
+// WorkflowExecutor
+// ============================================================================
+
+/**
+ * Executes a single validated `ExecutionPlan` from start to finish.
+ *
+ * One `WorkflowExecutor` instance corresponds to one workflow run — it holds
+ * no state that outlives a single `run()` call, so a fresh instance (or the
+ * `executeWorkflow` convenience function) should be used for every plan.
+ */
+export class WorkflowExecutor {
+	private readonly retryPolicy: RetryPolicy;
+	private readonly stopOnFailure: boolean;
+	private readonly events: EventDispatcher;
+	private readonly trace: TraceCollector;
+
+	constructor(options: RuntimeOptions = {}) {
+		this.retryPolicy = options.retryPolicy ?? noRetryPolicy();
+		this.stopOnFailure = options.stopOnFailure ?? true;
+		this.events = new EventDispatcher(options.onEvent);
+		this.trace = new TraceCollector();
+	}
+
+	/**
+	 * Run the given plan against the given step executor.
+	 *
+	 * Steps execute strictly in `plan.steps` order (the order the Planner
+	 * already computed via topological sort) — the Runtime never reorders
+	 * steps itself, it only decides whether each one runs, retries, or is
+	 * skipped.
+	 */
+	async run(plan: ExecutionPlan, executeStep: StepExecutorFn): Promise<WorkflowResult> {
+		const skillIds = plan.steps.map((step) => step.skillId);
+		const state = new RuntimeStateTracker(skillIds);
+		const context = createRuntimeContext(plan.intent);
+		const results: StepResult[] = [];
+
+		this.emitAndTrace('workflow-started', {}, state);
+
+		for (const step of plan.steps) {
+			const blockedBy = this.findFailedOrSkippedDependency(step, state);
+
+			if (blockedBy !== undefined) {
+				state.skip(step.skillId);
+				results.push({ skillId: step.skillId, status: 'skipped', attempts: 0 });
+				this.emitAndTrace(
+					'step-skipped',
+					{ skillId: step.skillId, data: { blockedBy } },
+					state,
+				);
+				continue;
+			}
+
+			const result = await this.runStep(step, context, state, executeStep);
+			results.push(result);
+
+			if (result.status === 'failed' && this.stopOnFailure) {
+				this.skipRemaining(plan.steps, step.skillId, state, results);
+				break;
+			}
+		}
+
+		const status: WorkflowResult['status'] = results.some(
+			(r) => r.status === 'failed',
+		)
+			? 'failed'
+			: 'completed';
+
+		this.emitAndTrace(
+			status === 'completed' ? 'workflow-completed' : 'workflow-failed',
+			{},
+			state,
+		);
+
+		return {
+			status,
+			intent: plan.intent,
+			outputs: context.toObject(),
+			steps: results,
+			events: this.events.all(),
+			trace: this.trace.all(),
+			state: state.snapshot(),
+		};
+	}
+
+	/**
+	 * Execute a single step, applying the retry policy on failure.
+	 * Returns once the step has either succeeded or exhausted its retries.
+	 */
+	private async runStep(
+		step: ExecutionStep,
+		context: RuntimeContext,
+		state: RuntimeStateTracker,
+		executeStep: StepExecutorFn,
+	): Promise<StepResult> {
+		state.start(step.skillId);
+		this.emitAndTrace('step-started', { skillId: step.skillId, attempt: 1 }, state);
+
+		const maxAttempts = this.retryPolicy.maxRetries + 1;
+		let lastError: unknown;
+
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			try {
+				const output = await executeStep(step, context);
+				context.set(step.skillId, output);
+				state.complete(step.skillId);
+				this.emitAndTrace(
+					'step-completed',
+					{ skillId: step.skillId, attempt },
+					state,
+					{ result: output },
+				);
+				return {
+					skillId: step.skillId,
+					status: 'completed',
+					output,
+					attempts: attempt,
+				};
+			} catch (error) {
+				lastError = error;
+				const isLastAttempt = attempt >= maxAttempts;
+				const willRetry =
+					!isLastAttempt &&
+					(this.retryPolicy.shouldRetry?.(error, attempt) ?? true);
+
+				if (willRetry) {
+					const delayMs = this.retryPolicy.delayForAttempt(attempt);
+					this.emitAndTrace(
+						'step-retry',
+						{
+							skillId: step.skillId,
+							attempt,
+							data: { delayMs, reason: describeCause(error) },
+						},
+						state,
+					);
+					continue;
+				}
+
+				const runtimeError = new RuntimeError(
+					'STEP_EXECUTION_FAILED',
+					`Step "${step.skillId}" failed after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${describeCause(error)}`,
+					{ skillId: step.skillId, attempt, cause: error },
+				);
+				state.fail(step.skillId);
+				this.emitAndTrace(
+					'step-failed',
+					{ skillId: step.skillId, attempt },
+					state,
+					{ error: runtimeError.toInfo() },
+				);
+				return {
+					skillId: step.skillId,
+					status: 'failed',
+					error: runtimeError.toInfo(),
+					attempts: attempt,
+				};
+			}
+		}
+
+		// Defensive fallback — the loop above always returns; this satisfies
+		// noImplicitReturns without changing observable behavior.
+		const fallbackError = new RuntimeError(
+			'STEP_EXECUTION_FAILED',
+			`Step "${step.skillId}" failed: ${describeCause(lastError)}`,
+			{ skillId: step.skillId, attempt: maxAttempts, cause: lastError },
+		);
+		state.fail(step.skillId);
+		return {
+			skillId: step.skillId,
+			status: 'failed',
+			error: fallbackError.toInfo(),
+			attempts: maxAttempts,
+		};
+	}
+
+	private findFailedOrSkippedDependency(
+		step: ExecutionStep,
+		state: RuntimeStateTracker,
+	): string | undefined {
+		for (const depId of step.dependencies) {
+			const status = state.statusOf(depId);
+			if (status === 'failed' || status === 'skipped') {
+				return depId;
+			}
+		}
+		return undefined;
+	}
+
+	private skipRemaining(
+		steps: ExecutionStep[],
+		failedSkillId: string,
+		state: RuntimeStateTracker,
+		results: StepResult[],
+	): void {
+		for (const step of steps) {
+			if (!state.isPending(step.skillId)) continue;
+			state.skip(step.skillId);
+			results.push({ skillId: step.skillId, status: 'skipped', attempts: 0 });
+			this.emitAndTrace(
+				'step-skipped',
+				{ skillId: step.skillId, data: { blockedBy: failedSkillId } },
+				state,
+			);
+		}
+	}
+
+	private emitAndTrace(
+		type: Parameters<EventDispatcher['emit']>[0],
+		details: Parameters<EventDispatcher['emit']>[1],
+		state: RuntimeStateTracker,
+		extras: { result?: unknown; error?: import('./types.js').RuntimeErrorInfo } = {},
+	): void {
+		const event = this.events.emit(type, details);
+		this.trace.record(event, state.snapshot(), extras);
+	}
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+export async function executeWorkflow(
+	plan: ExecutionPlan,
+	executeStep: StepExecutorFn,
+	options?: RuntimeOptions,
+): Promise<WorkflowResult> {
+	const executor = new WorkflowExecutor(options);
+	return executor.run(plan, executeStep);
+}

--- a/packages/hr-skills-build/src/types.ts
+++ b/packages/hr-skills-build/src/types.ts
@@ -184,3 +184,176 @@ export interface PlanValidationResult {
 	isValid: boolean;
 	issues: PlanValidationIssue[];
 }
+
+// ---------------------------------------------------------------------------
+// Workflow runtime types
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifecycle status of a single execution step within the runtime.
+ *
+ * `pending` -> `running` -> (`completed` | `failed` | `skipped`)
+ */
+export type StepStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+
+/**
+ * A snapshot of the runtime's execution state at a point in time.
+ *
+ * Skill IDs move between these buckets as execution proceeds. A skill ID
+ * appears in exactly one bucket at any given moment.
+ */
+export interface RuntimeStateSnapshot {
+	pending: string[];
+	running: string[];
+	completed: string[];
+	failed: string[];
+	skipped: string[];
+}
+
+/**
+ * A step's result after it finishes running (successfully or not).
+ */
+export interface StepResult {
+	skillId: string;
+	status: 'completed' | 'failed' | 'skipped';
+	/** Output produced by the step, available to later steps via RuntimeContext. */
+	output?: unknown;
+	/** Populated when status is 'failed'. */
+	error?: RuntimeErrorInfo;
+	/** Number of attempts made (1 = succeeded/failed on first try). */
+	attempts: number;
+}
+
+/**
+ * Plain, serializable description of a runtime failure — used in traces and
+ * results so failures survive JSON serialization (unlike Error instances).
+ */
+export interface RuntimeErrorInfo {
+	code: string;
+	message: string;
+	skillId?: string;
+	attempt?: number;
+	cause?: string;
+}
+
+/**
+ * A function that performs the actual work for a single execution step.
+ *
+ * The Runtime is deliberately agnostic about *what* a step does — invoking a
+ * skill, calling a model, running a tool, and so on are all the caller's
+ * responsibility. The Runtime only sequences calls to this function,
+ * threads context between them, and manages state/retries/events/tracing.
+ *
+ * Throw (or reject) to signal step failure; the Runtime will apply the
+ * configured RetryPolicy before giving up.
+ */
+export type StepExecutorFn = (
+	step: ExecutionStep,
+	context: RuntimeContext,
+) => unknown | Promise<unknown>;
+
+/**
+ * Explicit, mutable context object threaded through workflow execution.
+ *
+ * Each completed step's output is recorded here and made available to every
+ * subsequent step — this is how "context propagation" is implemented, rather
+ * than relying on module-level globals or closures.
+ */
+export interface RuntimeContext {
+	/** The original user intent the plan was generated for. */
+	readonly intent: string;
+	/** Read a previous step's output by skill ID. Returns undefined if absent. */
+	get(skillId: string): unknown;
+	/** Record a step's output, making it visible to later steps. */
+	set(skillId: string, value: unknown): void;
+	/** True if the given skill ID has already produced output. */
+	has(skillId: string): boolean;
+	/** A plain-object snapshot of all outputs recorded so far, keyed by skill ID. */
+	toObject(): Record<string, unknown>;
+}
+
+/**
+ * Deterministic retry policy consulted by the runtime after a step fails.
+ *
+ * `delayForAttempt` returns a logical delay in milliseconds; the runtime
+ * never actually sleeps for it (that would break determinism and slow down
+ * tests) — the value is recorded on retry events/traces for callers that
+ * want to honor it in their own step executor or a wrapping scheduler.
+ */
+export interface RetryPolicy {
+	/** Maximum number of retry attempts after the initial try (0 = no retries). */
+	readonly maxRetries: number;
+	/** Logical delay (ms) to record before retry attempt `attempt` (1-indexed). */
+	delayForAttempt(attempt: number): number;
+	/** Whether this error should be retried at all. Defaults to "always" when omitted. */
+	shouldRetry?(error: unknown, attempt: number): boolean;
+}
+
+export type RuntimeEventType =
+	| 'workflow-started'
+	| 'step-started'
+	| 'step-retry'
+	| 'step-completed'
+	| 'step-failed'
+	| 'step-skipped'
+	| 'workflow-completed'
+	| 'workflow-failed';
+
+/**
+ * A single runtime event. `order` is a logical clock (a monotonically
+ * increasing integer assigned by the EventDispatcher) rather than a wall
+ * clock timestamp, which keeps execution fully deterministic and makes
+ * traces reproducible in tests.
+ */
+export interface RuntimeEvent {
+	order: number;
+	type: RuntimeEventType;
+	skillId?: string;
+	attempt?: number;
+	data?: Record<string, unknown>;
+}
+
+/**
+ * One entry in the execution trace — an event paired with the runtime state
+ * snapshot immediately after that event was applied. Traces are the primary
+ * debugging artifact: replaying them reconstructs exactly what happened and
+ * in what order, without needing wall-clock timestamps.
+ */
+export interface TraceEntry {
+	order: number;
+	type: RuntimeEventType;
+	skillId?: string;
+	attempt?: number;
+	state: RuntimeStateSnapshot;
+	result?: unknown;
+	error?: RuntimeErrorInfo;
+}
+
+/**
+ * Configuration accepted by `executeWorkflow` / `WorkflowExecutor`.
+ */
+export interface RuntimeOptions {
+	/** Retry behavior applied to every step. Defaults to zero retries. */
+	retryPolicy?: RetryPolicy;
+	/** Called synchronously as each event is emitted (for live progress UIs, logging, etc). */
+	onEvent?: (event: RuntimeEvent) => void;
+	/**
+	 * Whether a step failure (after exhausting retries) halts remaining
+	 * steps. Defaults to true. When false, downstream steps that depend on
+	 * the failed step are skipped, but independent steps still run.
+	 */
+	stopOnFailure?: boolean;
+}
+
+/**
+ * The final outcome of running an execution plan through the Runtime.
+ */
+export interface WorkflowResult {
+	status: 'completed' | 'failed';
+	intent: string;
+	outputs: Record<string, unknown>;
+	steps: StepResult[];
+	events: RuntimeEvent[];
+	trace: TraceEntry[];
+	state: RuntimeStateSnapshot;
+}

--- a/packages/hr-skills-build/test/runtime.test.ts
+++ b/packages/hr-skills-build/test/runtime.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it } from 'bun:test';
+import { executeWorkflow, WorkflowExecutor } from '../src/runtime.js';
+import { exponentialRetryPolicy, fixedRetryPolicy } from '../src/runtime-retry.js';
+import type {
+	ExecutionPlan,
+	ExecutionStep,
+	RuntimeContext,
+	RuntimeEvent,
+} from '../src/types.js';
+
+// ============================================================================
+// Test fixtures
+// ============================================================================
+
+function makeStep(overrides: Partial<ExecutionStep> = {}): ExecutionStep {
+	return {
+		skillId: 'hr-test-skill',
+		order: 0,
+		reason: 'direct-capability-match',
+		dependencies: [],
+		...overrides,
+	};
+}
+
+function makePlan(steps: ExecutionStep[], intent = 'test intent'): ExecutionPlan {
+	return {
+		intent,
+		requestedCapabilities: [intent],
+		capabilityMatches: [],
+		steps,
+		summary: 'test plan',
+		complexity: 'simple',
+	};
+}
+
+// ============================================================================
+// Successful execution
+// ============================================================================
+
+describe('executeWorkflow — successful execution', () => {
+	it('executes a single-step plan and returns completed status', async () => {
+		const plan = makePlan([makeStep({ skillId: 'hr-onboarding', order: 0 })]);
+
+		const result = await executeWorkflow(plan, (step) => `output-of-${step.skillId}`);
+
+		expect(result.status).toBe('completed');
+		expect(result.steps).toHaveLength(1);
+		expect(result.steps[0]).toMatchObject({
+			skillId: 'hr-onboarding',
+			status: 'completed',
+			output: 'output-of-hr-onboarding',
+			attempts: 1,
+		});
+		expect(result.outputs['hr-onboarding']).toBe('output-of-hr-onboarding');
+	});
+
+	it('executes steps in the exact order given by the plan', async () => {
+		const plan = makePlan([
+			makeStep({ skillId: 'a', order: 0 }),
+			makeStep({ skillId: 'b', order: 1, dependencies: ['a'] }),
+			makeStep({ skillId: 'c', order: 2, dependencies: ['b'] }),
+		]);
+
+		const executionOrder: string[] = [];
+		const result = await executeWorkflow(plan, (step) => {
+			executionOrder.push(step.skillId);
+			return step.skillId;
+		});
+
+		expect(executionOrder).toEqual(['a', 'b', 'c']);
+		expect(result.status).toBe('completed');
+		expect(result.steps.map((s) => s.skillId)).toEqual(['a', 'b', 'c']);
+	});
+
+	it('produces the same result across repeated runs (deterministic)', async () => {
+		const plan = makePlan([
+			makeStep({ skillId: 'a', order: 0 }),
+			makeStep({ skillId: 'b', order: 1, dependencies: ['a'] }),
+		]);
+
+		const executor = () => 42;
+		const first = await executeWorkflow(plan, executor);
+		const second = await executeWorkflow(plan, executor);
+
+		expect(first.events.map((e) => e.type)).toEqual(second.events.map((e) => e.type));
+		expect(first.trace).toEqual(second.trace);
+		expect(first.outputs).toEqual(second.outputs);
+	});
+});
+
+// ============================================================================
+// Context propagation
+// ============================================================================
+
+describe('executeWorkflow — context propagation', () => {
+	it('makes earlier step outputs available to later steps', async () => {
+		const plan = makePlan([
+			makeStep({ skillId: 'hr-recruiting', order: 0 }),
+			makeStep({
+				skillId: 'hr-onboarding',
+				order: 1,
+				dependencies: ['hr-recruiting'],
+			}),
+		]);
+
+		const seenByOnboarding: unknown[] = [];
+
+		await executeWorkflow(plan, (step: ExecutionStep, context: RuntimeContext) => {
+			if (step.skillId === 'hr-recruiting') {
+				return { candidate: 'Jane Doe' };
+			}
+			seenByOnboarding.push(context.get('hr-recruiting'));
+			return 'ok';
+		});
+
+		expect(seenByOnboarding).toEqual([{ candidate: 'Jane Doe' }]);
+	});
+
+	it('exposes all accumulated outputs via context.toObject()', async () => {
+		const plan = makePlan([
+			makeStep({ skillId: 'a', order: 0 }),
+			makeStep({ skillId: 'b', order: 1 }),
+		]);
+
+		let snapshotAtB: Record<string, unknown> = {};
+		await executeWorkflow(plan, (step, context) => {
+			if (step.skillId === 'a') return 1;
+			snapshotAtB = context.toObject();
+			return 2;
+		});
+
+		expect(snapshotAtB).toEqual({ a: 1 });
+	});
+
+	it('exposes the original intent on the context', async () => {
+		const plan = makePlan(
+			[makeStep({ skillId: 'a', order: 0 })],
+			'write a job description',
+		);
+
+		const intents: string[] = [];
+		await executeWorkflow(plan, (_step, context) => {
+			intents.push(context.intent);
+			return null;
+		});
+
+		expect(intents).toEqual(['write a job description']);
+	});
+});
+
+// ============================================================================
+// Retry handling
+// ============================================================================
+
+describe('executeWorkflow — retries', () => {
+	it('retries a failing step up to maxRetries and eventually succeeds', async () => {
+		const plan = makePlan([makeStep({ skillId: 'flaky', order: 0 })]);
+		let attempts = 0;
+
+		const result = await executeWorkflow(
+			plan,
+			() => {
+				attempts++;
+				if (attempts < 3) throw new Error('transient failure');
+				return 'recovered';
+			},
+			{ retryPolicy: fixedRetryPolicy({ maxRetries: 3, delayMs: 10 }) },
+		);
+
+		expect(attempts).toBe(3);
+		expect(result.status).toBe('completed');
+		expect(result.steps[0]).toMatchObject({ status: 'completed', attempts: 3 });
+
+		const retryEvents = result.events.filter((e) => e.type === 'step-retry');
+		expect(retryEvents).toHaveLength(2);
+	});
+
+	it('fails after exhausting all retries', async () => {
+		const plan = makePlan([makeStep({ skillId: 'always-fails', order: 0 })]);
+		let attempts = 0;
+
+		const result = await executeWorkflow(
+			plan,
+			() => {
+				attempts++;
+				throw new Error('permanent failure');
+			},
+			{ retryPolicy: fixedRetryPolicy({ maxRetries: 2 }) },
+		);
+
+		expect(attempts).toBe(3); // 1 initial + 2 retries
+		expect(result.status).toBe('failed');
+		expect(result.steps[0]?.status).toBe('failed');
+		expect(result.steps[0]?.attempts).toBe(3);
+	});
+
+	it('does not retry when maxRetries is 0 (default policy)', async () => {
+		const plan = makePlan([makeStep({ skillId: 'no-retry', order: 0 })]);
+		let attempts = 0;
+
+		const result = await executeWorkflow(plan, () => {
+			attempts++;
+			throw new Error('fails once');
+		});
+
+		expect(attempts).toBe(1);
+		expect(result.status).toBe('failed');
+	});
+
+	it('produces deterministic delay values from exponentialRetryPolicy', () => {
+		const policy = exponentialRetryPolicy({ maxRetries: 4, baseDelayMs: 100 });
+		expect(policy.delayForAttempt(1)).toBe(100);
+		expect(policy.delayForAttempt(2)).toBe(200);
+		expect(policy.delayForAttempt(3)).toBe(400);
+	});
+
+	it('respects shouldRetry to skip retrying for specific errors', async () => {
+		const plan = makePlan([makeStep({ skillId: 'unretryable', order: 0 })]);
+		let attempts = 0;
+
+		const result = await executeWorkflow(
+			plan,
+			() => {
+				attempts++;
+				throw new Error('fatal');
+			},
+			{
+				retryPolicy: {
+					maxRetries: 5,
+					delayForAttempt: () => 0,
+					shouldRetry: () => false,
+				},
+			},
+		);
+
+		expect(attempts).toBe(1);
+		expect(result.status).toBe('failed');
+	});
+});
+
+// ============================================================================
+// Failure handling and dependency skipping
+// ============================================================================
+
+describe('executeWorkflow — failure handling', () => {
+	it('stops execution and skips remaining steps by default', async () => {
+		const plan = makePlan([
+			makeStep({ skillId: 'a', order: 0 }),
+			makeStep({ skillId: 'b', order: 1 }),
+			makeStep({ skillId: 'c', order: 2 }),
+		]);
+
+		const result = await executeWorkflow(plan, (step) => {
+			if (step.skillId === 'a') throw new Error('boom');
+			return 'ok';
+		});
+
+		expect(result.status).toBe('failed');
+		expect(result.steps.map((s) => ({ id: s.skillId, status: s.status }))).toEqual([
+			{ id: 'a', status: 'failed' },
+			{ id: 'b', status: 'skipped' },
+			{ id: 'c', status: 'skipped' },
+		]);
+	});
+
+	it('skips steps whose dependency failed, even with stopOnFailure disabled', async () => {
+		const plan = makePlan([
+			makeStep({ skillId: 'a', order: 0 }),
+			makeStep({ skillId: 'b', order: 1, dependencies: ['a'] }),
+			makeStep({ skillId: 'independent', order: 2 }),
+		]);
+
+		const executed: string[] = [];
+		const result = await executeWorkflow(
+			plan,
+			(step) => {
+				executed.push(step.skillId);
+				if (step.skillId === 'a') throw new Error('boom');
+				return 'ok';
+			},
+			{ stopOnFailure: false },
+		);
+
+		expect(result.status).toBe('failed');
+		expect(executed).toEqual(['a', 'independent']);
+		expect(result.steps.map((s) => ({ id: s.skillId, status: s.status }))).toEqual([
+			{ id: 'a', status: 'failed' },
+			{ id: 'b', status: 'skipped' },
+			{ id: 'independent', status: 'completed' },
+		]);
+	});
+
+	it('produces a structured, serializable error on failure', async () => {
+		const plan = makePlan([makeStep({ skillId: 'a', order: 0 })]);
+
+		const result = await executeWorkflow(plan, () => {
+			throw new Error('specific failure message');
+		});
+
+		expect(result.steps[0]?.error).toMatchObject({
+			code: 'STEP_EXECUTION_FAILED',
+			skillId: 'a',
+			attempt: 1,
+		});
+		expect(result.steps[0]?.error?.message).toContain('specific failure message');
+		// The whole result must survive JSON round-tripping (no Error instances).
+		expect(() => JSON.parse(JSON.stringify(result))).not.toThrow();
+	});
+});
+
+// ============================================================================
+// Execution state
+// ============================================================================
+
+describe('executeWorkflow — execution state', () => {
+	it('reports a final state snapshot partitioning all skill IDs', async () => {
+		const plan = makePlan([
+			makeStep({ skillId: 'a', order: 0 }),
+			makeStep({ skillId: 'b', order: 1 }),
+		]);
+
+		const result = await executeWorkflow(plan, () => 'ok');
+
+		expect(result.state.completed.sort()).toEqual(['a', 'b']);
+		expect(result.state.pending).toEqual([]);
+		expect(result.state.running).toEqual([]);
+		expect(result.state.failed).toEqual([]);
+		expect(result.state.skipped).toEqual([]);
+	});
+
+	it('tracks failed and skipped buckets correctly after a failure', async () => {
+		const plan = makePlan([
+			makeStep({ skillId: 'a', order: 0 }),
+			makeStep({ skillId: 'b', order: 1 }),
+		]);
+
+		const result = await executeWorkflow(plan, (step) => {
+			if (step.skillId === 'a') throw new Error('boom');
+			return 'ok';
+		});
+
+		expect(result.state.failed).toEqual(['a']);
+		expect(result.state.skipped).toEqual(['b']);
+		expect(result.state.completed).toEqual([]);
+	});
+});
+
+// ============================================================================
+// Events
+// ============================================================================
+
+describe('executeWorkflow — events', () => {
+	it('emits workflow-started, step events, and workflow-completed in order', async () => {
+		const plan = makePlan([makeStep({ skillId: 'a', order: 0 })]);
+		const result = await executeWorkflow(plan, () => 'ok');
+
+		expect(result.events.map((e) => e.type)).toEqual([
+			'workflow-started',
+			'step-started',
+			'step-completed',
+			'workflow-completed',
+		]);
+	});
+
+	it('assigns strictly increasing logical order to every event', async () => {
+		const plan = makePlan([
+			makeStep({ skillId: 'a', order: 0 }),
+			makeStep({ skillId: 'b', order: 1 }),
+		]);
+		const result = await executeWorkflow(plan, () => 'ok');
+
+		const orders = result.events.map((e) => e.order);
+		expect(orders).toEqual(orders.slice().sort((x, y) => x - y));
+		expect(new Set(orders).size).toBe(orders.length);
+	});
+
+	it('invokes the onEvent callback synchronously for every event', async () => {
+		const plan = makePlan([makeStep({ skillId: 'a', order: 0 })]);
+		const observed: RuntimeEvent[] = [];
+
+		await executeWorkflow(plan, () => 'ok', {
+			onEvent: (event) => observed.push(event),
+		});
+
+		expect(observed.map((e) => e.type)).toEqual([
+			'workflow-started',
+			'step-started',
+			'step-completed',
+			'workflow-completed',
+		]);
+	});
+
+	it('emits workflow-failed instead of workflow-completed on failure', async () => {
+		const plan = makePlan([makeStep({ skillId: 'a', order: 0 })]);
+		const result = await executeWorkflow(plan, () => {
+			throw new Error('boom');
+		});
+
+		expect(result.events.at(-1)?.type).toBe('workflow-failed');
+	});
+});
+
+// ============================================================================
+// Tracing
+// ============================================================================
+
+describe('executeWorkflow — tracing', () => {
+	it('produces one trace entry per event, each with a state snapshot', async () => {
+		const plan = makePlan([makeStep({ skillId: 'a', order: 0 })]);
+		const result = await executeWorkflow(plan, () => 'ok');
+
+		expect(result.trace).toHaveLength(result.events.length);
+		for (const entry of result.trace) {
+			expect(entry.state).toHaveProperty('pending');
+			expect(entry.state).toHaveProperty('running');
+			expect(entry.state).toHaveProperty('completed');
+			expect(entry.state).toHaveProperty('failed');
+			expect(entry.state).toHaveProperty('skipped');
+		}
+	});
+
+	it('records the step output on the step-completed trace entry', async () => {
+		const plan = makePlan([makeStep({ skillId: 'a', order: 0 })]);
+		const result = await executeWorkflow(plan, () => ({ answer: 42 }));
+
+		const completedEntry = result.trace.find((e) => e.type === 'step-completed');
+		expect(completedEntry?.result).toEqual({ answer: 42 });
+	});
+
+	it('records the structured error on the step-failed trace entry', async () => {
+		const plan = makePlan([makeStep({ skillId: 'a', order: 0 })]);
+		const result = await executeWorkflow(plan, () => {
+			throw new Error('trace this failure');
+		});
+
+		const failedEntry = result.trace.find((e) => e.type === 'step-failed');
+		expect(failedEntry?.error?.message).toContain('trace this failure');
+	});
+
+	it('reflects state transitions across the trace (running before completed)', async () => {
+		const plan = makePlan([makeStep({ skillId: 'a', order: 0 })]);
+		const result = await executeWorkflow(plan, () => 'ok');
+
+		const startedEntry = result.trace.find((e) => e.type === 'step-started');
+		const completedEntry = result.trace.find((e) => e.type === 'step-completed');
+
+		expect(startedEntry?.state.running).toEqual(['a']);
+		expect(completedEntry?.state.completed).toEqual(['a']);
+	});
+});
+
+// ============================================================================
+// WorkflowExecutor class + async executors
+// ============================================================================
+
+describe('WorkflowExecutor', () => {
+	it('supports async step executors', async () => {
+		const plan = makePlan([makeStep({ skillId: 'a', order: 0 })]);
+		const executor = new WorkflowExecutor();
+
+		const result = await executor.run(plan, async (step) => {
+			await Promise.resolve();
+			return `async-${step.skillId}`;
+		});
+
+		expect(result.status).toBe('completed');
+		expect(result.outputs['a']).toBe('async-a');
+	});
+
+	it('handles an empty plan gracefully', async () => {
+		const plan = makePlan([]);
+		const result = await executeWorkflow(plan, () => 'unused');
+
+		expect(result.status).toBe('completed');
+		expect(result.steps).toEqual([]);
+		expect(result.events.map((e) => e.type)).toEqual([
+			'workflow-started',
+			'workflow-completed',
+		]);
+	});
+});


### PR DESCRIPTION
Add a deterministic Workflow Runtime that executes execution plans
produced by the Skill Planner (Phase 4.2).

Types (src/types.ts):
- StepStatus, RuntimeStateSnapshot, StepResult, RuntimeErrorInfo,
  StepExecutorFn, RuntimeContext, RetryPolicy, RuntimeEventType,
  RuntimeEvent, TraceEntry, RuntimeOptions, WorkflowResult

Building blocks:
- runtime-context.ts   RuntimeContextImpl — context propagation between steps
- runtime-state.ts     RuntimeStateTracker — pending/running/completed/failed/skipped
- runtime-retry.ts     noRetryPolicy, fixedRetryPolicy, exponentialRetryPolicy
- runtime-events.ts    EventDispatcher — logical clock, deterministic event order
- runtime-trace.ts     TraceCollector — event + state snapshot pairing
- runtime-errors.ts    RuntimeError — structured, JSON-serializable failures

Orchestrator:
- runtime.ts           WorkflowExecutor / executeWorkflow() — consumes an
                        ExecutionPlan directly, executes steps strictly in
                        plan order, skips steps whose dependencies failed or
                        were skipped, applies the configured RetryPolicy,
                        stops on failure by default (or only skips
                        dependents when stopOnFailure is disabled), and
                        emits workflow/step events alongside a full
                        execution trace

CLI:
- execute-plan.ts      `bun run execute "<intent>"` — generates a plan via
                        the existing Planner and runs it through the Runtime
                        with a stub step executor for demonstration

Docs:
- docs/runtime.md       architecture, execution lifecycle, state management,
                        context propagation, retry/failure handling, events,
                        tracing, and extension points
- docs/ROADMAP.md       mark Phase 4.3 complete
- AGENTS.md             document `bun run execute`

Tests:
- test/runtime.test.ts  execution order, deterministic repeated runs,
                        context propagation, retries (success/exhausted/
                        shouldRetry/backoff), failure handling
                        (stop-on-failure and dependency-based skipping),
                        state transitions, events, tracing, async
                        executors, and an empty-plan edge case

Changeset:
- .changeset/workflow-runtime-foundation.md