### PR TITLE
docs(jsdoc): normalize and expand JSDoc across all source files

### DIFF
--- a/packages/hr-skills-build/src/config.ts
+++ b/packages/hr-skills-build/src/config.ts
@@ -5,7 +5,20 @@ import { HR_SKILL_PREFIX, SKILLS_DIR } from './constants.js';
 import type { SkillDirectoryOptions } from './types.js';
 
 /**
- * Get a list of HR skills.
+ * Discover all HR skill directory names in `skills/` that satisfy the given options.
+ *
+ * A directory is included only if:
+ *  1. It starts with the configured `prefix` (default: `"hr-"`).
+ *  2. It contains a `SKILL.md` file at its root (checked via `fs.access`).
+ *
+ * @param options - Filtering and sorting options.
+ * @param options.prefix - Directory-name prefix to filter by. Defaults to `"hr-"`.
+ * @param options.sort - Whether to return names in lexicographic order. Defaults to `true`.
+ * @returns A promise that resolves to an array of skill directory names (not full paths).
+ *
+ * @example
+ * const skills = await getHrSkills();
+ * // => ['hr-analytics', 'hr-compliance', 'hr-onboarding', ...]
  */
 export async function getHrSkills(
 	options: SkillDirectoryOptions = {},

--- a/packages/hr-skills-build/src/constants.ts
+++ b/packages/hr-skills-build/src/constants.ts
@@ -3,46 +3,93 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+/** Absolute path to the repository root (three levels up from `src/`). */
 export const ROOT_DIR = join(__dirname, '../../..');
 
+/** Absolute path to the `skills/` directory at the repo root. */
 export const SKILLS_DIR = join(ROOT_DIR, 'skills');
 
+/** Matches a markdown task-list item line, e.g. `- some task`. */
 export const TASK_ITEM_REGEX = /^- /;
 
+/** The directory-name prefix shared by all HR skill folders, e.g. `hr-`. */
 export const HR_SKILL_PREFIX = 'hr-';
 
+/**
+ * Captures the body of a `## Key prompts` section (including sub-headings)
+ * up to the next `##` section, a `---` divider, or end of file.
+ * Capture group 1 contains the raw block text.
+ */
 export const KEY_PROMPTS_REGEX =
 	/## Key prompts\r?\n\r?\n([\s\S]*?)(?=\r?\n## |\r?\n---\r?\n|$)/;
 
+/**
+ * Matches a numbered or bulleted quoted prompt line inside a Key prompts block,
+ * e.g. `1. "Create a job description for..."` or `- "Draft an offer letter..."`.
+ * Capture group 1 contains the quoted prompt text (without surrounding quotes).
+ */
 export const QUOTED_PROMPT_REGEX = /^(?:\d+\. |[-*] )"([^"]+)"/gm;
 
+/**
+ * Case-insensitive match for the phrase `Use when` inside a skill description,
+ * used to split a description into its "coverage" and "trigger" clauses.
+ */
 export const USE_WHEN_REGEX = /Use when/i;
 
+/** Matches a trailing period at the end of a string — used to strip it before appending a new one. */
 export const PERIOD_REGEX = /\.$/;
 
+/**
+ * Captures YAML frontmatter delimited by `---` at the start of a markdown file.
+ * Capture group 1 contains the raw YAML text between the delimiters.
+ */
 export const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
 
+/**
+ * Captures the body of a `## Supported tasks` section up to the next `##` heading
+ * or end of file. Capture group 1 contains the raw block text.
+ */
 export const TASKS_REGEX = /## Supported tasks\r?\n\r?\n([\s\S]*?)(?=\r?\n##|$)/;
 
+/**
+ * The three markdown section headings that every skill SKILL.md must contain.
+ * Validated by `validateRequiredSections` in validate.ts.
+ */
 export const REQUIRED_SECTIONS = ['## Supported tasks', '## Key prompts', '## Tips'];
 
+/** Minimum character length for a skill's frontmatter `description` field. */
 export const MIN_DESCRIPTION_LENGTH = 50;
 
+/** Minimum character length for the full SKILL.md content body. */
 export const MIN_CONTENT_LENGTH = 1000;
 
+/**
+ * Captures the body of a `## Tips` section up to the next `##` heading or end of file.
+ * Capture group 1 contains the raw block text.
+ */
 export const TIPS_REGEX = /## Tips\r?\n\r?\n([\s\S]*?)(?=\r?\n##|$)/;
 
 /**
- * Matches markdown links to skills, e.g. `[hr-recruiting](skills/hr-recruiting)`.
+ * Matches markdown links that reference another skill, e.g.
+ * `[hr-recruiting](skills/hr-recruiting)`.
+ * Capture group 1 contains the skill ID (`hr-<slug>`).
+ *
  * Shared by router consistency validation and registry dependency extraction
- * (CATEGORY_META.preamble in classifier.ts) so both stay in sync.
+ * (`CATEGORY_META.preamble` in classifier.ts) so both stay in sync.
  */
 export const SKILL_LINK_REGEX = /\[hr-[a-z0-9-]+\]\(skills\/(hr-[a-z0-9-]+)\)/g;
 
+/**
+ * Schema version for `registry/skills.json`.
+ * Increment this when the shape of {@link RegistryEntry} changes in a breaking way.
+ */
 export const REGISTRY_SCHEMA_VERSION = 1;
 
+/** Absolute path to the `eval/` directory inside `hr-skills-build`. */
 const EVAL_DIR = join(__dirname, '..', 'eval');
 
+/** Absolute path to the `eval/datasets/` directory containing hand-authored evaluation cases. */
 export const EVAL_DATASETS_DIR = join(EVAL_DIR, 'datasets');
 
+/** Absolute path to the `eval/golden/` directory containing committed golden fixtures. */
 export const EVAL_GOLDEN_DIR = join(EVAL_DIR, 'golden');

--- a/packages/hr-skills-build/src/helpers.ts
+++ b/packages/hr-skills-build/src/helpers.ts
@@ -7,14 +7,22 @@ import type { SkillFrontmatter } from './schema.js';
 import type { SkillValidationIssue, Tier } from './types.js';
 
 /**
- * Extract a match from a markdown skill file.
+ * Extract and trim the first capture group from a regex match against `content`.
+ *
+ * @param regex - A regular expression with at least one capture group.
+ * @param content - The string to search.
+ * @returns The trimmed contents of capture group 1, or `null` if the regex did not match.
  */
 export function extractMatch(regex: RegExp, content: string): string | null {
 	return regex.exec(content)?.[1]?.trim() ?? null;
 }
 
 /**
- * Discover skills in the skills directory.
+ * Discover all HR skill directory names in `skills/`, sorted lexicographically.
+ *
+ * Only directories whose names start with `HR_SKILL_PREFIX` (`"hr-"`) are returned.
+ *
+ * @returns A promise that resolves to a sorted array of skill directory names.
  */
 export async function discoverSkills(): Promise<string[]> {
 	const entries = await readdir(SKILLS_DIR, {
@@ -28,7 +36,12 @@ export async function discoverSkills(): Promise<string[]> {
 }
 
 /**
- * Read a skill file.
+ * Read a skill's `SKILL.md` content and parse its YAML frontmatter.
+ *
+ * @param skillName - The skill's directory name (e.g. `"hr-onboarding"`).
+ * @returns A promise that resolves to an object containing the raw `content`
+ *   string and the parsed `frontmatter` record.
+ * @throws If `SKILL.md` cannot be read from the filesystem.
  */
 export async function readSkill(skillName: string): Promise<{
 	content: string;
@@ -44,7 +57,14 @@ export async function readSkill(skillName: string): Promise<{
 }
 
 /**
- * Read a skill file content.
+ * Read a skill's `SKILL.md` content, collecting a validation issue instead of
+ * throwing if the file is not found.
+ *
+ * @param skillName - The skill's directory name (e.g. `"hr-onboarding"`).
+ * @param errors - Mutable array to which a `SkillValidationIssue` is pushed
+ *   if the file cannot be read.
+ * @returns A promise that resolves to the raw file content, or `null` if the
+ *   file was not found (in which case an issue has been added to `errors`).
  */
 export async function readSkillContent(
 	skillName: string,
@@ -64,7 +84,16 @@ export async function readSkillContent(
 }
 
 /**
- * Normalize author name.
+ * Normalize an author name to Title Case.
+ *
+ * Each whitespace-separated word is capitalized; all other characters are
+ * lower-cased. Leading and trailing whitespace is stripped.
+ *
+ * @param name - The raw author string to normalize.
+ * @returns The normalized Title Case author name.
+ *
+ * @example
+ * normalizeAuthorName('john DOE') // => 'John Doe'
  */
 export function normalizeAuthorName(name: string): string {
 	return name
@@ -75,7 +104,11 @@ export function normalizeAuthorName(name: string): string {
 }
 
 /**
- * Get the first element of an array.
+ * Return the first element of a non-empty readonly array.
+ *
+ * @param items - A readonly array that must contain at least one element.
+ * @returns The first element of `items`.
+ * @throws {Error} If `items` is empty.
  */
 export function first<T>(items: readonly T[]): T {
 	const first = items.at(0);
@@ -87,7 +120,11 @@ export function first<T>(items: readonly T[]): T {
 }
 
 /**
- * Check if a directory exists.
+ * Check whether a filesystem path exists and is a directory.
+ *
+ * @param path - The filesystem path to check.
+ * @returns A promise that resolves to `true` if `path` is an existing directory,
+ *   or `false` if it does not exist or is not a directory.
  */
 export async function dirExists(path: string): Promise<boolean> {
 	try {
@@ -99,7 +136,11 @@ export async function dirExists(path: string): Promise<boolean> {
 }
 
 /**
- * Count .md files in a directory.
+ * Count the number of `.md` files directly inside a directory.
+ * Returns `0` if the directory does not exist or cannot be read.
+ *
+ * @param dirPath - The absolute path to the directory to inspect.
+ * @returns A promise that resolves to the count of `.md` files found.
  */
 export async function countFiles(dirPath: string): Promise<number> {
 	try {
@@ -111,11 +152,21 @@ export async function countFiles(dirPath: string): Promise<number> {
 }
 
 /**
- * Compute a skill's maturity tier from its subdirectory presence.
+ * Compute a skill's maturity tier based on which optional subdirectories it contains.
  *
- * Single source of truth for tier classification — used by both
- * generate-skill-matrix.ts and generate-registry.ts so the matrix and the
+ * Tier rules:
+ * - `'full'`    — all three subdirectories (`content/`, `prompts/`, `examples/`) are present.
+ * - `'bare'`    — none of the subdirectories are present.
+ * - `'partial'` — one or two subdirectories are present.
+ *
+ * This is the single source of truth for tier classification — used by both
+ * `generate-skill-matrix.ts` and `generate-registry.ts` so the matrix and the
  * registry can never disagree about a skill's tier.
+ *
+ * @param hasContent - Whether the `content/` subdirectory exists and is non-empty.
+ * @param hasPrompts - Whether the `prompts/` subdirectory exists and is non-empty.
+ * @param hasExamples - Whether the `examples/` subdirectory exists and is non-empty.
+ * @returns The computed {@link Tier} for the skill.
  */
 export function computeTier(
 	hasContent: boolean,
@@ -128,7 +179,14 @@ export function computeTier(
 }
 
 /**
- * Return the emoji icon for a skill tier.
+ * Return the emoji icon associated with a skill maturity tier.
+ *
+ * - `'full'`    → `'🟢'`
+ * - `'partial'` → `'🟡'`
+ * - `'bare'`    → `'🔴'`
+ *
+ * @param tier - The skill's maturity tier.
+ * @returns A single emoji string representing the tier.
  */
 export function tierIcon(tier: Tier): string {
 	if (tier === 'full') return '🟢';
@@ -137,7 +195,10 @@ export function tierIcon(tier: Tier): string {
 }
 
 /**
- * Return the display label for a skill tier.
+ * Return the human-readable display label for a skill maturity tier.
+ *
+ * @param tier - The skill's maturity tier.
+ * @returns `'Full'`, `'Partial'`, or `'Bare'`.
  */
 export function tierLabel(tier: Tier): string {
 	if (tier === 'full') return 'Full';
@@ -146,7 +207,15 @@ export function tierLabel(tier: Tier): string {
 }
 
 /**
- * Build content with N subtopics of M prompts each.
+ * Build a SKILL.md content string with a `## Key prompts` section containing
+ * `subtopics` H3 sub-headings, each with `promptsEach` numbered quoted prompts.
+ *
+ * Used in unit tests to generate fixture content of a specific size without
+ * manually crafting strings.
+ *
+ * @param subtopics - Number of H3 sub-heading blocks to generate.
+ * @param promptsEach - Number of quoted prompts to generate under each sub-heading.
+ * @returns A full SKILL.md string with valid frontmatter and the generated prompts section.
  */
 export function makeKeyPromptsContent(subtopics: number, promptsEach: number): string {
 	const blocks = Array.from({ length: subtopics }, (_, si) => {

--- a/packages/hr-skills-build/src/runtime-context.ts
+++ b/packages/hr-skills-build/src/runtime-context.ts
@@ -14,28 +14,62 @@ class RuntimeContextImpl implements RuntimeContext {
 	readonly intent: string;
 	private readonly outputs = new Map<string, unknown>();
 
+	/**
+	 * @param intent - The original user intent the plan was generated for.
+	 *   Stored read-only on the context so every step executor can inspect it.
+	 */
 	constructor(intent: string) {
 		this.intent = intent;
 	}
 
+	/**
+	 * Retrieve the output recorded for a completed step.
+	 *
+	 * @param skillId - The ID of the skill whose output to retrieve.
+	 * @returns The stored output value, or `undefined` if the skill has not yet run.
+	 */
 	get(skillId: string): unknown {
 		return this.outputs.get(skillId);
 	}
 
+	/**
+	 * Record the output produced by a completed step, making it visible
+	 * to all subsequent steps in the workflow.
+	 *
+	 * @param skillId - The ID of the skill that produced the output.
+	 * @param value - The output value to store (any serializable type).
+	 */
 	set(skillId: string, value: unknown): void {
 		this.outputs.set(skillId, value);
 	}
 
+	/**
+	 * Check whether a skill has already produced output in this context.
+	 *
+	 * @param skillId - The ID of the skill to check.
+	 * @returns `true` if an output was recorded for `skillId`, `false` otherwise.
+	 */
 	has(skillId: string): boolean {
 		return this.outputs.has(skillId);
 	}
 
+	/**
+	 * Return a plain-object snapshot of all outputs recorded so far, keyed by skill ID.
+	 * The returned object is a shallow copy — mutations do not affect the internal map.
+	 *
+	 * @returns A `Record<string, unknown>` containing all skill outputs recorded so far.
+	 */
 	toObject(): Record<string, unknown> {
 		return Object.fromEntries(this.outputs);
 	}
 }
 
-/** Create a fresh, empty runtime context for the given plan intent. */
+/**
+ * Create a fresh, empty runtime context for the given plan intent.
+ *
+ * @param intent - The original user intent passed to `generateExecutionPlan`.
+ * @returns A new `RuntimeContext` instance with no recorded outputs.
+ */
 export function createRuntimeContext(intent: string): RuntimeContext {
 	return new RuntimeContextImpl(intent);
 }

--- a/packages/hr-skills-build/src/runtime-errors.ts
+++ b/packages/hr-skills-build/src/runtime-errors.ts
@@ -8,17 +8,39 @@
 
 import type { RuntimeErrorInfo } from './types.js';
 
+/**
+ * Machine-readable codes for runtime failures.
+ *
+ * - `STEP_EXECUTION_FAILED` — the step executor threw after exhausting retries.
+ * - `STEP_DEPENDENCY_FAILED` — a required upstream step failed.
+ * - `STEP_DEPENDENCY_SKIPPED` — a required upstream step was skipped.
+ */
 export type RuntimeErrorCode =
 	| 'STEP_EXECUTION_FAILED'
 	| 'STEP_DEPENDENCY_FAILED'
 	| 'STEP_DEPENDENCY_SKIPPED';
 
+/**
+ * Structured error produced by the Workflow Runtime when a step fails.
+ *
+ * Extends the native `Error` class with `code`, `skillId`, and `attempt`
+ * fields so that error handlers can branch on failure type without string
+ * parsing, and so that traces capture enough context to reconstruct what
+ * went wrong without needing to re-run the workflow.
+ */
 export class RuntimeError extends Error {
 	readonly code: RuntimeErrorCode;
 	readonly skillId: string;
 	readonly attempt: number;
 	override readonly cause?: unknown;
 
+	/**
+	 * @param code - Machine-readable failure code.
+	 * @param message - Human-readable description of the failure.
+	 * @param options.skillId - The skill ID of the step that failed.
+	 * @param options.attempt - The attempt number on which the failure occurred (1-indexed).
+	 * @param options.cause - The original thrown value, if available.
+	 */
 	constructor(
 		code: RuntimeErrorCode,
 		message: string,
@@ -32,7 +54,14 @@ export class RuntimeError extends Error {
 		this.cause = options.cause;
 	}
 
-	/** Convert to a plain, JSON-serializable shape for traces and results. */
+	/**
+	 * Convert to a plain, JSON-serializable shape for traces and results.
+	 * The `cause` field is normalized via {@link describeCause} so that
+	 * non-serializable thrown values (e.g. Error instances) survive
+	 * `JSON.stringify` without losing the message.
+	 *
+	 * @returns A {@link RuntimeErrorInfo} object suitable for embedding in step results and traces.
+	 */
 	toInfo(): RuntimeErrorInfo {
 		const info: RuntimeErrorInfo = {
 			code: this.code,
@@ -49,7 +78,16 @@ export class RuntimeError extends Error {
 
 /**
  * Normalize an unknown thrown value (from a step executor) into a
- * human-readable message, without assuming it's an `Error` instance.
+ * human-readable string, without assuming it is an `Error` instance.
+ *
+ * Resolution order:
+ *  1. `Error` instance → `error.message`
+ *  2. String primitive → returned as-is
+ *  3. Any serializable value → `JSON.stringify`
+ *  4. Anything else → `String(cause)`
+ *
+ * @param cause - The unknown value that was thrown.
+ * @returns A human-readable string describing the cause.
  */
 export function describeCause(cause: unknown): string {
 	if (cause instanceof Error) return cause.message;

--- a/packages/hr-skills-build/src/runtime-events.ts
+++ b/packages/hr-skills-build/src/runtime-events.ts
@@ -16,10 +16,27 @@ export class EventDispatcher {
 	private nextOrder = 0;
 	private readonly onEvent: ((event: RuntimeEvent) => void) | undefined;
 
+	/**
+	 * @param onEvent - Optional callback invoked synchronously each time an
+	 *   event is emitted. Useful for live progress UIs or logging. The
+	 *   callback receives the fully constructed event object before it is
+	 *   added to the internal event log.
+	 */
 	constructor(onEvent?: (event: RuntimeEvent) => void) {
 		this.onEvent = onEvent;
 	}
 
+	/**
+	 * Emit a new runtime event, assign it the next logical clock value,
+	 * append it to the internal log, and invoke the optional `onEvent` callback.
+	 *
+	 * @param type - The event type (e.g. `'step-started'`, `'workflow-completed'`).
+	 * @param details - Optional supplementary data to attach to the event.
+	 * @param details.skillId - The skill this event concerns, if applicable.
+	 * @param details.attempt - The attempt number for retry events.
+	 * @param details.data - Arbitrary key-value pairs for diagnostics or tracing.
+	 * @returns The fully constructed {@link RuntimeEvent} that was emitted.
+	 */
 	emit(
 		type: RuntimeEventType,
 		details: {
@@ -38,6 +55,11 @@ export class EventDispatcher {
 		return event;
 	}
 
+	/**
+	 * Return a shallow copy of all events emitted so far, in emission order.
+	 *
+	 * @returns An array of {@link RuntimeEvent} objects ordered by their `order` field.
+	 */
 	all(): RuntimeEvent[] {
 		return [...this.events];
 	}

--- a/packages/hr-skills-build/src/runtime-retry.ts
+++ b/packages/hr-skills-build/src/runtime-retry.ts
@@ -11,7 +11,15 @@
 
 import type { RetryPolicy } from './types.js';
 
-/** No retries: fail immediately on the first error. */
+/**
+ * Create a retry policy that never retries — the step fails immediately
+ * on the first error.
+ *
+ * This is the default policy used by `WorkflowExecutor` when no
+ * `retryPolicy` option is provided.
+ *
+ * @returns A {@link RetryPolicy} with `maxRetries: 0`.
+ */
 export function noRetryPolicy(): RetryPolicy {
 	return {
 		maxRetries: 0,
@@ -19,7 +27,15 @@ export function noRetryPolicy(): RetryPolicy {
 	};
 }
 
-/** Retry a fixed number of times with a constant logical delay. */
+/**
+ * Create a retry policy that retries a fixed number of times with a
+ * constant logical delay between each attempt.
+ *
+ * @param options.maxRetries - Maximum number of retry attempts after the initial try.
+ * @param options.delayMs - Logical delay in milliseconds recorded per retry attempt.
+ *   Defaults to `0` (no delay recorded). The runtime does not actually sleep.
+ * @returns A {@link RetryPolicy} with a fixed delay for all attempts.
+ */
 export function fixedRetryPolicy(options: {
 	maxRetries: number;
 	delayMs?: number;
@@ -31,7 +47,18 @@ export function fixedRetryPolicy(options: {
 	};
 }
 
-/** Retry with exponential backoff: delay = baseDelayMs * 2^(attempt - 1). */
+/**
+ * Create a retry policy that uses exponential backoff:
+ * `delay = baseDelayMs * 2^(attempt - 1)`, capped at `maxDelayMs`.
+ *
+ * Example with `baseDelayMs: 100`: attempt 1 → 100 ms, attempt 2 → 200 ms,
+ * attempt 3 → 400 ms, and so on.
+ *
+ * @param options.maxRetries - Maximum number of retry attempts after the initial try.
+ * @param options.baseDelayMs - Base delay in milliseconds. Defaults to `100`.
+ * @param options.maxDelayMs - Upper bound on any single delay. Defaults to `Infinity`.
+ * @returns A {@link RetryPolicy} with exponential backoff delays.
+ */
 export function exponentialRetryPolicy(options: {
 	maxRetries: number;
 	baseDelayMs?: number;

--- a/packages/hr-skills-build/src/runtime-state.ts
+++ b/packages/hr-skills-build/src/runtime-state.ts
@@ -21,8 +21,15 @@ export class RuntimeStateTracker {
 	private readonly failed = new Set<string>();
 	private readonly skipped = new Set<string>();
 
+	/** Map from status label to the corresponding bucket set, used by `transition`. */
 	private readonly buckets: Record<StepStatus, Set<string>>;
 
+	/**
+	 * Initialize the tracker with all given skill IDs in the `pending` bucket.
+	 *
+	 * @param skillIds - The ordered list of skill IDs from the execution plan.
+	 *   Every ID starts in `pending` and transitions through the lifecycle from there.
+	 */
 	constructor(skillIds: readonly string[]) {
 		this.buckets = {
 			pending: this.pending,
@@ -36,6 +43,12 @@ export class RuntimeStateTracker {
 		}
 	}
 
+	/**
+	 * Return the current lifecycle status of a skill ID.
+	 *
+	 * @param skillId - The skill ID to look up.
+	 * @returns The current {@link StepStatus}, or `undefined` if the ID is unknown.
+	 */
 	statusOf(skillId: string): StepStatus | undefined {
 		for (const [status, bucket] of Object.entries(this.buckets) as Array<
 			[StepStatus, Set<string>]
@@ -45,7 +58,14 @@ export class RuntimeStateTracker {
 		return undefined;
 	}
 
-	/** Move a skill ID from its current bucket into `next`. */
+	/**
+	 * Move a skill ID from its current bucket into `next`.
+	 * Removes the ID from all buckets before adding it to the target,
+	 * ensuring the partitioning invariant is maintained.
+	 *
+	 * @param skillId - The skill ID to transition.
+	 * @param next - The target lifecycle status.
+	 */
 	private transition(skillId: string, next: StepStatus): void {
 		for (const bucket of Object.values(this.buckets)) {
 			bucket.delete(skillId);
@@ -53,26 +73,63 @@ export class RuntimeStateTracker {
 		this.buckets[next].add(skillId);
 	}
 
+	/**
+	 * Transition a skill from `pending` to `running`.
+	 * Called immediately before the step executor is invoked.
+	 *
+	 * @param skillId - The skill ID that is beginning execution.
+	 */
 	start(skillId: string): void {
 		this.transition(skillId, 'running');
 	}
 
+	/**
+	 * Transition a skill from `running` to `completed`.
+	 * Called after the step executor returns successfully.
+	 *
+	 * @param skillId - The skill ID that finished without error.
+	 */
 	complete(skillId: string): void {
 		this.transition(skillId, 'completed');
 	}
 
+	/**
+	 * Transition a skill from `running` to `failed`.
+	 * Called after the step executor throws and all retry attempts are exhausted.
+	 *
+	 * @param skillId - The skill ID that failed definitively.
+	 */
 	fail(skillId: string): void {
 		this.transition(skillId, 'failed');
 	}
 
+	/**
+	 * Transition a skill directly to `skipped` (bypassing `running`).
+	 * Called when a step's dependency has failed or been skipped.
+	 *
+	 * @param skillId - The skill ID that is being skipped.
+	 */
 	skip(skillId: string): void {
 		this.transition(skillId, 'skipped');
 	}
 
+	/**
+	 * Check whether a skill is still in the `pending` bucket.
+	 *
+	 * @param skillId - The skill ID to check.
+	 * @returns `true` if the skill has not yet started execution.
+	 */
 	isPending(skillId: string): boolean {
 		return this.pending.has(skillId);
 	}
 
+	/**
+	 * Return a plain-object snapshot of the current state across all buckets.
+	 * Arrays for `pending` and `running` are sorted for determinism; `completed`,
+	 * `failed`, and `skipped` preserve insertion order (execution sequence).
+	 *
+	 * @returns A {@link RuntimeStateSnapshot} reflecting the current lifecycle distribution.
+	 */
 	snapshot(): RuntimeStateSnapshot {
 		return {
 			pending: Array.from(this.pending).sort(),

--- a/packages/hr-skills-build/src/runtime-trace.ts
+++ b/packages/hr-skills-build/src/runtime-trace.ts
@@ -19,6 +19,17 @@ import type {
 export class TraceCollector {
 	private readonly entries: TraceEntry[] = [];
 
+	/**
+	 * Record a new trace entry pairing an event with the runtime state snapshot
+	 * that was taken immediately after the event was applied.
+	 *
+	 * @param event - The runtime event that was just emitted.
+	 * @param state - Snapshot of the runtime state after `event` was applied.
+	 * @param extras - Optional supplementary data attached to the entry.
+	 * @param extras.result - The output value returned by a completed step.
+	 * @param extras.error - The serializable error info produced by a failed step.
+	 * @returns The newly created {@link TraceEntry} that was appended to the log.
+	 */
 	record(
 		event: RuntimeEvent,
 		state: RuntimeStateSnapshot,
@@ -38,6 +49,12 @@ export class TraceCollector {
 		return entry;
 	}
 
+	/**
+	 * Return a shallow copy of all trace entries recorded so far, in the order
+	 * they were recorded (i.e. matching the logical event clock order).
+	 *
+	 * @returns An array of {@link TraceEntry} objects representing the full execution trace.
+	 */
 	all(): TraceEntry[] {
 		return [...this.entries];
 	}

--- a/packages/hr-skills-build/src/schema.ts
+++ b/packages/hr-skills-build/src/schema.ts
@@ -1,5 +1,9 @@
 import * as v from 'valibot';
 
+/**
+ * Valibot schema for `.claude-plugin/marketplace.json`.
+ * Used by `sync.ts` to parse and validate the file before updating it.
+ */
 export const MarketplaceJsonSchema = v.object({
 	name: v.string(),
 	description: v.string(),
@@ -13,6 +17,12 @@ export const MarketplaceJsonSchema = v.object({
 	),
 });
 
+/**
+ * Valibot schema for the YAML frontmatter of a skill's `SKILL.md`.
+ * All fields are optional — callers should treat a missing field as absent
+ * rather than as an error at this layer (higher-level validation handles
+ * required-field checks).
+ */
 export const SkillFrontmatterSchema = v.object({
 	name: v.optional(v.pipe(v.string(), v.trim())),
 	description: v.optional(v.pipe(v.string(), v.trim())),
@@ -24,12 +34,17 @@ export const SkillFrontmatterSchema = v.object({
 	),
 });
 
+/** TypeScript type inferred from {@link SkillFrontmatterSchema}. */
 export type SkillFrontmatter = v.InferOutput<typeof SkillFrontmatterSchema>;
 
 // ---------------------------------------------------------------------------
 // Skill registry schema
 // ---------------------------------------------------------------------------
 
+/**
+ * All valid domain category slugs for a skill entry.
+ * Must stay in sync with `SkillCategory` in classifier.ts.
+ */
 const SKILL_CATEGORIES = [
 	'talent-acquisition',
 	'onboarding-offboarding',
@@ -46,6 +61,10 @@ const SKILL_CATEGORIES = [
 	'uncategorized',
 ] as const;
 
+/**
+ * Valibot schema for a single entry in `registry/skills.json`.
+ * Mirrors the `RegistryEntry` interface in types.ts.
+ */
 const RegistryEntrySchema = v.object({
 	id: v.pipe(v.string(), v.minLength(1)),
 	name: v.pipe(v.string(), v.minLength(1)),
@@ -66,6 +85,11 @@ const RegistryEntrySchema = v.object({
 	relatedSkills: v.array(v.string()),
 });
 
+/**
+ * Valibot schema for the full `registry/skills.json` document.
+ * Used by `validate-registry.ts` to confirm the committed file conforms to
+ * the expected shape before checking staleness, duplicates, and graph integrity.
+ */
 export const RegistrySchema = v.object({
 	schemaVersion: v.number(),
 	generatedAt: v.string(),

--- a/packages/skills-ref/src/constants.ts
+++ b/packages/skills-ref/src/constants.ts
@@ -4,24 +4,50 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '../../..');
 
+/** Absolute path to the `skills/` directory at the repository root. */
 export const SKILLS_DIR = join(ROOT_DIR, 'skills');
 
+/**
+ * The YAML frontmatter key used to specify which Claude tools a skill is allowed to invoke.
+ * Maps to the `allowedTools` property in {@link SkillProperties}.
+ */
 export const ALLOWED_TOOLS_KEY = 'allowed-tools';
 
+/**
+ * Matches any non-whitespace character.
+ * Used when scanning YAML lines for their indentation level.
+ */
 export const NON_WHITESPACE_REGEX = /\S/u;
 
+/** The delimiter string that opens and closes a YAML frontmatter block in `SKILL.md`. */
 export const FRONTMATTER_DELIMITER = '---';
 
+/**
+ * Accepted filenames for a skill's primary markdown file, in priority order.
+ * `"SKILL.md"` is the canonical name; `"skill.md"` is accepted as a fallback
+ * for case-insensitive filesystems.
+ */
 export const SKILL_MD_FILENAMES = ['SKILL.md', 'skill.md'] as const;
 
+/** Maximum allowed character length for the `name` frontmatter field. */
 export const MAX_SKILL_NAME_LENGTH = 64;
 
+/** Maximum allowed character length for the `description` frontmatter field. */
 export const MAX_DESCRIPTION_LENGTH = 1024;
 
+/** Maximum allowed character length for the `compatibility` frontmatter field. */
 export const MAX_COMPATIBILITY_LENGTH = 500;
 
+/**
+ * Valid skill name pattern: lowercase letters, digits, and hyphens only.
+ * Must be tested against the normalized (trimmed, lowercased) name.
+ */
 export const SKILL_NAME_REGEX = /^[a-z0-9-]+$/;
 
+/**
+ * The set of YAML frontmatter field names recognized by the skill schema.
+ * Any key not in this set is treated as an unexpected field during validation.
+ */
 export const ALLOWED_FRONTMATTER_FIELDS = new Set<string>([
 	'name',
 	'description',
@@ -31,6 +57,10 @@ export const ALLOWED_FRONTMATTER_FIELDS = new Set<string>([
 	'compatibility',
 ]);
 
+/**
+ * Lookup map of XML special characters to their escaped entity equivalents.
+ * Used by `escapeXml` in `helpers.ts` when building `<skill>` XML blocks.
+ */
 export const XML_ESCAPES = new Map<string, string>([
 	['&', '&amp;'],
 	['<', '&lt;'],

--- a/packages/skills-ref/src/helpers.ts
+++ b/packages/skills-ref/src/helpers.ts
@@ -6,7 +6,11 @@ import { SKILLS_DIR, XML_ESCAPES } from './constants.js';
 import { findSkillMd, readProperties } from './loader.js';
 
 /**
- * Checks if a value is a plain object.
+ * Check whether a value is a plain object (i.e. created via `{}` or `Object.create(null)`).
+ * Returns `false` for arrays, class instances, `null`, and primitives.
+ *
+ * @param value - The value to test.
+ * @returns `true` if `value` is a plain object, `false` otherwise.
  */
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return (
@@ -17,7 +21,16 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 }
 
 /**
- * Removes quotes from a string.
+ * Strip surrounding single or double quotes from a string.
+ * If the string is not quoted, it is returned unchanged.
+ *
+ * @param value - The string to unquote.
+ * @returns The string with surrounding matching quotes removed, or the original string.
+ *
+ * @example
+ * unquote('"hello"')  // => 'hello'
+ * unquote("'world'")  // => 'world'
+ * unquote('no-quotes') // => 'no-quotes'
  */
 export function unquote(value: string): string {
 	if (
@@ -30,21 +43,39 @@ export function unquote(value: string): string {
 }
 
 /**
- * Converts a value to a string or undefined.
+ * Convert a nullable/undefined value to a trimmed string, or `undefined` if
+ * the result would be empty.
+ *
+ * @param value - The value to convert.
+ * @returns A non-empty trimmed string, or `undefined` if `value` is `null`,
+ *   `undefined`, or whitespace-only.
  */
 export function toStringOrUndefined(value: unknown): string | undefined {
 	return value != null ? String(value).trim() || undefined : undefined;
 }
 
 /**
- * Escapes XML special characters in a string.
+ * Escape XML special characters in a string so it can be safely embedded
+ * in an XML attribute value or element body.
+ *
+ * Escapes: `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`,
+ *           `"` → `&quot;`, `'` → `&apos;`.
+ *
+ * @param value - The raw string to escape.
+ * @returns The XML-escaped string.
  */
 function escapeXml(value: string): string {
 	return value.replace(/[&<>"']/g, (char) => XML_ESCAPES.get(char) ?? char);
 }
 
 /**
- * Creates an XML skill block for a skill.
+ * Build an XML `<skill>` block for the given skill directory.
+ *
+ * The block includes the skill's `<name>`, `<description>`, and the absolute
+ * `<location>` path to its `SKILL.md`. All values are XML-escaped.
+ *
+ * @param skillDir - The directory path (absolute or relative) of the skill.
+ * @returns A multi-line XML string representing the skill.
  */
 export function createSkillBlock(skillDir: string): string {
 	const resolvedPath = resolve(skillDir);
@@ -61,7 +92,10 @@ export function createSkillBlock(skillDir: string): string {
 }
 
 /**
- * Discovers all skill names in the skills directory.
+ * Discover all HR skill directory names in the `skills/` folder, sorted
+ * lexicographically. Only directories whose names begin with `"hr-"` are returned.
+ *
+ * @returns A sorted array of skill directory names (not full paths).
  */
 export function discoverSkillNames(): string[] {
 	return readdirSync(SKILLS_DIR, { withFileTypes: true })
@@ -71,7 +105,14 @@ export function discoverSkillNames(): string[] {
 }
 
 /**
- * Creates a temporary skill directory with a SKILL.md file.
+ * Create a temporary directory containing a single `SKILL.md` file with the
+ * given content. The directory is created in the OS temp directory.
+ *
+ * Intended for use in tests that need a real filesystem path to pass to
+ * skill-loading functions without polluting the repository.
+ *
+ * @param content - The UTF-8 content to write to `SKILL.md`.
+ * @returns The absolute path to the newly created temporary directory.
  */
 export function makeTempSkill(content: string): string {
 	const tmp = mkdtempSync(join(tmpdir(), 'skill-test-'));

--- a/packages/skills-ref/src/index.ts
+++ b/packages/skills-ref/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Public API for the `skills-ref` package.
+ *
+ * Re-exports the three main entry points:
+ *  - {@link readProperties} — read and validate skill frontmatter from disk.
+ *  - {@link toPrompt}       — render skill directories as an XML system-prompt block.
+ *  - {@link validate}       — validate a skill directory against all core rules.
+ */
 export { readProperties } from './loader.js';
 export { toPrompt } from './prompt.js';
 export { validate } from './validator.js';

--- a/packages/skills-ref/src/loader.ts
+++ b/packages/skills-ref/src/loader.ts
@@ -10,7 +10,13 @@ import type { SkillProperties } from './schema.js';
 import { SkillPropertiesSchema } from './schema.js';
 
 /**
- * Find SKILL.md in a skill directory.
+ * Find the `SKILL.md` file inside a skill directory.
+ *
+ * Checks filenames in the order defined by `SKILL_MD_FILENAMES` and
+ * returns the path to the first one that exists on disk.
+ *
+ * @param skillDir - Absolute path to the skill directory to search.
+ * @returns The absolute path to the found file, or `null` if neither filename exists.
  */
 export function findSkillMd(skillDir: string): string | null {
 	for (const filename of SKILL_MD_FILENAMES) {
@@ -21,7 +27,12 @@ export function findSkillMd(skillDir: string): string | null {
 }
 
 /**
- * Convert an unknown value to a string record.
+ * Coerce an unknown value to a `Record<string, string>` by stringifying every value.
+ * Returns `undefined` if the input is not a plain object.
+ *
+ * @param value - The value to coerce (typically the parsed `metadata:` block).
+ * @returns A `Record<string, string>` with all values converted via `String()`,
+ *   or `undefined` if `value` is not a plain object.
  */
 function toStringRecord(value: unknown): Record<string, string> | undefined {
 	if (!isPlainObject(value)) return undefined;
@@ -32,7 +43,18 @@ function toStringRecord(value: unknown): Record<string, string> | undefined {
 }
 
 /**
- * Read skill properties from SKILL.md frontmatter.
+ * Read and parse the properties of a skill from its `SKILL.md` frontmatter.
+ *
+ * Steps:
+ *  1. Locate `SKILL.md` (or `skill.md`) in `skillDir`.
+ *  2. Read the file as UTF-8.
+ *  3. Parse the YAML frontmatter.
+ *  4. Validate the parsed data against {@link SkillPropertiesSchema}.
+ *
+ * @param skillDir - Absolute path to the skill directory.
+ * @returns The validated {@link SkillProperties} extracted from the frontmatter.
+ * @throws {ParseError} If `SKILL.md` is not found or cannot be parsed.
+ * @throws {ValidationError} If the frontmatter does not satisfy the schema.
  */
 export function readProperties(skillDir: string): SkillProperties {
 	const skillMd = findSkillMd(skillDir);

--- a/packages/skills-ref/src/models.ts
+++ b/packages/skills-ref/src/models.ts
@@ -2,7 +2,16 @@ import { ALLOWED_TOOLS_KEY } from './constants.js';
 import type { SkillProperties } from './schema.js';
 
 /**
- * Converts a skill's properties to a dictionary.
+ * Convert a skill's {@link SkillProperties} to a plain dictionary suitable for
+ * serialization (e.g. JSON output or YAML round-tripping).
+ *
+ * Only fields with defined, non-null values are included in the result —
+ * optional properties are omitted rather than serialized as `null`.
+ * The `allowedTools` field is keyed as `"allowed-tools"` to match the raw
+ * frontmatter field name expected by the Claude plugin format.
+ *
+ * @param props - The validated skill properties to convert.
+ * @returns A `Record<string, unknown>` containing only the present fields.
  */
 export function toDict(props: SkillProperties): Record<string, unknown> {
 	const result: Record<string, unknown> = {

--- a/packages/skills-ref/src/parser.ts
+++ b/packages/skills-ref/src/parser.ts
@@ -3,7 +3,18 @@ import { ParseError } from './errors.js';
 import { unquote } from './helpers.js';
 
 /**
- * Parse YAML frontmatter from SKILL.md content.
+ * Parse the YAML frontmatter block from a `SKILL.md` file.
+ *
+ * Expects the content to begin with a `---` delimiter, followed by YAML,
+ * followed by a closing `---` delimiter. Everything after the closing
+ * delimiter is the body.
+ *
+ * @param content - The full UTF-8 content of a `SKILL.md` file.
+ * @returns A tuple of `[frontmatter, body]` where `frontmatter` is the
+ *   parsed key-value map and `body` is the trimmed markdown content
+ *   that follows the closing `---`.
+ * @throws {ParseError} If the content does not start with `---` or the
+ *   frontmatter block is not properly closed.
  */
 export function parseFrontmatter(content: string): [Record<string, unknown>, string] {
 	if (!content.startsWith(FRONTMATTER_DELIMITER))
@@ -25,7 +36,22 @@ export function parseFrontmatter(content: string): [Record<string, unknown>, str
 }
 
 /**
- * Parse a simple YAML string.
+ * Parse a restricted subset of YAML sufficient for `SKILL.md` frontmatter.
+ *
+ * Supports:
+ * - Scalar string values (quoted or unquoted).
+ * - Nested objects (one level deep, indented with any consistent whitespace).
+ * - Block scalars (`|` literal and `>` folded).
+ * - Comment lines (lines beginning with `#`).
+ *
+ * Does **not** support: arrays, anchors, aliases, multi-document streams,
+ * or more than one level of nesting.
+ *
+ * Prototype-pollution keys (`__proto__`, `constructor`, `prototype`) are
+ * silently ignored.
+ *
+ * @param yaml - The raw YAML string extracted between the `---` delimiters.
+ * @returns A `Record<string, unknown>` of parsed top-level key-value pairs.
  */
 function parseSimpleYaml(yaml: string): Record<string, unknown> {
 	const result: Record<string, unknown> = {};
@@ -102,7 +128,7 @@ function parseSimpleYaml(yaml: string): Record<string, unknown> {
 			continue;
 		}
 
-		// Nested object
+		// Nested object (value is empty, children follow on indented lines)
 		if (value === '') {
 			const nested: Record<string, string> = {};
 			index++;

--- a/packages/skills-ref/src/prompt.ts
+++ b/packages/skills-ref/src/prompt.ts
@@ -1,7 +1,26 @@
 import { createSkillBlock } from './helpers.js';
 
 /**
- * Generate an <available_skills> XML block for inclusion in agent system prompts.
+ * Generate an `<available_skills>` XML block for inclusion in an agent system prompt.
+ *
+ * Each skill directory is represented as a `<skill>` element containing the
+ * skill's `<name>`, `<description>`, and the absolute `<location>` of its
+ * `SKILL.md` file. When `skillDirs` is empty, the function returns a valid
+ * but empty `<available_skills>` block rather than throwing.
+ *
+ * @param skillDirs - An array of skill directory paths (absolute or relative).
+ *   Each path is resolved to absolute before being embedded in the XML.
+ * @returns A multi-line XML string wrapped in `<available_skills>` tags,
+ *   ready to embed in a Claude system prompt.
+ *
+ * @example
+ * const xml = toPrompt(['./skills/hr-recruiting', './skills/hr-onboarding']);
+ * // <available_skills>
+ * // <skill>
+ * // <name>hr-recruiting</name>
+ * // ...
+ * // </skill>
+ * // </available_skills>
  */
 export function toPrompt(skillDirs: string[]): string {
 	if (skillDirs.length === 0) return '<available_skills>\n</available_skills>';

--- a/packages/skills-ref/src/schema.ts
+++ b/packages/skills-ref/src/schema.ts
@@ -1,12 +1,25 @@
 import * as v from 'valibot';
 
+/**
+ * Valibot schema for the properties read from a skill's `SKILL.md` frontmatter.
+ *
+ * Only `name` and `description` are required; all other fields are optional.
+ * String values are trimmed of leading and trailing whitespace during parsing.
+ */
 export const SkillPropertiesSchema = v.object({
+	/** Skill identifier (required). Must match the containing directory name. */
 	name: v.pipe(v.string(), v.trim()),
+	/** Short description of what the skill does (required). */
 	description: v.pipe(v.string(), v.trim()),
+	/** SPDX license identifier for the skill content (optional). */
 	license: v.optional(v.pipe(v.string(), v.trim())),
+	/** Compatibility notes for the skill, e.g. supported Claude versions (optional). */
 	compatibility: v.optional(v.pipe(v.string(), v.trim())),
+	/** Comma-separated list of Claude tools this skill is permitted to use (optional). */
 	allowedTools: v.optional(v.pipe(v.string(), v.trim())),
+	/** Arbitrary key-value metadata pairs from the `metadata:` block (optional). */
 	metadata: v.optional(v.record(v.string(), v.pipe(v.string(), v.trim()))),
 });
 
+/** TypeScript type inferred from {@link SkillPropertiesSchema}. */
 export type SkillProperties = v.InferOutput<typeof SkillPropertiesSchema>;


### PR DESCRIPTION
- constants.ts (both packages): add @description for every export, document regex capture groups, magic numbers, and directory paths
- schema.ts (both packages): document each Valibot schema, its purpose, and the TypeScript type it produces
- runtime-context.ts: add @param / @returns to all RuntimeContextImpl methods (get, set, has, toObject) and createRuntimeContext factory
- runtime-errors.ts: document RuntimeErrorCode variants, RuntimeError constructor params, toInfo return shape, and describeCause resolution order
- runtime-events.ts: add @param / @returns to EventDispatcher.emit and .all
- runtime-retry.ts: add @param / @returns to all three factory functions with concrete backoff examples for exponentialRetryPolicy
- runtime-state.ts: document all public methods (start, complete, fail, skip, isPending, snapshot, statusOf) and the internal transition helper
- runtime-trace.ts: add @param / @returns to TraceCollector.record and .all
- helpers.ts (hr-skills-build): expand every function's JSDoc with @param, @returns, @throws, and @example where applicable
- helpers.ts (skills-ref): same treatment; add escapeXml escape table
- config.ts: add @param / @returns / @example to getHrSkills
- loader.ts: document findSkillMd, toStringRecord, and readProperties with @throws clauses
- models.ts: document toDict serialization rules (omitted nulls, key alias)
- parser.ts: document parseFrontmatter return tuple and parseSimpleYaml supported YAML subset with prototype-pollution note
- prompt.ts: add @param / @returns / @example to toPrompt
- index.ts (skills-ref): add module-level overview comment