### PR TITLE
docs: add contributor guide and docs/contributing subtree

### DIFF
--- a/CONTRIBUTING.md.suggestions.md
+++ b/CONTRIBUTING.md.suggestions.md
@@ -1,0 +1,103 @@
+# Suggested edits to `CONTRIBUTING.md`
+
+All suggestions are additive or clarifying — nothing in the current file is incorrect, so
+nothing needs to be removed. Each item states the exact location and proposed text.
+
+---
+
+## 1. Expand "Before you submit" to match CI — **[Proposed]**
+
+**Where:** the `## Before you submit` section, current code block.
+
+**Why:** `.github/workflows/` runs `test.yml` and `knip.yml` as separate CI jobs, and
+`lint:links` is a real script that matters for any change touching `docs/` or `skills/`, but
+none of the three appear in the local pre-submit checklist. A contributor who only runs the
+documented five commands can still fail CI.
+
+**Current:**
+
+```bash
+bun run validate    # Validate all SKILL.md files
+bun run check       # 0 Biome check errors required
+bun run lint:md     # 0 markdownlint errors required
+bun run typecheck   # 0 TypeScript errors required
+bun run build       # All workspace builds must complete successfully
+```
+
+**Proposed replacement:**
+
+```bash
+bun run validate     # Validate all SKILL.md files
+bun run check        # 0 Biome check errors required
+bun run lint:md       # 0 markdownlint errors required
+bun run lint:links    # No broken links in docs/ or skills/
+bun run typecheck    # 0 TypeScript errors required
+bun run build        # All workspace builds must complete successfully
+bun run test          # All workspace tests must pass
+bun run knip          # No unused files or dependencies introduced
+```
+
+---
+
+## 2. Link out to `docs/contributing/` — **[Proposed]**
+
+**Where:** add a short paragraph directly under the `# Contributing` H1, before `## Prerequisites`.
+
+**Why:** gives external contributors a map before they hit the setup steps, without bloating
+this file. Non-invasive — everything currently in CONTRIBUTING.md stays exactly where it is.
+
+**Proposed addition:**
+
+```markdown
+For a deeper walkthrough — repository architecture, the full contributor journey, and worked
+examples — see [`docs/contributing/`](./docs/contributing/onboarding.md). This file covers
+the minimum steps to get a pull request merged.
+```
+
+---
+
+## 3. Clarify PR review expectations — **[Unknown, needs maintainer input]**
+
+**Where:** end of `CONTRIBUTING.md`, after `## Questions`.
+
+**Why:** `.github/CODEOWNERS` shows a single owner (`@tuanductran`) for the whole repository.
+No SLA or backup-reviewer path is documented anywhere. This is not something to invent —
+flagging it so the maintainer can add a line if desired.
+
+**Proposed placeholder (maintainer to fill in the specifics):**
+
+```markdown
+## Review process
+
+Pull requests are reviewed by the repository owner (see `.github/CODEOWNERS`).
+<!-- maintainer: add expected turnaround time / escalation path here if applicable -->
+```
+
+---
+
+## 4. Optional: reference `skill-vetter` if it's part of human review — **[Unknown, needs maintainer input]**
+
+**Where:** `## Adding a new skill`, after step 4 ("Validate and package").
+
+**Why:** `.agents/skills/skill-vetter/SKILL.md` exists in the repository but is never
+referenced from any contributor-facing document. If it encodes the actual review bar
+maintainers apply, linking it would help contributors self-check before opening a PR. If it's
+Claude-Code-only tooling, no change is needed — do not add this without confirming intent.
+
+**Proposed addition (only if confirmed applicable to human contributors):**
+
+```markdown
+Before opening a pull request, you can self-review against the same checklist maintainers use:
+see [`.agents/skills/skill-vetter/SKILL.md`](../.agents/skills/skill-vetter/SKILL.md).
+```
+
+---
+
+## Summary of changes
+
+| # | Change | Confidence | Action needed |
+|---|---|---|---|
+| 1 | Expand pre-submit checklist | **[Proposed]**, low-risk, matches existing scripts/CI | Safe to merge |
+| 2 | Link to `docs/contributing/` | **[Proposed]**, depends on that subtree being added | Merge together with subtree |
+| 3 | Review process note | **[Unknown]** | Needs maintainer to supply content |
+| 4 | `skill-vetter` reference | **[Unknown]** | Needs maintainer to confirm intent |

--- a/CONTRIBUTOR_GUIDE.md
+++ b/CONTRIBUTOR_GUIDE.md
@@ -1,0 +1,126 @@
+# HR Skills — Contributor Guide (Proposed)
+
+> Status: **Draft proposal** for `tuanductran/hr-skills`, prepared to support Roadmap Phase 5
+> ("Community & Distribution" — better documentation, external contributors).
+>
+> This is the top-level index. The four companion files are meant to live at
+> `docs/contributing/*.md` (delivered alongside this one). `CONTRIBUTING.md` itself should
+> stay short and link out to them — see Section 7, Documentation Maintenance.
+
+## Labels used throughout all deliverables
+
+- **[Existing]** — verified by reading the repository directly (README.md, CONTRIBUTING.md,
+  AGENTS.md, `docs/format.md`, `.github/skill-template.md`, `.github/pull_request_template.md`,
+  `.github/CODEOWNERS`, `.github/workflows/*`, `package.json`, `packages/hr-skills-build/src/validate.ts`,
+  and sampled skill packages such as `skills/hr-onboarding/`).
+- **[Inferred]** — not written down anywhere, but consistently observed across the repository
+  (e.g. by comparing multiple `skills/hr-*` directories).
+- **[Proposed]** — a new recommendation, not currently in the repository. Requires maintainer
+  sign-off before merging.
+- **[Unknown]** — cannot be determined from the repository as cloned. Listed explicitly rather
+  than guessed at.
+
+## Repository analysis performed
+
+| Source | What it confirmed |
+|---|---|
+| `README.md` | Product description, quick start, repo structure diagram, package table |
+| `CONTRIBUTING.md` | Setup, pre-submit checklist, new-skill steps, PR target branch |
+| `AGENTS.md` | Branch strategy, commit convention, full command list, project structure table, content standards |
+| `docs/format.md` | Full `SKILL.md` spec, maturity tiers, `content/`/`prompts/`/`examples/` rules |
+| `.github/skill-template.md` | Canonical SKILL.md template (source of truth, cross-referenced from CONTRIBUTING.md) |
+| `.github/pull_request_template.md` | PR checklist fields actually shown to contributors |
+| `.github/CODEOWNERS` | `* @tuanductran` — single owner, all paths |
+| `.github/workflows/*.yml` | CI jobs exist for: `knip`, `lint`, `matrix`, `release`, `test`, `typecheck`, `validate` |
+| `package.json` | Exact script names/behavior, workspaces, catalog dependencies, `preinstall`/`prepare` hooks |
+| `packages/hr-skills-build/src/validate.ts` (+ neighbors) | Confirms `bun run validate` is a real, implemented CLI backed by `skills-ref`, not just documentation |
+| `.agents/skills/hr-root-router-maintaining/SKILL.md` | Router update procedure referenced by CONTRIBUTING.md actually exists and is detailed |
+| `skills/hr-onboarding/` (sample Full-tier skill) | Confirms real-world `content/`, `prompts/`, `examples/` structure matches `docs/format.md` |
+
+No conflicts were found between documentation and implementation. This means the work here is
+**additive and organizational** (filling gaps, consolidating, cross-linking) rather than
+corrective.
+
+## Key findings
+
+1. **[Existing]** Core docs (README, CONTRIBUTING, AGENTS.md, docs/format.md) are internally
+   consistent with each other and with `package.json`.
+2. **[Existing]** CONTRIBUTING.md's "Before you submit" checklist lists `validate`, `check`,
+   `lint:md`, `typecheck`, `build` — it does **not** mention `lint:links`, `test`, or `knip`,
+   even though all three are real scripts and CI runs `test.yml` and `knip.yml` as separate
+   jobs. **[Proposed]** Add these to the pre-submit checklist so local runs match CI.
+3. **[Existing]** There is no single "start here" contributor page — onboarding, environment
+   setup, and skill-authoring guidance are correctly documented but split across four files.
+   **[Proposed]** A `docs/contributing/` subtree (delivered here) consolidates this without
+   duplicating `docs/format.md`, which stays the single source of truth for the SKILL.md spec.
+4. **[Unknown]** Whether `.agents/skills/skill-vetter/SKILL.md` is used by the human maintainer
+   as a PR review checklist, or is intended only for Claude Code's own use. Not stated anywhere
+   in CONTRIBUTING.md, AGENTS.md, or the PR template. Recommend the maintainer clarify.
+5. **[Unknown]** Expected PR review turnaround time. CODEOWNERS shows a single owner
+   (`@tuanductran`) for the entire repository, but no SLA or backup-reviewer policy is stated.
+6. **[Unknown]** Exact cadence/trigger for merging `dev` → `main` (i.e., when a release
+   happens). `bun run release` and `.github/workflows/release.yml` exist, confirming a release
+   process exists, but not when/how often it runs relative to `dev` activity.
+
+## Deliverables in this drop
+
+| File | Purpose |
+|---|---|
+| `CONTRIBUTOR_GUIDE.md` (this file) | Index, analysis summary, findings, cross-links |
+| `CONTRIBUTING.md.suggestions.md` | Copy-pasteable diff-style suggestions for the existing `CONTRIBUTING.md` |
+| `docs/contributing/onboarding.md` | Section 1 — architecture, directories, contributor journey |
+| `docs/contributing/workflow.md` | Section 2 — setup, commands, branching, PR workflow |
+| `docs/contributing/skill-authoring.md` | Section 3 — skill structure, tiers, naming, validation |
+| `docs/contributing/examples.md` | Section 4 — worked examples with real git/bun commands |
+| Section 7 below | Documentation maintenance recommendations |
+
+---
+
+## 7. Documentation Maintenance Recommendations
+
+### Current state
+
+- **[Existing]** No contradictions found between documented commands and actual `package.json`
+  scripts, or between documented skill structure and sampled skills on disk.
+- **[Existing]** `docs/skill-matrix.md`, `registry/skills.json`, and
+  `.claude-plugin/marketplace.json` are correctly documented in AGENTS.md as generated,
+  do-not-hand-edit files, regenerated by `bun run matrix`, `bun run registry`, and
+  `bun run sync` respectively.
+
+### Gaps identified
+
+| Gap | Evidence | Recommendation |
+|---|---|---|
+| Pre-submit checklist incomplete | CONTRIBUTING.md omits `lint:links`, `test`, `knip`; CI runs all of them as separate jobs | **[Proposed]** Expand the checklist (see `CONTRIBUTING.md.suggestions.md`) |
+| No single onboarding entry point | Info split across 4 files | **[Proposed]** Add `docs/contributing/` subtree, link from CONTRIBUTING.md |
+| Review process undocumented | Single CODEOWNERS entry, no SLA/escalation text anywhere | **[Unknown]** — flag for maintainer, don't invent a policy |
+| `skill-vetter` role unclear | Meta-skill exists in `.agents/skills/` but never referenced from contributor-facing docs | **[Unknown]** — flag for maintainer |
+
+### Recommended organization — **[Proposed]**
+
+```text
+CONTRIBUTING.md              # stays short: setup + checklist + links out (GitHub surfaces this file automatically)
+docs/
+├── contributing/
+│   ├── onboarding.md        # architecture + contributor journey
+│   ├── workflow.md          # setup + commands + branching + PR steps
+│   ├── skill-authoring.md   # cross-links docs/format.md rather than duplicating it
+│   └── examples.md          # worked git/bun command sequences
+├── format.md                 # unchanged — remains the canonical SKILL.md spec
+└── ROADMAP.md
+```
+
+Rationale: keeps `CONTRIBUTING.md` short (GitHub convention — it's auto-surfaced in the PR/issue
+UI), while `docs/contributing/` gives depth without duplicating `docs/format.md`, mirroring how
+`docs/evaluation.md`, `docs/planner.md`, `docs/runtime.md`, and `docs/registry.md` already
+document subsystems separately.
+
+### Maintenance risks going forward — **[Proposed]**
+
+- Script tables in AGENTS.md and CONTRIBUTING.md are both hand-maintained lists of
+  `package.json` scripts. Any new script risks going undocumented in one or both places.
+  Recommend a PR-checklist reminder line ("If you added a script, update AGENTS.md and
+  CONTRIBUTING.md") rather than tooling, since no doc-generation tooling for this exists today.
+- `docs/format.md` and `.github/skill-template.md` are explicitly cross-referenced as the same
+  source of truth (per the template file's own header) — a change to one without the other is
+  the most likely future documentation drift point.

--- a/docs/contributing/examples.md
+++ b/docs/contributing/examples.md
@@ -1,0 +1,138 @@
+# Contribution examples
+
+## Purpose
+
+Show complete, copy-pasteable command sequences for the four most common contribution types,
+so a first-time contributor can match their situation to a working example.
+
+All commands below use scripts and conventions verified in `package.json`, `AGENTS.md`, and
+`CONTRIBUTING.md` — nothing here is invented. **[Existing]** unless marked otherwise.
+
+## Example A — creating a new skill
+
+```bash
+git checkout dev
+git pull
+git checkout -b feat/hr-payroll-tax-compliance
+
+mkdir -p skills/hr-payroll-tax-compliance/{content,prompts,examples}
+# Author SKILL.md from .github/skill-template.md, plus one .md file per subdirectory.
+
+bun run sync         # regenerate .claude-plugin/marketplace.json
+# Update the root router per .agents/skills/hr-root-router-maintaining/SKILL.md
+bun run validate      # must pass with 0 errors
+bun run matrix         # regenerate docs/skill-matrix.md
+bun run registry       # regenerate registry/skills.json
+
+git add .
+git commit -m "feat(hr-payroll-tax-compliance): add new skill"
+git push origin feat/hr-payroll-tax-compliance
+# Open PR: base = dev, head = feat/hr-payroll-tax-compliance
+```
+
+Resulting structure:
+
+```text
+skills/
+├── hr-payroll-tax-compliance/     # new
+│   ├── SKILL.md
+│   ├── content/
+│   │   └── understanding-payroll-tax-compliance.md
+│   ├── prompts/
+│   │   └── payroll-tax-prompts.md
+│   └── examples/
+│       └── quarterly-tax-filing-workflow.md
+└── ... (existing skills, unchanged)
+```
+
+## Example B — upgrading an existing skill's tier (Partial → Full)
+
+```bash
+git checkout dev
+git pull
+git checkout -b feat/hr-offboarding-add-examples
+
+# Add skills/hr-offboarding/examples/conducting-an-exit-interview.md
+
+bun run validate
+bun run lint:md
+
+git add .
+git commit -m "feat(hr-offboarding): add exit interview example workflow"
+git push origin feat/hr-offboarding-add-examples
+```
+
+No router change needed — the skill already exists in the routing table. Only its maturity
+tier changes (Partial → Full), which `bun run matrix` will reflect automatically.
+
+## Example C — updating an existing skill's content
+
+```bash
+git checkout -b fix/hr-analytics-turnover-formula
+
+# Edit skills/hr-analytics/content/*.md
+
+bun run lint:md
+git commit -m "fix(hr-analytics): correct turnover formula in tips"
+git push origin fix/hr-analytics-turnover-formula
+```
+
+## Example D — fixing documentation
+
+```bash
+git checkout -b docs/clarify-skill-tiers
+
+# Edit docs/format.md (or docs/contributing/*.md once added)
+
+bun run lint:md
+bun run lint:links
+git commit -m "docs: clarify skill maturity tier definitions"
+git push origin docs/clarify-skill-tiers
+```
+
+## Example E — submitting the pull request
+
+Applies to all of the above:
+
+1. Base branch: `dev` (never `main`).
+2. Fill in `.github/pull_request_template.md`:
+   - **What changed** — one or two sentences
+   - **Content type** — check the box(es) that apply (skill definition, competency
+     framework, interview questions, assessment criteria, recruiting workflow, AI prompt,
+     documentation, tooling/configuration)
+   - **Why** — the problem being solved or value added
+   - **Related issue** — `Closes #NN` if applicable
+   - **Validation** — confirm content reviewed, no duplicate information, links verified,
+     formatting follows repository standards, CI checks pass
+   - **Commit convention** — confirm commits follow Conventional Commits
+3. Wait for CI (`.github/workflows/`: `knip`, `lint`, `matrix`, `test`, `typecheck`,
+   `validate`) to pass.
+4. A maintainer reviews and merges.
+
+## Best practices
+
+- Run the exact validation commands relevant to your change type before pushing — a
+  content-only change doesn't need `bun run typecheck`, but a `packages/` change does.
+- Keep the commit scope aligned with the primary thing changed (`hr-analytics`,
+  `hr-skills-build`, or no scope for repo-wide changes).
+
+## Common mistakes
+
+- Forgetting `bun run sync` after adding a new skill directory (Example A) — leaves
+  `.claude-plugin/marketplace.json` out of sync with the PR's actual skill additions.
+- Opening the PR against `main`.
+- Skipping `bun run lint:md` on documentation-only changes — markdownlint and case-police
+  still apply to prose, not just skill files.
+
+## Suggested improvements
+
+- **[Proposed]** None beyond what's already captured in `CONTRIBUTOR_GUIDE.md` and
+  `CONTRIBUTING.md.suggestions.md` — this page is meant to stay a stable set of worked
+  examples that references those files rather than duplicating their reasoning.
+
+## Unknown or ambiguous information
+
+- **[Unknown]** Whether maintainers expect changeset entries (`bun run changeset`) from
+  external contributors, or whether that's reserved for maintainer-driven releases. Not
+  stated in CONTRIBUTING.md or AGENTS.md; worth confirming before including it in a
+  contributor-facing example.

--- a/docs/contributing/onboarding.md
+++ b/docs/contributing/onboarding.md
@@ -1,0 +1,98 @@
+# Contributor onboarding
+
+## Purpose
+
+Give a first-time contributor enough context to go from "I cloned the repo" to "I understand
+where things live and why" before writing any code or content.
+
+## Explanation
+
+HR Skills **[Existing]** is a Bun + Turborepo monorepo. Three kinds of things live in it:
+
+1. **The product** — `skills/hr-*/`, 140+ domain-specific Agent Skill packages.
+2. **The tooling** — `packages/hr-skills-build/` (validation, matrix/registry generation,
+   planner, evaluation CLI) and `packages/skills-ref/` (TypeScript library for reading,
+   validating, and generating prompts from skill files).
+3. **The meta layer** — `.agents/skills/`, a set of skills that describe how to maintain the
+   repository itself (for example `hr-root-router-maintaining`, `hr-skills-maintaining`,
+   `skill-vetter`). These are worth reading before your first PR since they encode conventions
+   Claude Code is expected to follow when helping maintain the repo, and are a fast way to
+   understand "how things are done here."
+
+`docs/` **[Existing]** holds two kinds of files: specifications you can read and are expected
+to follow (`docs/format.md`, `docs/evaluation.md`, `docs/planner.md`, `docs/runtime.md`,
+`docs/registry.md`), and **generated reports** you should never hand-edit
+(`docs/skill-matrix.md`).
+
+## Existing behavior — directory reference
+
+| Path | Purpose | Editable by contributors? |
+|---|---|---|
+| `skills/hr-*/SKILL.md` | Skill definition (required file) | Yes |
+| `skills/hr-*/content/` | Long-form reference material | Yes (optional dir) |
+| `skills/hr-*/prompts/` | Reusable prompt libraries | Yes (optional dir) |
+| `skills/hr-*/examples/` | End-to-end workflow walkthroughs | Yes (optional dir) |
+| `docs/format.md` | Skill authoring spec | Yes, via PR + maintainer review |
+| `docs/skill-matrix.md` | Generated — run `bun run matrix` | No, never hand-edit |
+| `registry/skills.json` | Generated — run `bun run registry` | No, never hand-edit |
+| `.claude-plugin/marketplace.json` | Generated — run `bun run sync` | No, never hand-edit |
+| `packages/hr-skills-build/` | Validation/CLI tooling source | Yes, via PR |
+| `packages/skills-ref/` | Library source | Yes, via PR |
+| `.agents/skills/` | Meta-skills for maintaining the repo | Yes, read before contributing |
+
+All of the above is **[Existing]**, cross-checked against AGENTS.md's own project-structure
+table and confirmed by inspecting the files on disk.
+
+## Step-by-step: first look at the repository
+
+1. Read `README.md` for the product pitch and `AGENTS.md` for the branch/commit rules.
+2. Skim `docs/format.md` — this is the spec every skill must satisfy, and `bun run validate`
+   enforces it mechanically.
+3. Open one existing Full-tier skill end-to-end, for example `skills/hr-onboarding/`: read
+   `SKILL.md`, then one file from each of `content/`, `prompts/`, `examples/`. This is faster
+   than reading the spec alone and shows the target shape.
+4. Check `docs/skill-matrix.md` for the current maturity tier of every skill (🔴 Bare,
+   🟡 Partial, 🟢 Full) — a good first contribution is often upgrading a Bare or Partial skill
+   in a domain you already know.
+
+## Common contributor workflows
+
+- **Add a brand-new skill** → see `docs/contributing/skill-authoring.md`.
+- **Upgrade a Bare/Partial skill to Full tier** by adding the missing `content/`, `prompts/`,
+  or `examples/` directory — same validation rules as a new skill, no router change needed
+  since the skill already exists in the routing table.
+- **Fix a factual or formatting error in an existing skill** — smallest, lowest-risk PR type.
+- **Improve tooling** in `packages/hr-skills-build` or `packages/skills-ref` — requires
+  TypeScript and Bun familiarity; see AGENTS.md's "Packages" table.
+- **Improve documentation** — see `docs/contributing/workflow.md` and the documentation
+  maintenance recommendations in `CONTRIBUTOR_GUIDE.md`.
+
+## Best practices
+
+- Prefer small, single-purpose PRs (one skill, or one doc fix) over large batches — this
+  matches the repository's Conventional Commits scoping convention and is easier to review
+  given the repository has a single code owner.
+- Read the relevant `.agents/skills/*/SKILL.md` for the area you're touching before starting —
+  they're short and describe exact conventions (for example the router update procedure).
+
+## Common mistakes
+
+- Editing generated files (`docs/skill-matrix.md`, `registry/skills.json`,
+  `.claude-plugin/marketplace.json`) directly instead of regenerating them with the relevant
+  `bun run` command — changes will be overwritten on the next generation run.
+- Committing directly to `main` or targeting `main` in a pull request instead of `dev`.
+  **[Existing]** AGENTS.md explicitly states `main` is the publishing branch and direct
+  commits to it are forbidden.
+- Leaving an empty `content/`, `prompts/`, or `examples/` directory in a skill package.
+  **[Existing]** `docs/format.md` states this is strictly forbidden and will fail validation.
+
+## Suggested improvements
+
+- **[Proposed]** Consider a `good-first-contribution` label pointing to Bare-tier skills in
+  `docs/skill-matrix.md`, since that data already exists and would lower the bar for a first PR.
+
+## Unknown or ambiguous information
+
+- **[Unknown]** Whether there is an expected order of preference among the "common contributor
+  workflows" above (e.g. whether maintainers prefer tier upgrades over brand-new skills right
+  now). Not stated in the repository; worth asking the maintainer if prioritization matters.

--- a/docs/contributing/skill-authoring.md
+++ b/docs/contributing/skill-authoring.md
@@ -1,0 +1,119 @@
+# Skill authoring guidelines
+
+## Purpose
+
+Help a contributor produce a structurally valid, discoverable skill on the first attempt,
+before running `bun run validate`. This page is a practical walkthrough; the authoritative
+specification remains [`docs/format.md`](../format.md) — if anything here and `docs/format.md`
+ever disagree, `docs/format.md` wins, and this page should be corrected to match.
+
+## Explanation
+
+Every HR skill lives in its own directory under `skills/`. A skill package consists of a
+required `SKILL.md` file and may include supporting material in `content/`, `prompts/`, and
+`examples/`. All of this is **[Existing]**, taken from `docs/format.md` and confirmed against
+`.github/skill-template.md` and sampled skills such as `skills/hr-onboarding/`.
+
+## Existing behavior — required structure
+
+```text
+skills/hr-your-skill/
+├── SKILL.md          # required
+├── content/           # optional, but if present: no empty dirs, ≥1 .md file
+├── prompts/            # optional, same rule
+└── examples/           # optional, same rule
+```
+
+- Directory name: lowercase, hyphens only, must start with `hr-`.
+- Directory name must exactly match the `name` field in `SKILL.md` frontmatter.
+
+## Existing behavior — maturity tiers
+
+| Tier | Requirement |
+|---|---|
+| 🔴 Bare | `SKILL.md` only |
+| 🟡 Partial | `SKILL.md` + 1–2 non-empty supporting dirs |
+| 🟢 Full | `SKILL.md` + all three supporting dirs, each with at least one `.md` file |
+
+> **Subdirectory rule [Existing]:** empty supporting directories are strictly forbidden. Any
+> `content/`, `prompts/`, or `examples/` directory present on disk must contain at least one
+> `.md` file, or validation fails.
+
+## Step-by-step: creating a new skill
+
+1. `mkdir skills/hr-your-skill-name`
+2. Copy the frontmatter and body structure from `.github/skill-template.md` into
+   `skills/hr-your-skill-name/SKILL.md`. This template is the canonical source — don't
+   hand-recreate the structure from memory.
+3. Fill in frontmatter:
+   - `name`: kebab-case, matches the directory name exactly
+   - `description`: at least 50 characters, states the HR domain, the target audience, and
+     realistic trigger phrases (for example `"write a job description"`,
+     `"analyze turnover"`) — this is the single field that determines whether an assistant
+     ever activates the skill
+   - `metadata.author`, `metadata.version` (start new skills at `"1.0.0"`)
+4. Write the required body sections:
+   - **Supported tasks** — a bullet list, recommended 8–12 items
+   - **Key prompts** — 3–6 subtopics, each with 4–7 numbered prompts using `[placeholders]`
+     for variable inputs
+   - **Tips** — 4–6 bullets of practical, professional guidance
+5. (Recommended for Full tier) Add `content/*.md`, `prompts/*.md`, `examples/*.md`:
+   - `content/*.md` — explains concepts in depth (Overview / Main topics / Practical guidance
+     is a typical, not mandatory, shape)
+   - `prompts/*.md` — a focused prompt library for one subtopic, introduction plus a list of
+     reusable prompts
+   - `examples/*.md` — a realistic end-to-end workflow (Context / Step 1..N / Workflow summary
+     is a typical, not mandatory, shape)
+6. Run `bun run sync` to regenerate `.claude-plugin/marketplace.json` from the new frontmatter.
+7. Update the root router so the skill is discoverable. **[Existing, CONTRIBUTING.md]** Follow
+   the procedure in
+   [`.agents/skills/hr-root-router-maintaining/SKILL.md`](../../.agents/skills/hr-root-router-maintaining/SKILL.md),
+   which documents the canonical routing sections, exact table row format, and the rule to bump
+   the router's patch version on every change.
+8. Run `bun run validate` — must pass with 0 errors before continuing.
+9. Run `bun run matrix` and `bun run registry` to refresh the generated reports.
+10. Open a pull request against `dev` (see `docs/contributing/workflow.md`).
+
+## Existing behavior — naming conventions
+
+- Skill directories: `hr-<kebab-case-domain>`
+- `content/`, `prompts/`, `examples/` files: descriptive kebab-case, for example
+  `employee-lifecycle.md`, `behavioral-interview-prompts.md`,
+  `conducting-an-exit-interview.md`
+
+## Best practices
+
+- Write the `description` for activation accuracy first — get this right before filling in
+  the rest of the file.
+- Keep `SKILL.md` focused on *what to do*; push deep explanation into `content/`, prompt
+  collections into `prompts/`, and worked scenarios into `examples/`. Avoid duplicating the
+  same material across files — **[Existing, docs/format.md]** this is called out explicitly
+  as something to avoid.
+- Avoid vendor marketing language and time-sensitive facts (specific compliance thresholds,
+  salary figures) that will go stale — **[Existing, docs/format.md]**.
+
+## Common mistakes
+
+- Description under 50 characters or missing realistic trigger phrases → weak or no
+  activation by the assistant.
+- Creating an empty `content/`, `prompts/`, or `examples/` folder "for later" — fails
+  validation immediately.
+- Forgetting the root router update — the skill exists on disk but is undiscoverable through
+  the root `SKILL.md` entry point.
+- Mismatched `name` frontmatter vs. directory name.
+- Writing prompt libraries inside `content/*.md`, or long explanatory prose inside
+  `prompts/*.md` — **[Existing, docs/format.md]** each file type has a distinct purpose and
+  the spec explicitly lists these as things to avoid.
+
+## Suggested improvements
+
+- **[Proposed]** `docs/format.md` already contains a "Quality checklist" at its end;
+  consider linking to it directly from `.github/pull_request_template.md`'s "Validation"
+  section so contributors see it at PR-creation time, not just while reading docs.
+
+## Unknown or ambiguous information
+
+- **[Unknown]** Whether `content/`, `prompts/`, and `examples/` file counts have an upper
+  recommended bound (the spec gives ranges for sections inside `SKILL.md` itself — supported
+  tasks, key prompts, tips — but not for the number of files in the supporting directories).
+  Worth asking the maintainer if very large supporting directories should be split.

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -1,0 +1,151 @@
+# Repository workflow
+
+## Purpose
+
+One authoritative page covering environment setup, local commands, and the fork → PR path, so
+contributors don't have to reverse-engineer `package.json` scripts or piece together rules
+from multiple files.
+
+## Explanation
+
+The repository is a Bun workspace orchestrated by Turborepo. Almost every contributor-facing
+command is a `bun run <script>` defined in the root `package.json`, several of which delegate
+to `turbo run <task> --filter=<package>` so they execute in the right workspace package with
+caching. This section documents each command's effect, not just its name.
+
+## Existing behavior — development setup
+
+**Requirements — [Existing]:**
+
+- [Bun](https://bun.sh/) ≥ 1.3.9 (the repository pins `bun@1.3.14` as `packageManager` in
+  `package.json`)
+- Node.js is **not** required — Bun handles install, run, and workspace resolution
+- Git
+
+**Setup — [Existing]:**
+
+```bash
+git clone https://github.com/tuanductran/hr-skills.git
+cd hr-skills
+bun install
+```
+
+`bun install` triggers two lifecycle scripts defined in `package.json`:
+
+- `preinstall`: `bunx only-allow bun` — this will error out if you try `npm install` or
+  `yarn install` instead of `bun install`.
+- `prepare`: `lefthook install` — installs git hooks (for example commit message linting via
+  `commitlint`).
+
+## Existing behavior — local development commands
+
+| Command | What it does |
+|---|---|
+| `bun run validate` | Validates every `SKILL.md` against the spec in `docs/format.md` (backed by `packages/hr-skills-build/src/validate.ts`) |
+| `bun run sync` | Regenerates `.claude-plugin/marketplace.json` from skill frontmatter |
+| `bun run matrix` | Regenerates `docs/skill-matrix.md` |
+| `bun run registry` | Regenerates `registry/skills.json` |
+| `bun run check` | Biome check, no writes |
+| `bun run lint` | Biome check with auto-fix |
+| `bun run format` | Biome formatter |
+| `bun run lint:md` | markdownlint + case-police on Markdown |
+| `bun run lint:md:fix` | Same, with auto-fix |
+| `bun run lint:links` | Validates Markdown links in `docs/` and `skills/` |
+| `bun run typecheck` | TypeScript check across workspace packages |
+| `bun run build` | All workspace builds via Turborepo |
+| `bun run test` | Tests across workspace packages |
+| `bun run knip` | Detects unused files/dependencies |
+| `bun run plan "<intent>"` | Generates an execution plan for a user intent (see `docs/planner.md`) |
+| `bun run execute "<intent>"` | AGENTS.md-documented; generates a plan and runs it through the workflow runtime (see `docs/runtime.md`) |
+| `bun run evaluate` | Runs the evaluation framework (see `docs/evaluation.md`) |
+| `bun run changeset` / `bun run release` | Versioning/release |
+
+All of the above is **[Existing]**, taken directly from `package.json` scripts and
+cross-checked against AGENTS.md's own command list, which matches exactly.
+
+**[Existing]** CI (`.github/workflows/`) runs `knip.yml`, `lint.yml`, `matrix.yml`,
+`release.yml`, `test.yml`, `typecheck.yml`, and `validate.yml` as separate jobs — meaning
+`test` and `knip` are enforced in CI even though they're not currently listed in
+CONTRIBUTING.md's pre-submit checklist (see `CONTRIBUTING.md.suggestions.md`).
+
+## Existing behavior — testing and validation
+
+Minimum bar before opening a PR, per CONTRIBUTING.md, cross-checked against AGENTS.md and CI:
+
+```bash
+bun run validate    # 0 errors — SKILL.md spec compliance
+bun run check        # 0 Biome errors
+bun run lint:md       # 0 markdownlint errors
+bun run typecheck    # 0 TypeScript errors
+bun run build        # all workspace builds succeed
+```
+
+**[Proposed]** Also run locally, since CI checks them separately:
+
+```bash
+bun run lint:links    # no broken links in docs/ or skills/
+bun run test           # workspace tests pass
+bun run knip           # no unused files/dependencies
+```
+
+## Step-by-step: fork → development → pull request
+
+1. **Fork** the repository on GitHub.
+2. **Branch from `dev`, not `main`.** **[Existing, AGENTS.md]** `main` is the publishing
+   branch (used via `npx skills add tuanductran/hr-skills`) and only contains released
+   skills; direct commits to it are forbidden, and pull requests must target `dev`.
+3. **Develop** your change — new skill, edit, doc fix, or tooling change.
+4. **Run the full validation suite locally** (previous section).
+5. **Commit using Conventional Commits.** **[Existing, AGENTS.md]**:
+
+   ```text
+   <type>(<scope>): <short summary>
+   ```
+
+   - Imperative mood ("add", "fix", not "added", "fixes")
+   - Summary under 72 characters
+   - Scope = skill or package name when the change is isolated
+   - Reference issues in the body when relevant (`Closes #42`)
+
+   Example:
+
+   ```text
+   feat(hr-recruiting): add ATS integration prompts
+   ```
+
+6. **Open a pull request against `dev`**, filling in `.github/pull_request_template.md`:
+   what changed, content type (skill definition / competency framework / interview questions
+   / assessment criteria / recruiting workflow / AI prompt / documentation / tooling), why,
+   related issue, and the validation checklist.
+7. A maintainer reviews and merges. **[Existing]** `.github/CODEOWNERS` lists a single owner
+   (`@tuanductran`) for the entire repository. **[Unknown]** review turnaround time / SLA is
+   not documented.
+8. Periodically, `dev` is released to `main` via the release process
+   (`bun run release`, `.github/workflows/release.yml`). **[Unknown]** the exact cadence or
+   trigger for this is not documented in the repository.
+
+## Best practices
+
+- Keep PRs scoped to one skill or one concern — mirrors the commit scope convention and eases
+  review given the single-owner review model.
+- After adding or removing a skill, run `bun run sync` and `bun run matrix` locally so the
+  diff to generated files (`.claude-plugin/marketplace.json`, `docs/skill-matrix.md`) is
+  included in your PR rather than left for a maintainer to regenerate.
+
+## Common mistakes
+
+- Opening a PR against `main` instead of `dev`.
+- Running `npm install` or `yarn install` — blocked by `preinstall`, but worth knowing in
+  advance so the resulting error isn't confusing.
+- Forgetting to run `bun run sync` after adding a new skill directory, leaving
+  `.claude-plugin/marketplace.json` stale relative to `skills/`.
+
+## Suggested improvements
+
+- **[Proposed]** CONTRIBUTING.md's checklist should include `lint:links`, `test`, and `knip`
+  to match what CI actually enforces (see `CONTRIBUTING.md.suggestions.md`, item 1).
+
+## Unknown or ambiguous information
+
+- **[Unknown]** PR review SLA / backup reviewer path.
+- **[Unknown]** `dev` → `main` release cadence/trigger.


### PR DESCRIPTION
Add a consolidated contributor guide (CONTRIBUTOR_GUIDE.md) plus a new docs/contributing/ subtree covering onboarding, repository workflow, skill authoring, and worked examples for external contributors.

Also adds CONTRIBUTING.md.suggestions.md with concrete, diff-style edits proposed for the existing CONTRIBUTING.md (expanded pre-submit checklist, link-out to docs/contributing/, and two items flagged for maintainer clarification: PR review SLA and the intended audience of .agents/skills/skill-vetter/SKILL.md).

No existing files were modified. All additions are labeled [Existing], [Inferred], [Proposed], or [Unknown] to distinguish verified repository behavior from recommendations.

Related: Roadmap Phase 5 — Community & Distribution (better documentation, external contributors).

Closes #139 