### PR TITLE
feat(hr-skills-build): add related skill recommendations

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -330,7 +330,9 @@ contributors, rather than leaving them as internal planner input only.
 * Recommendation engine — surface `registry/skills.json`'s existing
   `relatedSkills` graph as user-facing "skills you might also need"
   suggestions, instead of only consuming it internally in the Planner
-  (4.2)
+  (4.2). Delivered — see [`docs/recommendations.md`](recommendations.md)
+  for the recommendation format, ranking rule, limitations, and intended
+  consumer usage
 * Improved skill discovery — ranked/fuzzy search over the registry
   (capabilities, tags, aliases) beyond exact trigger-phrase matching
 * Usage-informed relevance — once there's a way to observe which skills

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -1,0 +1,111 @@
+# Skill Recommendations
+
+> Phase 6.1 of the [roadmap](ROADMAP.md) — exposes the [Skill
+> Registry](registry.md)'s existing `relatedSkills` graph as a user-facing
+> "skills you might also need" API, instead of leaving it as internal
+> [Planner](planner.md) input only.
+
+## What it is
+
+`packages/hr-skills-build/src/recommendations.ts` exports one function,
+`getRecommendations(skillId, registry, limit?)`, that looks up a skill's
+already-computed `relatedSkills` list from a `Registry` object (as produced
+from `registry/skills.json`) and returns it in a stable, documented shape.
+
+This is a read-only lookup layer, not a new ranking system. The ranking
+itself already exists — `rankRelatedSkills()` in
+`packages/hr-skills-build/src/registry.ts` computes it once, at registry
+generation time, and this module simply surfaces that result.
+
+## Recommendation format
+
+```ts
+interface SkillRecommendation {
+  id: string; // e.g. "hr-onboarding"
+  name: string;
+  description: string;
+  domain: SkillCategory;
+  rank: number; // 1-based position, best match first
+}
+
+interface RecommendationResult {
+  skillId: string;
+  recommendations: SkillRecommendation[];
+}
+```
+
+`getRecommendations()` returns a single `RecommendationResult`: the
+requested `skillId` plus its ranked `recommendations`, capped at `limit`
+(default 5).
+
+## Ranking rule
+
+Recommendations preserve the order already present in
+`RegistryEntry.relatedSkills` — same-domain skills ranked by shared-tag
+overlap, ties broken alphabetically (see [`registry.md`'s field
+notes](registry.md#field-notes)). This module does not re-rank, re-score,
+or introduce any new signal:
+
+- No AI ranking, embeddings, or runtime heuristics.
+- No parsing of `SKILL.md` — the only input is a `Registry` object.
+- Deterministic — the same registry state and skill ID always produce the
+  same output, in the same order.
+
+A dangling `relatedSkills` reference (an ID no longer present in the
+registry) is silently skipped rather than surfaced or thrown — registry
+consistency, including dangling references, is `bun run validate`'s job
+(see [`registry.md`](registry.md#validation)), not the recommendation
+layer's.
+
+## Usage
+
+```ts
+import { getRecommendations } from './recommendations.js';
+import { buildRegistry } from './registry.js';
+
+const registry = await buildRegistry();
+const result = getRecommendations('hr-onboarding', registry);
+
+// result.recommendations: SkillRecommendation[], ranked best-first
+```
+
+A CLI wrapper is also available for quick, interactive lookups:
+
+```bash
+bun run recommend hr-onboarding
+bun run recommend hr-onboarding --limit 3
+```
+
+Requesting a skill ID that isn't in the registry throws
+`UnknownSkillError` — callers should treat this as a client error (bad
+input), not a registry-consistency problem.
+
+## Intended consumer usage
+
+- **Documentation / product surfaces** — a "skills you might also need"
+  panel on a skill's detail page (see [Phase 7's web
+  platform](ROADMAP.md#phase-7--product--web-platform)).
+- **CLI / scripts** — `bun run recommend <skill-id>` for a quick lookup
+  during authoring or review.
+- **Downstream tools** — anything that already has (or can build) a
+  `Registry` object and wants ranked suggestions for a given skill,
+  without re-implementing the ranking logic or parsing `SKILL.md`.
+
+The Planner (`planner.ts`) is a separate consumer of the same
+`relatedSkills` data (via the `related-skill` `SelectionReason`) and is
+**not** changed by this module — the recommendation layer is purely
+additive.
+
+## Limitations
+
+- Capped at 5 recommendations per skill by default (matching the cap
+  already applied when `relatedSkills` is generated) — there is no larger
+  pool to page through.
+- Recommendations only ever come from the same `domain` as the source
+  skill, because that's what `relatedSkills` was computed from. Cross-domain
+  suggestions are out of scope for this module.
+- Static per registry generation — recommendations only change when
+  `registry/skills.json` is regenerated (`bun run registry`), not in
+  response to usage patterns. Usage-informed weighting is tracked
+  separately as a future roadmap item (see [6.1 in the
+  roadmap](ROADMAP.md#61-skill-intelligence)).

--- a/packages/hr-skills-build/package.json
+++ b/packages/hr-skills-build/package.json
@@ -29,6 +29,7 @@
 		"matrix": "bun src/generate-skill-matrix.ts",
 		"registry": "bun src/generate-registry.ts",
 		"plan": "bun src/generate-plan.ts",
+		"recommend": "bun src/recommend.ts",
 		"execute": "bun src/execute-plan.ts",
 		"evaluate": "bun src/run-evaluation.ts",
 		"test": "bun test",

--- a/packages/hr-skills-build/src/recommend.ts
+++ b/packages/hr-skills-build/src/recommend.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env bun
+
+/**
+ * CLI: Get "skills you might also need" recommendations for a given skill ID.
+ *
+ * Usage:
+ *   bun src/recommend.ts hr-onboarding
+ *   bun src/recommend.ts hr-onboarding --limit 3
+ */
+
+import * as p from '@clack/prompts';
+import { getRecommendations, UnknownSkillError } from './recommendations.js';
+import { buildRegistry } from './registry.js';
+
+async function main() {
+	const skillId = process.argv[2];
+
+	if (!skillId) {
+		p.log.error('Usage: bun src/recommend.ts <skill-id> [--limit N]');
+		p.log.info('Example:');
+		p.log.message('  bun src/recommend.ts hr-onboarding');
+		process.exit(1);
+	}
+
+	const limitFlagIndex = process.argv.indexOf('--limit');
+	const limit =
+		limitFlagIndex !== -1 ? Number(process.argv[limitFlagIndex + 1]) : undefined;
+
+	p.intro('Skill Recommendations');
+
+	const spinner = p.spinner();
+	spinner.start('Building Skill Registry...');
+	const registry = await buildRegistry();
+	spinner.stop(`Registry ready (${registry.skillCount} skills)`);
+
+	try {
+		const result = getRecommendations(skillId, registry, limit);
+
+		if (result.recommendations.length === 0) {
+			p.log.warn(`No recommendations available for "${skillId}"`);
+		} else {
+			p.note(
+				result.recommendations
+					.map(
+						(rec) =>
+							`${rec.rank}. ${rec.id} (${rec.domain})\n   ${rec.description}`,
+					)
+					.join('\n\n'),
+				`RECOMMENDATIONS FOR ${result.skillId}`,
+			);
+		}
+
+		p.outro('Done');
+	} catch (error) {
+		if (error instanceof UnknownSkillError) {
+			p.log.error(error.message);
+			process.exit(1);
+		}
+		throw error;
+	}
+}
+
+main().catch((err) => {
+	p.log.error(`Error: ${err.message}`);
+	process.exit(1);
+});

--- a/packages/hr-skills-build/src/recommendations.ts
+++ b/packages/hr-skills-build/src/recommendations.ts
@@ -1,0 +1,81 @@
+/**
+ * Skill Recommendation Layer — Phase 6.1
+ *
+ * Exposes the `relatedSkills` graph that already lives in
+ * `registry/skills.json` (computed by `rankRelatedSkills()` in registry.ts)
+ * as a reusable, user-facing "skills you might also need" API — instead of
+ * leaving it as internal Planner input only.
+ *
+ * This module is intentionally thin: it reads a `Registry` object and looks
+ * up an already-ranked, already-capped list. It does not re-rank, re-score,
+ * or introduce any new signal (no AI ranking, no embeddings, no heuristics).
+ * The only source of truth is `RegistryEntry.relatedSkills`.
+ *
+ * Consumes only `Registry` / `RegistryEntry` (as produced from
+ * `registry/skills.json`) — never parses `SKILL.md` files directly.
+ */
+
+import type { RecommendationResult, Registry, SkillRecommendation } from './types.js';
+
+/**
+ * Thrown when a recommendation is requested for a skill ID that does not
+ * exist in the given registry.
+ */
+export class UnknownSkillError extends Error {
+	constructor(skillId: string) {
+		super(`Unknown skill ID: "${skillId}" — not found in the registry`);
+		this.name = 'UnknownSkillError';
+	}
+}
+
+/**
+ * Get the top related skills for a given skill ID.
+ *
+ * Ranking rule: preserves the order already computed for
+ * `RegistryEntry.relatedSkills` (same-domain skills ranked by shared-tag
+ * overlap, ties broken alphabetically — see `rankRelatedSkills()` in
+ * registry.ts). This function does not alter that order; it only looks up,
+ * caps, and formats it.
+ *
+ * Deterministic: for a fixed registry and skill ID, the same input always
+ * produces the same output, in the same order.
+ *
+ * Dangling references (a related ID no longer present in the registry) are
+ * silently skipped rather than throwing, so a stale entry never breaks the
+ * whole result — `bun run validate` is the place that catches dangling
+ * `relatedSkills` references as a registry-consistency error.
+ *
+ * @param skillId - The skill to get recommendations for, e.g. "hr-onboarding".
+ * @param registry - A `Registry` object, as produced from `registry/skills.json`.
+ * @param limit - Maximum number of recommendations to return (default 5).
+ * @throws {UnknownSkillError} If `skillId` is not present in `registry`.
+ */
+export function getRecommendations(
+	skillId: string,
+	registry: Registry,
+	limit = 5,
+): RecommendationResult {
+	const byId = new Map(registry.skills.map((skill) => [skill.id, skill]));
+	const source = byId.get(skillId);
+
+	if (!source) {
+		throw new UnknownSkillError(skillId);
+	}
+
+	const recommendations: SkillRecommendation[] = [];
+
+	source.relatedSkills.slice(0, limit).forEach((relatedId, index) => {
+		const related = byId.get(relatedId);
+		if (!related) return; // dangling reference — skip rather than throw
+
+		recommendations.push({
+			id: related.id,
+			name: related.name,
+			description: related.description,
+			domain: related.domain,
+			rank: index + 1,
+		});
+	});
+
+	return { skillId, recommendations };
+}

--- a/packages/hr-skills-build/src/types.ts
+++ b/packages/hr-skills-build/src/types.ts
@@ -100,6 +100,39 @@ export interface RegistryEntry {
 	relatedSkills: string[];
 }
 
+// ---------------------------------------------------------------------------
+// Recommendation types (Phase 6.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single "you might also need" suggestion, derived from a `RegistryEntry`'s
+ * `relatedSkills` list. `rank` is the suggestion's 1-based position within
+ * that list, preserved as-is — recommendations never re-sort or re-score.
+ */
+export interface SkillRecommendation {
+	/** Recommended skill's ID, e.g. "hr-onboarding". */
+	id: string;
+	/** Recommended skill's display name. */
+	name: string;
+	/** Recommended skill's one-sentence description. */
+	description: string;
+	/** Recommended skill's routing domain. */
+	domain: SkillCategory;
+	/** 1-based position in the source skill's `relatedSkills` order. */
+	rank: number;
+}
+
+/**
+ * The recommendation output for one source skill: its ID plus the ranked
+ * list of related skills, capped at the requested limit.
+ */
+export interface RecommendationResult {
+	/** The skill the recommendations are for. */
+	skillId: string;
+	/** Related skills, ordered by rank (best match first). */
+	recommendations: SkillRecommendation[];
+}
+
 /**
  * The full generated Skill Registry document.
  */

--- a/packages/hr-skills-build/test/recommendations.test.ts
+++ b/packages/hr-skills-build/test/recommendations.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'bun:test';
+
+import { getRecommendations, UnknownSkillError } from '../src/recommendations.js';
+import type { Registry, RegistryEntry } from '../src/types.js';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+const createMockSkill = (overrides: Partial<RegistryEntry> = {}): RegistryEntry => ({
+	id: 'hr-test-skill',
+	name: 'hr-test-skill',
+	version: '1.0.0',
+	description: 'A test skill',
+	tier: 'full',
+	domain: 'onboarding-offboarding',
+	tags: [],
+	aliases: ['test-skill'],
+	capabilities: ['Testing basic capabilities'],
+	triggerPhrases: ['test this skill'],
+	paths: { content: true, prompts: true, examples: true },
+	dependencies: [],
+	relatedSkills: [],
+	...overrides,
+});
+
+const createMockRegistry = (skills: RegistryEntry[] = []): Registry => ({
+	schemaVersion: 1,
+	generatedAt: '2026-07-23',
+	skillCount: skills.length,
+	skills,
+});
+
+// ============================================================================
+// getRecommendations() Tests
+// ============================================================================
+
+describe('getRecommendations()', () => {
+	it('returns recommendations in relatedSkills order, ranked from 1', () => {
+		const registry = createMockRegistry([
+			createMockSkill({
+				id: 'hr-onboarding',
+				relatedSkills: ['hr-offboarding', 'hr-hris'],
+			}),
+			createMockSkill({ id: 'hr-offboarding', description: 'Offboarding skill' }),
+			createMockSkill({ id: 'hr-hris', description: 'HRIS skill' }),
+		]);
+
+		const result = getRecommendations('hr-onboarding', registry);
+
+		expect(result.skillId).toBe('hr-onboarding');
+		expect(result.recommendations.map((r) => r.id)).toEqual([
+			'hr-offboarding',
+			'hr-hris',
+		]);
+		expect(result.recommendations[0]?.rank).toBe(1);
+		expect(result.recommendations[1]?.rank).toBe(2);
+	});
+
+	it('never reorders relatedSkills — preserves registry ranking as-is', () => {
+		const registry = createMockRegistry([
+			createMockSkill({ id: 'hr-a', relatedSkills: ['hr-c', 'hr-b'] }),
+			createMockSkill({ id: 'hr-b' }),
+			createMockSkill({ id: 'hr-c' }),
+		]);
+
+		const result = getRecommendations('hr-a', registry);
+
+		expect(result.recommendations.map((r) => r.id)).toEqual(['hr-c', 'hr-b']);
+	});
+
+	it('caps output at the requested limit', () => {
+		const registry = createMockRegistry([
+			createMockSkill({ id: 'hr-a', relatedSkills: ['hr-b', 'hr-c', 'hr-d'] }),
+			createMockSkill({ id: 'hr-b' }),
+			createMockSkill({ id: 'hr-c' }),
+			createMockSkill({ id: 'hr-d' }),
+		]);
+
+		const result = getRecommendations('hr-a', registry, 2);
+
+		expect(result.recommendations.length).toBe(2);
+		expect(result.recommendations.map((r) => r.id)).toEqual(['hr-b', 'hr-c']);
+	});
+
+	it('defaults to a limit of 5', () => {
+		const registry = createMockRegistry([
+			createMockSkill({
+				id: 'hr-a',
+				relatedSkills: ['hr-b', 'hr-c', 'hr-d', 'hr-e', 'hr-f', 'hr-g'],
+			}),
+			createMockSkill({ id: 'hr-b' }),
+			createMockSkill({ id: 'hr-c' }),
+			createMockSkill({ id: 'hr-d' }),
+			createMockSkill({ id: 'hr-e' }),
+			createMockSkill({ id: 'hr-f' }),
+			createMockSkill({ id: 'hr-g' }),
+		]);
+
+		const result = getRecommendations('hr-a', registry);
+
+		expect(result.recommendations.length).toBe(5);
+	});
+
+	it('returns an empty list for a skill with no relatedSkills', () => {
+		const registry = createMockRegistry([
+			createMockSkill({ id: 'hr-a', relatedSkills: [] }),
+		]);
+
+		const result = getRecommendations('hr-a', registry);
+
+		expect(result.recommendations).toEqual([]);
+	});
+
+	it('silently skips a dangling relatedSkills reference', () => {
+		const registry = createMockRegistry([
+			createMockSkill({ id: 'hr-a', relatedSkills: ['hr-missing', 'hr-b'] }),
+			createMockSkill({ id: 'hr-b' }),
+		]);
+
+		const result = getRecommendations('hr-a', registry);
+
+		expect(result.recommendations.map((r) => r.id)).toEqual(['hr-b']);
+	});
+
+	it('throws UnknownSkillError for a skill ID not in the registry', () => {
+		const registry = createMockRegistry([createMockSkill({ id: 'hr-a' })]);
+
+		expect(() => getRecommendations('hr-does-not-exist', registry)).toThrow(
+			UnknownSkillError,
+		);
+	});
+
+	it('is deterministic — same registry and skill ID produce the same output', () => {
+		const registry = createMockRegistry([
+			createMockSkill({ id: 'hr-a', relatedSkills: ['hr-b', 'hr-c'] }),
+			createMockSkill({ id: 'hr-b' }),
+			createMockSkill({ id: 'hr-c' }),
+		]);
+
+		const first = getRecommendations('hr-a', registry);
+		const second = getRecommendations('hr-a', registry);
+
+		expect(first).toEqual(second);
+	});
+
+	it('includes name, description, and domain for each recommendation', () => {
+		const registry = createMockRegistry([
+			createMockSkill({ id: 'hr-a', relatedSkills: ['hr-b'] }),
+			createMockSkill({
+				id: 'hr-b',
+				name: 'hr-b',
+				description: 'Skill B description',
+				domain: 'compensation-rewards',
+			}),
+		]);
+
+		const result = getRecommendations('hr-a', registry);
+
+		expect(result.recommendations[0]).toEqual({
+			id: 'hr-b',
+			name: 'hr-b',
+			description: 'Skill B description',
+			domain: 'compensation-rewards',
+			rank: 1,
+		});
+	});
+});


### PR DESCRIPTION
Implements Phase 6.1 of the roadmap: a lightweight recommendation layer that surfaces the existing relatedSkills graph from registry/skills.json as a reusable, user-facing API.

- Add SkillRecommendation / RecommendationResult types
- Add getRecommendations(skillId, registry, limit?) — pure lookup over Registry.skills[].relatedSkills, preserving existing rank order, capped at 5 by default, skipping dangling references, throwing UnknownSkillError for unknown skill IDs
- Add recommend.ts CLI (bun run recommend <skill-id> [--limit N])
- Add unit tests covering ordering, capping, dangling refs, determinism, and error handling
- Add docs/recommendations.md: format, ranking rule, limitations, and intended consumer usage
- Mark the roadmap item as delivered

Additive only: no planner logic, registry generation, or ranking algorithm changed. No AI ranking, embeddings, or runtime scoring introduced; the only input is registry/skills.json, never SKILL.md.