### PR TITLE
chore(changeset): backfill missing changesets for Phase 5 PRs

### DIFF
--- a/.changeset/ecosystem-integrations.md
+++ b/.changeset/ecosystem-integrations.md
@@ -1,0 +1,5 @@
+---
+"hr-skills": minor
+---
+
+Added `docs/integrations.md` (Phase 5) defining the supported-platform matrix (Claude Code, claude.ai, `.claude-plugin/marketplace.json`, skills.sh, direct clone), candidate platforms (generic Agent Skills runtimes, OpenAI-style agents, LangChain/CrewAI), installation/onboarding requirements, the process for adding a new platform adapter, a three-layer integration testing strategy, backward-compatibility rules, and known platform limitations. Linked from `README.md` and `docs/ROADMAP.md`'s Phase 5 and Ecosystem Expansion sections.

--- a/.changeset/release-process.md
+++ b/.changeset/release-process.md
@@ -1,0 +1,8 @@
+---
+"hr-skills": minor
+---
+
+Added `docs/release.md` (Phase 5) defining the full release lifecycle for HR Skills: the five-stage flow from changeset through tag/publish matching the `changesets/action` + `release.yml` automation, a repo-specific semver versioning strategy, a release validation checklist split into automated and manual items, a release-notes workflow explaining how changeset descriptions become `CHANGELOG.md` and GitHub Release content, a cross-channel consistency table tying every distribution channel back to its generator, and rollback guidance for three concrete scenarios.
+
+- Corrected `.changeset/README.md`'s "Releasing" instructions, which had described a manual `bun changeset version` + tag + push flow that incorrectly claimed `release.yml` would then auto-create the GitHub Release; rewrote it to match the actual PR-bot flow (`release.yml` only runs a `version` step, no `publish` step, so it opens a Version Packages PR and never creates a tag or Release on its own).
+- Normalized `CHANGELOG.md`'s version headers to a single consistent format (Changesets' bare `major.minor.patch`, no `v` prefix) across all historical entries, which had mixed three different formats from three prior tooling generations; moved a misplaced intro paragraph back under the `# Changelog` heading. No bullet content, commit hashes, or historical facts were altered.


### PR DESCRIPTION
PR #149 (feature/ecosystem-integrations) and PR #150 (feature/release-process) both merged to dev without a changeset, so neither would have appeared in the next Version Packages PR's CHANGELOG.md entry. Add the two changesets retroactively, describing each merged PR's actual content so the next release correctly credits docs/integrations.md and docs/release.md (plus the release-doc/CHANGELOG.md fixes in the release-process follow-up commit).

Refs Phase 5 — Community & Distribution