### PR TITLE
feat(hr-skills-build): add deterministic skill search/discovery layer

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -334,7 +334,10 @@ contributors, rather than leaving them as internal planner input only.
   for the recommendation format, ranking rule, limitations, and intended
   consumer usage
 * Improved skill discovery — ranked/fuzzy search over the registry
-  (capabilities, tags, aliases) beyond exact trigger-phrase matching
+  (capabilities, tags, aliases) beyond exact trigger-phrase matching.
+  Delivered — see [`docs/search.md`](search.md) for supported query
+  types, searchable fields, ranking strategy, determinism guarantees,
+  the public API, and usage examples
 * Usage-informed relevance — once there's a way to observe which skills
   are actually selected together in practice (for example via evaluation
   runs or planner telemetry), use that signal to refine

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,237 @@
+# Skill Discovery (Search)
+
+> Phase 6.1 of the [roadmap](ROADMAP.md) — deterministic skill discovery over
+> [Skill Registry](registry.md) metadata, by structured fields instead of
+> exact trigger-phrase matching only.
+
+## What it is
+
+`packages/hr-skills-build/src/search.ts` exports one function,
+`searchSkills(query, registry)`, that ranks skills against a free-text query
+matched across structured registry fields — capabilities, aliases, tags,
+domain, and trigger phrases.
+
+This is a **retrieval** feature, not a planning one:
+
+- It answers "which skills relate to X?" — a ranked list with explanations.
+- The [Planner](planner.md) answers "which skills, in what order, satisfy
+  this request?" — a full execution plan.
+
+`searchSkills()` is read-only and pure. It consumes only a `Registry` object
+(as produced from `registry/skills.json`) and never parses `SKILL.md` files
+or scans the filesystem. It does not select, order, or execute skills, and
+it does not change how the Planner works — the two are independent
+consumers of the same registry data.
+
+## Searchable fields
+
+| Field | Source | Example values |
+|---|---|---|
+| `aliases` | `RegistryEntry.aliases` | `"onboarding"`, `"new-hire-onboarding"` |
+| `capabilities` | `RegistryEntry.capabilities` | `"Design onboarding plans"` |
+| `tags` | `RegistryEntry.tags` | `"lifecycle"`, `"new-hire"` |
+| `triggerPhrases` | `RegistryEntry.triggerPhrases` | `"onboard a new hire"` |
+| `domain` | `RegistryEntry.domain` | `"onboarding-offboarding"` |
+
+By default a query searches all five fields (`ALL_SEARCHABLE_FIELDS`
+in search.ts). Callers can restrict this with `query.fields`.
+
+## Supported query types
+
+- **Free-text search** — `{ text: "onboard new hires" }` searches the
+  chosen fields with both exact and fuzzy matching.
+- **Domain-filtered search** — `{ text: "...", domain: "onboarding-offboarding" }`
+  restricts candidates to one domain before scoring.
+- **Domain-only browse** — `{ text: "", domain: "..." }` lists every skill
+  in a domain (a valid query on its own; `text` and `domain` aren't both
+  required, but at least one must be present).
+- **Field-restricted search** — `{ text: "...", fields: ["tags"] }` searches
+  only the given fields.
+- **Exact-only search** — `{ text: "...", fuzzy: false }` disables fuzzy
+  matching, so only exact/substring hits are returned.
+
+## Matching: exact vs. fuzzy
+
+**Exact match** — the normalized (lowercased, trimmed) query equals a field
+value, or either one contains the other as a substring. This mirrors the
+"direct match" rule the [Planner already uses](planner.md#capability-matching)
+for capability matching, so the two systems stay conceptually consistent.
+
+**Fuzzy match** — used only when a field value isn't an exact match (and
+`fuzzy` isn't disabled). It's the better of two deterministic, dependency-free
+measures:
+
+- **Token Jaccard similarity** — `|intersection| / |union|` of the query's
+  and value's word sets. Good for reordered or partially-overlapping
+  multi-word phrases, e.g. `"new hire onboard"` vs. `"onboard a new hire"`.
+- **Normalized Levenshtein similarity** — `1 - editDistance / maxLength`.
+  Good for single-word typos, e.g. `"onbording"` vs. `"onboarding"`.
+
+A fuzzy match only counts if its similarity is at least `FUZZY_THRESHOLD`
+(0.34, in search.ts). Below that, it's treated as no match at all — this
+keeps low-quality fuzzy noise out of results.
+
+No ML models, embeddings, vector databases, or external search services are
+used anywhere in this pipeline.
+
+## Ranking
+
+Every result's `score` is built from four transparent, additive rules:
+
+1. **Field weight × match strength.** Each field has a base weight
+   (`FIELD_WEIGHTS` in search.ts — currently `aliases: 100`,
+   `capabilities: 80`, `tags: 60`, `triggerPhrases: 50`, `domain: 40`,
+   reflecting how deliberately each field is authored as a lookup key).
+   An exact match contributes the full weight; a fuzzy match contributes
+   `weight × FUZZY_DAMPING × similarity` (damped by 0.6, so fuzzy hits can
+   never outscore an exact hit on the same field).
+2. **Multi-field bonus.** A skill matching on more than one distinct field
+   gets `+5` per extra field, capped at `+20` — agreement across fields
+   (e.g. both a tag and a capability) is a stronger discoverability signal
+   than one strong match alone.
+3. **Exact-match confidence bonus.** A skill with at least one exact match
+   (on any field) gets a flat `+10` — this keeps exact matches reliably
+   ahead of fuzzy-only matches even when the fuzzy skill matched more
+   fields.
+4. **Deterministic tie-breaking.** Ties are broken first by number of
+   matched fields (descending), then by skill ID (ascending,
+   `localeCompare`). Two runs against the same registry state always
+   produce the same order — nothing here depends on iteration order,
+   timestamps, or randomness.
+
+Only the single **best** value per field counts toward a skill's score —
+e.g. a skill with five tags that all loosely match the query still only
+scores once for `tags`, not five times. This keeps scores from being
+inflated by keyword-stuffed fields.
+
+## Match explanation
+
+Every `SkillSearchResult` carries the evidence for its score, not just the
+number:
+
+```ts
+interface SkillFieldMatch {
+  field: SearchableField;   // e.g. "capabilities"
+  value: string;            // the exact field value that matched
+  matchType: 'exact' | 'fuzzy';
+  similarity: number;       // 0–1, always 1 for exact matches
+  weight: number;           // that field's base weight
+  contribution: number;     // weight * similarity, pre-bonus
+}
+```
+
+`result.matches` lists every field match (best-contribution first), and
+`result.explanation` renders them as a short, deterministic string, e.g.:
+
+```text
+aliases ~ "onboarding" (exact); capabilities ~ "Design onboarding plans" (fuzzy, 0.42)
+```
+
+## API
+
+```ts
+interface SkillSearchQuery {
+  text: string;
+  fields?: SearchableField[];   // default: all 5 fields
+  domain?: SkillCategory;       // optional pre-filter
+  fuzzy?: boolean;              // default: true
+  limit?: number;               // default: 10
+}
+
+interface SkillSearchResponse {
+  query: string;
+  resultCount: number;
+  results: SkillSearchResult[]; // ranked, best match first
+}
+
+function searchSkills(query: SkillSearchQuery, registry: Registry): SkillSearchResponse;
+```
+
+`searchSkills()` throws `InvalidSearchQueryError` for a structurally invalid
+query — empty `text` with no `domain` filter (nothing to search), or a
+non-positive/non-integer `limit`. A query that's valid but matches nothing
+is **not** an error — it returns `{ resultCount: 0, results: [] }`.
+
+This API is intentionally independent of Planner execution logic, so it's
+reusable by any future consumer that can supply a `Registry` object:
+
+- **CLI** — `bun run discover "<query>"` (below).
+- **Web UI / Registry Explorer** — a search box over the same registry data,
+  with `SkillFieldMatch[]` available to render "why this matched" per
+  result.
+- **Planner (future)** — could use `searchSkills()` as an additional
+  capability-discovery signal, but does not today; this module makes no
+  changes to `planner.ts`.
+
+## Usage
+
+### CLI
+
+```bash
+bun run discover "onboard new hires"
+bun run discover "onboarding" --domain onboarding-offboarding
+bun run discover "onbording" --limit 3 --no-fuzzy
+```
+
+The CLI reads `registry/skills.json` directly, so run `bun run registry`
+first if it's out of date.
+
+### Programmatic
+
+```ts
+import { searchSkills } from './search.js';
+import { buildRegistry } from './registry.js';
+
+const registry = await buildRegistry();
+const response = searchSkills({ text: 'onboard new hires' }, registry);
+
+for (const result of response.results) {
+  console.log(`${result.skillId} (${result.score}): ${result.explanation}`);
+}
+```
+
+## Determinism guarantees
+
+- Same registry content + same query → same `results`, in the same order,
+  every time.
+- No randomness, no external services, no ML/embedding models, no signal
+  that varies between runs (timestamps, locale-dependent sort order, object
+  iteration order).
+- Regenerating the registry (`bun run registry`) from unchanged skill
+  content produces unchanged search results, since `searchSkills()`'s only
+  input is the registry's structured fields.
+
+## Limitations
+
+- Search quality is bounded by how well a skill's `aliases`, `tags`,
+  `capabilities`, and `triggerPhrases` are authored — this module surfaces
+  registry metadata, it doesn't infer meaning beyond it.
+- Fuzzy matching is intentionally simple (token overlap + edit distance) for
+  determinism and explainability, not state-of-the-art recall — it won't
+  catch matches that require true semantic understanding (e.g. synonyms
+  never seen in shared tokens).
+- `domain` is matched as a single string, so a query only benefits from
+  fuzzy matching against the raw domain slug (e.g. `"onboarding-offboarding"`)
+  — it isn't matched against domain display names or descriptions.
+- Not real-time: results reflect whatever registry was passed in — from disk
+  (`registry/skills.json`) or freshly built (`buildRegistry()`). Regenerate
+  the registry to pick up new skills.
+
+## Extension guidelines
+
+- **New searchable field** — add it to `SearchableField` in types.ts, give
+  it a weight in `FIELD_WEIGHTS`, and add it to `getFieldValues()` in
+  search.ts.
+- **Tuning ranking** — the constants at the top of search.ts
+  (`FIELD_WEIGHTS`, `FUZZY_THRESHOLD`, `FUZZY_DAMPING`, `MULTI_FIELD_BONUS`,
+  `MULTI_FIELD_BONUS_CAP`, `EXACT_MATCH_CONFIDENCE_BONUS`) are the single
+  source of truth for scoring — change them there, not inline.
+- **New consumer** — anything that can produce or load a `Registry` object
+  can call `searchSkills()` directly; no new glue code should be needed.
+
+## Testing
+
+See `packages/hr-skills-build/test/search.test.ts`, which covers exact
+matches per field, fuzzy matches (typos and reordered phrases), field
+restriction, domain filtering and domain-only browsing, ranking and
+tie-breaking, match explanations, empty results, and invalid-query errors.

--- a/packages/hr-skills-build/package.json
+++ b/packages/hr-skills-build/package.json
@@ -28,6 +28,7 @@
 		"sync": "bun src/sync.ts",
 		"matrix": "bun src/generate-skill-matrix.ts",
 		"registry": "bun src/generate-registry.ts",
+		"discover": "bun src/discover.ts",
 		"plan": "bun src/generate-plan.ts",
 		"recommend": "bun src/recommend.ts",
 		"execute": "bun src/execute-plan.ts",

--- a/packages/hr-skills-build/src/discover.ts
+++ b/packages/hr-skills-build/src/discover.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+
+/**
+ * CLI: Search the generated Skill Registry by structured metadata.
+ *
+ * Reads `registry/skills.json` directly — it must already be generated
+ * (`bun run registry`) before this command is used.
+ *
+ * Usage:
+ *   bun src/discover.ts "onboard new hires"
+ *   bun src/discover.ts "onboarding" --domain onboarding-offboarding
+ *   bun src/discover.ts "onbording" --limit 3 --no-fuzzy
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import * as p from '@clack/prompts';
+
+import type { SkillCategory } from './classifier.js';
+import { ROOT_DIR } from './constants.js';
+import { InvalidSearchQueryError, searchSkills } from './search.js';
+import type { Registry, SkillSearchQuery } from './types.js';
+
+const REGISTRY_PATH = join(ROOT_DIR, 'registry', 'skills.json');
+
+function parseFlag(name: string): string | undefined {
+	const index = process.argv.indexOf(`--${name}`);
+	if (index === -1) return undefined;
+	return process.argv[index + 1];
+}
+
+function hasFlag(name: string): boolean {
+	return process.argv.includes(`--${name}`);
+}
+
+async function main() {
+	const text = process.argv[2];
+
+	if (!text || text.startsWith('--')) {
+		p.log.error(
+			'Usage: bun src/discover.ts "<query>" [--domain <domain>] [--limit N] [--no-fuzzy]',
+		);
+		p.log.info('Example:');
+		p.log.message('  bun src/discover.ts "onboard new hires"');
+		process.exit(1);
+	}
+
+	const domain = parseFlag('domain') as SkillCategory | undefined;
+	const limitFlag = parseFlag('limit');
+	const limit = limitFlag ? Number(limitFlag) : undefined;
+	const fuzzy = !hasFlag('no-fuzzy');
+
+	p.intro('Skill Search');
+
+	const spinner = p.spinner();
+	spinner.start('Loading Skill Registry...');
+	const raw = await readFile(REGISTRY_PATH, 'utf8');
+	const registry = JSON.parse(raw) as Registry;
+	spinner.stop(`Registry loaded (${registry.skillCount} skills)`);
+
+	const query: SkillSearchQuery = {
+		text,
+		fuzzy,
+		...(domain && { domain }),
+		...(limit && { limit }),
+	};
+
+	try {
+		const response = searchSkills(query, registry);
+
+		if (response.results.length === 0) {
+			p.log.warn(`No skills matched "${text}"`);
+		} else {
+			p.note(
+				response.results
+					.map(
+						(r) =>
+							`${r.skillId} — score ${r.score} (${r.domain})\n   ${r.explanation}`,
+					)
+					.join('\n\n'),
+				`RESULTS FOR "${response.query}" (${response.resultCount})`,
+			);
+		}
+
+		p.outro('Done');
+	} catch (error) {
+		if (error instanceof InvalidSearchQueryError) {
+			p.log.error(error.message);
+			process.exit(1);
+		}
+		throw error;
+	}
+}
+
+main().catch((err) => {
+	p.log.error(`Error: ${err.message}`);
+	process.exit(1);
+});

--- a/packages/hr-skills-build/src/search.ts
+++ b/packages/hr-skills-build/src/search.ts
@@ -1,0 +1,407 @@
+/**
+ * Skill Discovery / Search Layer — Phase 6.1
+ *
+ * Lets users and future tooling find skills by structured registry metadata
+ * (capabilities, aliases, tags, domain, trigger phrases) instead of exact
+ * trigger-phrase matching only. This is a retrieval problem, not a planning
+ * problem: `searchSkills()` is a pure, read-only query over an already-built
+ * `Registry` object (as produced from `registry/skills.json`). It never
+ * scans or parses `SKILL.md` files, and it does not select, order, or
+ * execute skills — that remains the Planner's job (planner.ts).
+ *
+ * Design goals (see docs/search.md for the full write-up):
+ *  - Deterministic: identical registry + identical query always produce
+ *    identical, identically-ordered output.
+ *  - Transparent: every result carries the field matches and weights that
+ *    produced its score, plus a human-readable explanation.
+ *  - No ML / embeddings / vector search / external services — matching is
+ *    exact-substring plus two simple, explainable similarity measures
+ *    (token Jaccard overlap and normalized Levenshtein distance), the same
+ *    family of technique already used by the Planner's capability matcher.
+ */
+
+import type {
+	MatchType,
+	Registry,
+	RegistryEntry,
+	SearchableField,
+	SkillFieldMatch,
+	SkillSearchQuery,
+	SkillSearchResponse,
+	SkillSearchResult,
+} from './types.js';
+
+// ============================================================================
+// Tuning constants — documented in docs/search.md
+// ============================================================================
+
+/** Base relevance weight per field, applied before match-strength scaling. */
+export const FIELD_WEIGHTS: Record<SearchableField, number> = {
+	aliases: 100,
+	capabilities: 80,
+	tags: 60,
+	triggerPhrases: 50,
+	domain: 40,
+};
+
+/** All searchable fields, in the fixed order used when `fields` is omitted. */
+export const ALL_SEARCHABLE_FIELDS: SearchableField[] = [
+	'aliases',
+	'capabilities',
+	'tags',
+	'triggerPhrases',
+	'domain',
+];
+
+/** Minimum similarity (0–1) for a fuzzy match to count at all. */
+const FUZZY_THRESHOLD = 0.34;
+
+/** Fuzzy matches are capped at this fraction of a field's full weight. */
+const FUZZY_DAMPING = 0.6;
+
+/** Flat bonus added once per additional distinct field beyond the first. */
+const MULTI_FIELD_BONUS = 5;
+
+/** Cap on the total multi-field bonus, regardless of how many fields match. */
+const MULTI_FIELD_BONUS_CAP = 20;
+
+/** Flat bonus added once if the skill has at least one exact match. */
+const EXACT_MATCH_CONFIDENCE_BONUS = 10;
+
+const DEFAULT_LIMIT = 10;
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+/**
+ * Thrown for a structurally invalid query — e.g. empty search text with no
+ * domain filter to fall back on, or a non-positive `limit`. This is a
+ * client-input error, not a "no results" case (which returns an empty
+ * `results` array instead).
+ */
+export class InvalidSearchQueryError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'InvalidSearchQueryError';
+	}
+}
+
+// ============================================================================
+// String similarity — deterministic, dependency-free
+// ============================================================================
+
+function normalize(value: string): string {
+	return value.toLowerCase().trim();
+}
+
+function tokenize(value: string): Set<string> {
+	return new Set(
+		normalize(value)
+			.split(/[^a-z0-9]+/)
+			.filter(Boolean),
+	);
+}
+
+/** Jaccard similarity (0–1) between the token sets of two strings. */
+function jaccardSimilarity(a: string, b: string): number {
+	const setA = tokenize(a);
+	const setB = tokenize(b);
+	if (setA.size === 0 || setB.size === 0) return 0;
+
+	let intersectionSize = 0;
+	for (const token of setA) {
+		if (setB.has(token)) intersectionSize++;
+	}
+	const unionSize = setA.size + setB.size - intersectionSize;
+	return unionSize === 0 ? 0 : intersectionSize / unionSize;
+}
+
+/**
+ * Classic Levenshtein edit distance between two strings.
+ *
+ * Uses a rolling two-row dynamic programming table, reducing memory from
+ * O(m × n) to O(n) while remaining fully deterministic.
+ */
+function levenshteinDistance(a: string, b: string): number {
+	const cols = b.length + 1;
+
+	let previous = Array.from({ length: cols }, (_, i) => i);
+	let current = new Array<number>(cols).fill(0);
+
+	for (let i = 1; i <= a.length; i++) {
+		current[0] = i;
+
+		for (let j = 1; j <= b.length; j++) {
+			const left = current[j - 1];
+			const above = previous[j];
+			const diagonal = previous[j - 1];
+
+			if (left === undefined || above === undefined || diagonal === undefined) {
+				throw new Error('Levenshtein matrix invariant violated');
+			}
+
+			const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+
+			current[j] = Math.min(above + 1, left + 1, diagonal + cost);
+		}
+
+		[previous, current] = [current, previous];
+	}
+
+	const distance = previous[b.length];
+
+	if (distance === undefined) {
+		throw new Error('Levenshtein matrix invariant violated');
+	}
+
+	return distance;
+}
+
+/** Edit-distance similarity (0–1), normalized by the longer string's length. */
+function levenshteinSimilarity(a: string, b: string): number {
+	const normA = normalize(a);
+	const normB = normalize(b);
+	const maxLen = Math.max(normA.length, normB.length);
+	if (maxLen === 0) return 1;
+	return 1 - levenshteinDistance(normA, normB) / maxLen;
+}
+
+/**
+ * Combined fuzzy similarity: the better of token-overlap similarity (good
+ * for multi-word phrases, e.g. "onboard new hire" vs "new hire onboarding")
+ * and edit-distance similarity (good for single-word typos, e.g.
+ * "onbording" vs "onboarding"). Both are deterministic and dependency-free.
+ */
+function fuzzySimilarity(query: string, value: string): number {
+	return Math.max(jaccardSimilarity(query, value), levenshteinSimilarity(query, value));
+}
+
+// ============================================================================
+// Field matching
+// ============================================================================
+
+function isExactMatch(query: string, value: string): boolean {
+	const q = normalize(query);
+	const v = normalize(value);
+	if (q.length === 0 || v.length === 0) return false;
+	return q === v || v.includes(q) || q.includes(v);
+}
+
+function getFieldValues(entry: RegistryEntry, field: SearchableField): string[] {
+	switch (field) {
+		case 'aliases':
+			return entry.aliases;
+		case 'capabilities':
+			return entry.capabilities;
+		case 'tags':
+			return entry.tags;
+		case 'triggerPhrases':
+			return entry.triggerPhrases;
+		case 'domain':
+			return [entry.domain];
+		default:
+			return [];
+	}
+}
+
+/**
+ * Match a query string against a single field of a single skill, returning
+ * the single best match for that field (or `null` if none clears the
+ * fuzzy threshold). Only the best value per field is kept, so a skill with
+ * five overlapping tags doesn't get five separate `aliases`-weight scores
+ * for effectively the same hit.
+ */
+function matchField(
+	query: string,
+	entry: RegistryEntry,
+	field: SearchableField,
+	fuzzy: boolean,
+): SkillFieldMatch | null {
+	const weight = FIELD_WEIGHTS[field];
+	let best: SkillFieldMatch | null = null;
+
+	for (const value of getFieldValues(entry, field)) {
+		if (isExactMatch(query, value)) {
+			const contribution = weight; // similarity 1.0
+			if (!best || contribution > best.contribution) {
+				best = {
+					field,
+					value,
+					matchType: 'exact',
+					similarity: 1,
+					weight,
+					contribution,
+				};
+			}
+			continue;
+		}
+
+		if (!fuzzy) continue;
+
+		const similarity = fuzzySimilarity(query, value);
+		if (similarity < FUZZY_THRESHOLD) continue;
+
+		const contribution = weight * FUZZY_DAMPING * similarity;
+		if (!best || (best.matchType === 'fuzzy' && contribution > best.contribution)) {
+			best = { field, value, matchType: 'fuzzy', similarity, weight, contribution };
+		}
+	}
+
+	return best;
+}
+
+// ============================================================================
+// Scoring
+// ============================================================================
+
+interface ScoredEntry {
+	entry: RegistryEntry;
+	score: number;
+	matches: SkillFieldMatch[];
+}
+
+function scoreEntry(
+	query: string,
+	entry: RegistryEntry,
+	fields: SearchableField[],
+	fuzzy: boolean,
+): ScoredEntry | null {
+	const matches: SkillFieldMatch[] = [];
+
+	for (const field of fields) {
+		const match = matchField(query, entry, field, fuzzy);
+		if (match) matches.push(match);
+	}
+
+	if (matches.length === 0) return null;
+
+	const baseScore = matches.reduce((sum, m) => sum + m.contribution, 0);
+	const multiFieldBonus = Math.min(
+		(matches.length - 1) * MULTI_FIELD_BONUS,
+		MULTI_FIELD_BONUS_CAP,
+	);
+	const confidenceBonus = matches.some((m) => m.matchType === 'exact')
+		? EXACT_MATCH_CONFIDENCE_BONUS
+		: 0;
+
+	// Highest-weight, then highest-contribution matches first — this is also
+	// the order the explanation string is built from.
+	matches.sort(
+		(a, b) => b.contribution - a.contribution || a.field.localeCompare(b.field),
+	);
+
+	const score = Math.round((baseScore + multiFieldBonus + confidenceBonus) * 100) / 100;
+
+	return { entry, score, matches };
+}
+
+/** Build the deterministic, human-readable "why this matched" explanation. */
+function buildExplanation(matches: SkillFieldMatch[]): string {
+	return matches
+		.map((m) => {
+			const kind =
+				m.matchType === 'exact' ? 'exact' : `fuzzy, ${m.similarity.toFixed(2)}`;
+			return `${m.field} ~ "${m.value}" (${kind})`;
+		})
+		.join('; ');
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Search the generated Skill Registry by structured metadata.
+ *
+ * Ranking rule (see docs/search.md for the full explanation):
+ *  1. Each field match contributes `weight * similarity` to the skill's
+ *     score (`similarity` is always 1 for exact matches).
+ *  2. A skill matching on more than one distinct field gets a small flat
+ *     bonus per extra field (capped), since agreement across fields is a
+ *     stronger discoverability signal than one big match.
+ *  3. A skill with at least one *exact* match gets a flat confidence bonus,
+ *     so exact matches reliably outrank fuzzy-only matches.
+ *  4. Ties are broken by skill ID, ascending — so identical registry
+ *     content always produces identical ordering, run after run.
+ *
+ * @param query - The search query. `query.text` is required unless
+ *   `query.domain` is set (a domain-only browse is a valid query).
+ * @param registry - A `Registry` object, as produced from `registry/skills.json`.
+ * @throws {InvalidSearchQueryError} If the query has no text and no domain
+ *   filter, or if `limit` is not a positive integer.
+ */
+export function searchSkills(
+	query: SkillSearchQuery,
+	registry: Registry,
+): SkillSearchResponse {
+	const text = query.text ?? '';
+	const trimmedText = text.trim();
+
+	if (trimmedText.length === 0 && !query.domain) {
+		throw new InvalidSearchQueryError(
+			'Search query must include non-empty "text" and/or a "domain" filter.',
+		);
+	}
+
+	const limit = query.limit ?? DEFAULT_LIMIT;
+	if (!Number.isInteger(limit) || limit <= 0) {
+		throw new InvalidSearchQueryError(
+			`"limit" must be a positive integer, received: ${limit}`,
+		);
+	}
+
+	const fields =
+		query.fields && query.fields.length > 0 ? query.fields : ALL_SEARCHABLE_FIELDS;
+	const fuzzy = query.fuzzy ?? true;
+
+	const candidates = query.domain
+		? registry.skills.filter((entry) => entry.domain === query.domain)
+		: registry.skills;
+
+	let scored: ScoredEntry[];
+
+	if (trimmedText.length === 0) {
+		// Domain-only browse: every candidate "matches" via the domain field,
+		// so results are still explainable and consistently ranked.
+		scored = candidates.map((entry) => ({
+			entry,
+			score: FIELD_WEIGHTS.domain,
+			matches: [
+				{
+					field: 'domain' as const,
+					value: entry.domain,
+					matchType: 'exact' as MatchType,
+					similarity: 1,
+					weight: FIELD_WEIGHTS.domain,
+					contribution: FIELD_WEIGHTS.domain,
+				},
+			],
+		}));
+	} else {
+		scored = candidates
+			.map((entry) => scoreEntry(trimmedText, entry, fields, fuzzy))
+			.filter((s): s is ScoredEntry => s !== null);
+	}
+
+	scored.sort(
+		(a, b) =>
+			b.score - a.score ||
+			b.matches.length - a.matches.length ||
+			a.entry.id.localeCompare(b.entry.id),
+	);
+
+	const results: SkillSearchResult[] = scored
+		.slice(0, limit)
+		.map(({ entry, score, matches }) => ({
+			skillId: entry.id,
+			name: entry.name,
+			description: entry.description,
+			domain: entry.domain,
+			score,
+			matches,
+			explanation: buildExplanation(matches),
+		}));
+
+	return { query: text, resultCount: results.length, results };
+}

--- a/packages/hr-skills-build/src/types.ts
+++ b/packages/hr-skills-build/src/types.ts
@@ -133,6 +133,94 @@ export interface RecommendationResult {
 	recommendations: SkillRecommendation[];
 }
 
+// ---------------------------------------------------------------------------
+// Skill search / discovery types (Phase 6.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Registry fields that `searchSkills()` can match against. Kept in sync
+ * with the field list in the Phase 6.1 issue: capabilities, aliases, tags,
+ * domain, trigger phrases.
+ */
+export type SearchableField =
+	| 'capabilities'
+	| 'aliases'
+	| 'tags'
+	| 'domain'
+	| 'triggerPhrases';
+
+/** How a single field value matched the query text. */
+export type MatchType = 'exact' | 'fuzzy';
+
+/**
+ * One matched field value for one skill, with enough detail to explain
+ * *why* the skill matched — the raw ingredients of the result's score.
+ */
+export interface SkillFieldMatch {
+	/** Which registry field matched, e.g. "capabilities". */
+	field: SearchableField;
+	/** The exact field value that matched, e.g. "employee onboarding". */
+	value: string;
+	/** Whether this was an exact or fuzzy match. */
+	matchType: MatchType;
+	/** Match strength, 0–1. Always 1 for exact matches. */
+	similarity: number;
+	/** The field's base weight (see `FIELD_WEIGHTS` in search.ts). */
+	weight: number;
+	/** `weight * similarity`, before any cross-field bonuses. */
+	contribution: number;
+}
+
+/**
+ * One skill's search result: its identity, final score, every field match
+ * that contributed to that score, and a human-readable explanation.
+ */
+export interface SkillSearchResult {
+	/** Matched skill's ID, e.g. "hr-onboarding". */
+	skillId: string;
+	/** Matched skill's display name. */
+	name: string;
+	/** Matched skill's one-sentence description. */
+	description: string;
+	/** Matched skill's routing domain. */
+	domain: SkillCategory;
+	/** Final composite relevance score (see search.ts for the formula). */
+	score: number;
+	/** Every field match that contributed to `score`, most relevant first. */
+	matches: SkillFieldMatch[];
+	/** Deterministic, human-readable summary of why this skill matched. */
+	explanation: string;
+}
+
+/**
+ * A search query against the generated Skill Registry.
+ */
+export interface SkillSearchQuery {
+	/** Free-text query, matched (exact and/or fuzzy) against `fields`. */
+	text: string;
+	/** Fields to search. Defaults to all `SearchableField`s. */
+	fields?: SearchableField[];
+	/** Restrict results to a single domain before scoring. */
+	domain?: SkillCategory;
+	/** Enable fuzzy matching in addition to exact matching. Defaults to true. */
+	fuzzy?: boolean;
+	/** Maximum number of results to return. Defaults to 10. */
+	limit?: number;
+}
+
+/**
+ * The full output of `searchSkills()`: the query that was run plus its
+ * ranked results.
+ */
+export interface SkillSearchResponse {
+	/** The `text` query that was run, echoed back verbatim. */
+	query: string;
+	/** Number of results returned (i.e. `results.length`). */
+	resultCount: number;
+	/** Matching skills, ranked by `score` descending. */
+	results: SkillSearchResult[];
+}
+
 /**
  * The full generated Skill Registry document.
  */

--- a/packages/hr-skills-build/test/search.test.ts
+++ b/packages/hr-skills-build/test/search.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+	ALL_SEARCHABLE_FIELDS,
+	FIELD_WEIGHTS,
+	InvalidSearchQueryError,
+	searchSkills,
+} from '../src/search.js';
+import type { Registry, RegistryEntry } from '../src/types.js';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+const createMockSkill = (overrides: Partial<RegistryEntry> = {}): RegistryEntry => ({
+	id: 'hr-test-skill',
+	name: 'hr-test-skill',
+	version: '1.0.0',
+	description: 'A test skill',
+	tier: 'full',
+	domain: 'onboarding-offboarding',
+	tags: [],
+	aliases: ['test-skill'],
+	capabilities: ['Testing basic capabilities'],
+	triggerPhrases: ['test this skill'],
+	paths: { content: true, prompts: true, examples: true },
+	dependencies: [],
+	relatedSkills: [],
+	...overrides,
+});
+
+const createMockRegistry = (skills: RegistryEntry[] = []): Registry => ({
+	schemaVersion: 1,
+	generatedAt: '2026-07-23',
+	skillCount: skills.length,
+	skills,
+});
+
+const REGISTRY = createMockRegistry([
+	createMockSkill({
+		id: 'hr-onboarding',
+		name: 'hr-onboarding',
+		description: 'Plans and runs new-hire onboarding.',
+		domain: 'onboarding-offboarding',
+		tags: ['lifecycle', 'new-hire'],
+		aliases: ['onboarding', 'new-hire-onboarding'],
+		capabilities: ['Design onboarding plans', 'Draft welcome emails'],
+		triggerPhrases: ['onboard a new hire', 'create an onboarding checklist'],
+	}),
+	createMockSkill({
+		id: 'hr-offboarding',
+		name: 'hr-offboarding',
+		description: 'Plans and runs employee offboarding.',
+		domain: 'onboarding-offboarding',
+		tags: ['lifecycle', 'exit'],
+		aliases: ['offboarding'],
+		capabilities: ['Design offboarding plans', 'Draft exit checklists'],
+		triggerPhrases: ['offboard an employee'],
+	}),
+	createMockSkill({
+		id: 'hr-compensation-benefits',
+		name: 'hr-compensation-benefits',
+		description: 'Designs compensation and benefits programs.',
+		domain: 'compensation-rewards',
+		tags: ['pay', 'benefits'],
+		aliases: ['comp-benefits'],
+		capabilities: ['Build salary bands', 'Design benefits packages'],
+		triggerPhrases: ['design a compensation structure'],
+	}),
+]);
+
+// ============================================================================
+// Exact Match Tests
+// ============================================================================
+
+describe('searchSkills() — exact matches', () => {
+	it('matches an exact alias', () => {
+		const response = searchSkills({ text: 'onboarding' }, REGISTRY);
+		const top = response.results[0];
+		expect(top?.skillId).toBe('hr-onboarding');
+		expect(
+			top?.matches.some((m) => m.field === 'aliases' && m.matchType === 'exact'),
+		).toBe(true);
+	});
+
+	it('matches an exact tag', () => {
+		const response = searchSkills({ text: 'exit', fields: ['tags'] }, REGISTRY);
+		expect(response.results[0]?.skillId).toBe('hr-offboarding');
+		expect(response.results[0]?.matches[0]?.matchType).toBe('exact');
+	});
+
+	it('matches an exact capability substring', () => {
+		const response = searchSkills(
+			{ text: 'salary bands', fields: ['capabilities'] },
+			REGISTRY,
+		);
+		expect(response.results[0]?.skillId).toBe('hr-compensation-benefits');
+	});
+
+	it('matches an exact trigger phrase', () => {
+		const response = searchSkills(
+			{ text: 'offboard an employee', fields: ['triggerPhrases'] },
+			REGISTRY,
+		);
+		expect(response.results[0]?.skillId).toBe('hr-offboarding');
+	});
+
+	it('matches domain exactly', () => {
+		const response = searchSkills(
+			{ text: 'compensation-rewards', fields: ['domain'] },
+			REGISTRY,
+		);
+		expect(response.results[0]?.skillId).toBe('hr-compensation-benefits');
+	});
+
+	it('is case-insensitive', () => {
+		const response = searchSkills({ text: 'ONBOARDING' }, REGISTRY);
+		expect(response.results[0]?.skillId).toBe('hr-onboarding');
+	});
+});
+
+// ============================================================================
+// Fuzzy Match Tests
+// ============================================================================
+
+describe('searchSkills() — fuzzy matches', () => {
+	it('finds a skill despite a typo', () => {
+		const response = searchSkills(
+			{ text: 'onbording', fields: ['aliases'] },
+			REGISTRY,
+		);
+		expect(response.results.some((r) => r.skillId === 'hr-onboarding')).toBe(true);
+		const match = response.results.find((r) => r.skillId === 'hr-onboarding')
+			?.matches[0];
+		expect(match?.matchType).toBe('fuzzy');
+	});
+
+	it('finds a skill via reordered multi-word overlap', () => {
+		const response = searchSkills(
+			{ text: 'new hire onboard', fields: ['triggerPhrases'] },
+			REGISTRY,
+		);
+		expect(response.results[0]?.skillId).toBe('hr-onboarding');
+	});
+
+	it('does not fuzzy match when fuzzy is disabled', () => {
+		const response = searchSkills(
+			{ text: 'onbording', fields: ['aliases'], fuzzy: false },
+			REGISTRY,
+		);
+		expect(response.results.length).toBe(0);
+	});
+
+	it('fuzzy matches score lower than exact matches for the same field', () => {
+		const exact = searchSkills({ text: 'onboarding', fields: ['aliases'] }, REGISTRY);
+		const fuzzy = searchSkills({ text: 'onbording', fields: ['aliases'] }, REGISTRY);
+		const exactScore = exact.results[0]?.score ?? 0;
+		const fuzzyScore =
+			fuzzy.results.find((r) => r.skillId === 'hr-onboarding')?.score ?? 0;
+		expect(fuzzyScore).toBeLessThan(exactScore);
+	});
+});
+
+// ============================================================================
+// Field-Specific Search Tests
+// ============================================================================
+
+describe('searchSkills() — field targeting', () => {
+	it('restricts matching to the requested fields only', () => {
+		// "lifecycle" is a tag on both onboarding and offboarding, but not an
+		// alias or capability — searching aliases only should find nothing.
+		const response = searchSkills(
+			{ text: 'lifecycle', fields: ['aliases'] },
+			REGISTRY,
+		);
+		expect(response.results.length).toBe(0);
+	});
+
+	it('searches all fields by default', () => {
+		expect(ALL_SEARCHABLE_FIELDS.length).toBe(5);
+		const response = searchSkills({ text: 'lifecycle' }, REGISTRY);
+		expect(response.results.length).toBeGreaterThan(0);
+	});
+
+	it('filters candidates by domain before scoring', () => {
+		const response = searchSkills(
+			{ text: 'benefits', domain: 'compensation-rewards' },
+			REGISTRY,
+		);
+		expect(response.results.length).toBeGreaterThan(0);
+		expect(response.results.every((r) => r.domain === 'compensation-rewards')).toBe(
+			true,
+		);
+	});
+
+	it('supports a domain-only browse query with empty text', () => {
+		const response = searchSkills(
+			{ text: '', domain: 'onboarding-offboarding' },
+			REGISTRY,
+		);
+		expect(response.results.map((r) => r.skillId).sort()).toEqual([
+			'hr-offboarding',
+			'hr-onboarding',
+		]);
+	});
+});
+
+// ============================================================================
+// Ranking & Determinism Tests
+// ============================================================================
+
+describe('searchSkills() — ranking and determinism', () => {
+	it('produces identical ordering across repeated runs', () => {
+		const first = searchSkills({ text: 'onboarding plans' }, REGISTRY);
+		const second = searchSkills({ text: 'onboarding plans' }, REGISTRY);
+		expect(first).toEqual(second);
+	});
+
+	it('ranks a skill matching multiple fields above one matching a single field', () => {
+		// "onboarding" hits aliases + tags-adjacent fields for hr-onboarding
+		// via multiple query terms; confirm multi-field skills aren't buried.
+		const response = searchSkills({ text: 'onboarding' }, REGISTRY);
+		const top = response.results[0];
+		expect(top?.skillId).toBe('hr-onboarding');
+		expect(top?.matches.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('breaks ties by skill ID ascending', () => {
+		const registry = createMockRegistry([
+			createMockSkill({ id: 'hr-zeta', aliases: ['shared-alias'] }),
+			createMockSkill({ id: 'hr-alpha', aliases: ['shared-alias'] }),
+		]);
+		const response = searchSkills({ text: 'shared-alias' }, registry);
+		expect(response.results.map((r) => r.skillId)).toEqual(['hr-alpha', 'hr-zeta']);
+	});
+
+	it('sorts results by score descending', () => {
+		const response = searchSkills({ text: 'onboarding offboarding' }, REGISTRY);
+		const scores = response.results.map((r) => r.score);
+		const sorted = [...scores].sort((a, b) => b - a);
+		expect(scores).toEqual(sorted);
+	});
+
+	it('respects the requested limit', () => {
+		const response = searchSkills({ text: 'lifecycle', limit: 1 }, REGISTRY);
+		expect(response.results.length).toBe(1);
+	});
+
+	it('exposes field weights used in scoring', () => {
+		expect(FIELD_WEIGHTS.aliases).toBeGreaterThan(FIELD_WEIGHTS.domain);
+	});
+});
+
+// ============================================================================
+// Explanation Tests
+// ============================================================================
+
+describe('searchSkills() — match explanations', () => {
+	it('includes a non-empty explanation for every result', () => {
+		const response = searchSkills({ text: 'onboarding' }, REGISTRY);
+		for (const result of response.results) {
+			expect(result.explanation.length).toBeGreaterThan(0);
+			expect(result.matches.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('explanation references the matched field and value', () => {
+		const response = searchSkills(
+			{ text: 'onboarding', fields: ['aliases'] },
+			REGISTRY,
+		);
+		expect(response.results[0]?.explanation).toContain('aliases');
+		expect(response.results[0]?.explanation).toContain('onboarding');
+	});
+});
+
+// ============================================================================
+// Empty Results & Invalid Query Tests
+// ============================================================================
+
+describe('searchSkills() — empty results and invalid queries', () => {
+	it('returns an empty result set for a query that matches nothing', () => {
+		const response = searchSkills({ text: 'zzzznonexistentzzzz' }, REGISTRY);
+		expect(response.results).toEqual([]);
+		expect(response.resultCount).toBe(0);
+	});
+
+	it('throws InvalidSearchQueryError for empty text with no domain filter', () => {
+		expect(() => searchSkills({ text: '' }, REGISTRY)).toThrow(
+			InvalidSearchQueryError,
+		);
+	});
+
+	it('throws InvalidSearchQueryError for whitespace-only text with no domain filter', () => {
+		expect(() => searchSkills({ text: '   ' }, REGISTRY)).toThrow(
+			InvalidSearchQueryError,
+		);
+	});
+
+	it('throws InvalidSearchQueryError for a zero limit', () => {
+		expect(() => searchSkills({ text: 'onboarding', limit: 0 }, REGISTRY)).toThrow(
+			InvalidSearchQueryError,
+		);
+	});
+
+	it('throws InvalidSearchQueryError for a negative limit', () => {
+		expect(() => searchSkills({ text: 'onboarding', limit: -1 }, REGISTRY)).toThrow(
+			InvalidSearchQueryError,
+		);
+	});
+
+	it('throws InvalidSearchQueryError for a non-integer limit', () => {
+		expect(() => searchSkills({ text: 'onboarding', limit: 1.5 }, REGISTRY)).toThrow(
+			InvalidSearchQueryError,
+		);
+	});
+
+	it('returns an empty result set for an empty registry', () => {
+		const response = searchSkills({ text: 'onboarding' }, createMockRegistry([]));
+		expect(response.results).toEqual([]);
+	});
+});


### PR DESCRIPTION
Implements Phase 6.1 (Issue #154): ranked skill discovery over the generated registry's structured metadata, instead of exact trigger-phrase matching only.

- Add SkillSearchQuery / SkillSearchResponse / SkillSearchResult / SkillFieldMatch / SearchableField / MatchType types
- Add searchSkills(query, registry) in search.ts:
  - searches capabilities, aliases, tags, domain, and triggerPhrases
  - exact matching (equality/substring) plus deterministic fuzzy matching (token Jaccard overlap + normalized Levenshtein similarity, no ML/embeddings/external services)
  - transparent, additive scoring: field weight * match strength, a capped multi-field bonus, an exact-match confidence bonus, and skill-ID tie-breaking for fully deterministic ordering
  - every result includes per-field match detail and a human-readable explanation string
  - throws InvalidSearchQueryError for empty/invalid queries (distinct from a valid query with zero results)
- Add discover.ts CLI (bun run discover "<query>" [--domain D] [--limit N] [--no-fuzzy]), reading registry/skills.json directly
- Add packages/hr-skills-build/test/search.test.ts: exact matches per field, fuzzy matches, field/domain filtering, domain-only browse, ranking, tie-breaking, explanations, empty results, and invalid-query errors
- Add docs/search.md: query types, searchable fields, ranking strategy, match-explanation format, public API, usage examples, determinism guarantees, and limitations
- Mark the roadmap item as delivered

Additive only: no planner logic, registry schema, or registry generation changed. Reuses the Planner's existing Jaccard-similarity approach as prior art for the fuzzy matcher, but is otherwise fully independent of planner.ts.