### PR TITLE
feat(validation): phase 6.2 — add duplicate-content detection

### DIFF
--- a/docs/duplicate-detection.md
+++ b/docs/duplicate-detection.md
@@ -1,0 +1,184 @@
+# Duplicate-content detection (Phase 6.2)
+
+The repository validates structural correctness and metadata on every run.
+Phase 6.2 adds a second quality layer: **deterministic duplicate-content detection** that identifies pairs of skills whose descriptions or body content substantially overlap.
+
+---
+
+## Purpose
+
+HR skills naturally share vocabulary — words like *employee*, *manager*, *process*, and *hiring* appear throughout the repository.  Duplicate detection does **not** flag this.
+
+It flags cases where two skills appear to be describing **the same knowledge** — for example, two skills that both explain how to run a structured behavioural interview, using nearly the same phrasing across both their descriptions and their content files.
+
+The goal is to help maintainers spot accidental duplication early, **before** it accumulates into maintenance debt.  Reviewers can then decide whether to merge, refactor, or leave the skills as-is (some overlap is intentional).
+
+---
+
+## What is analysed
+
+For each skill the detector reads:
+
+| Source | Used for |
+|--------|----------|
+| Frontmatter `description` field | Description-level Jaccard signal |
+| Body of `SKILL.md` (after stripping frontmatter) | Content-level token and bigram signals |
+| All `.md` files under `content/` (if the directory exists) | Content-level token and bigram signals |
+
+Content from `prompts/` and `examples/` subdirectories is intentionally excluded — example prompts and worked examples are expected to reuse common phrasing.
+
+---
+
+## Similarity heuristic
+
+The detector computes a **weighted composite score** for every pair of skills:
+
+```text
+composite = 0.35 × descriptionJaccard
+          + 0.40 × contentJaccard
+          + 0.25 × bigramJaccard
+```
+
+### Step 1 — Normalise
+
+Each text source is normalised before comparison:
+
+1. Strip YAML frontmatter.
+2. Remove fenced code blocks, inline code, URLs, markdown formatting characters, and punctuation.
+3. Lower-case everything.
+4. Split on whitespace.
+5. Remove tokens shorter than 3 characters.
+6. Remove HR domain stop-words (see below).
+
+The result is a list of meaningful content tokens.
+
+### Step 2 — Description Jaccard (weight 0.35)
+
+The normalised token sets of both `description` fields are compared with Jaccard similarity:
+
+```text
+|A ∩ B| / |A ∪ B|
+```
+
+A score of 1.0 means both descriptions use exactly the same vocabulary (after stop-word removal).
+
+### Step 3 — Content Jaccard (weight 0.40)
+
+The same Jaccard formula is applied to the full normalised token multisets of both skills' combined markdown bodies (SKILL.md body + `content/` files).
+
+Multiset semantics are used: a token appearing twice in skill A and once in skill B contributes 1 to the intersection, not 2.
+
+### Step 4 — Bigram Jaccard (weight 0.25)
+
+Consecutive token pairs (*bigrams*) are extracted from the normalised content before sorting.  These are compared with Jaccard similarity, catching **phrase-level** duplication that single-token overlap misses.
+
+For example, two skills that both repeatedly use the phrase "salary benchmarking" will produce many shared bigrams even if their individual token counts are similar but not identical.
+
+### Step 5 — Composite and threshold
+
+The three signals are combined with the weights above.  A pair is reported when:
+
+```text
+composite ≥ 0.55   (default DUPLICATE_THRESHOLD)
+```
+
+---
+
+## HR domain stop-words
+
+Approximately 70 common HR terms and English function words are filtered out before similarity is measured.  This prevents high vocabulary overlap caused by domain terminology alone from triggering false-positive warnings.
+
+Examples of filtered terms:
+
+> `employee`, `employees`, `manager`, `team`, `process`, `policy`, `hiring`, `training`, `system`, `the`, `and`, `for`, `with`, …
+
+The full list is defined in `detect-duplicates.ts` (`HR_STOP_WORDS`).
+
+---
+
+## Configurable thresholds
+
+All weights and the threshold are exported named constants in `detect-duplicates.ts`:
+
+| Constant | Default | Description |
+|----------|---------|-------------|
+| `WEIGHT_DESCRIPTION` | `0.35` | Weight for description Jaccard |
+| `WEIGHT_CONTENT` | `0.40` | Weight for content Jaccard |
+| `WEIGHT_BIGRAM` | `0.25` | Weight for bigram Jaccard |
+| `DUPLICATE_THRESHOLD` | `0.55` | Minimum composite score to report |
+
+To tighten detection (fewer warnings, higher precision), increase `DUPLICATE_THRESHOLD`.  To loosen it, decrease it.
+
+---
+
+## Interpreting warnings
+
+A warning looks like this in the validator output:
+
+```text
+WARN  hr-interview-structured ↔ hr-interview-behavioral:
+  [duplicate-warning] Similarity score 67% (description: 72%, content: 63%, bigrams: 61%).
+  Composite score 67% exceeds threshold 55%: high description overlap (72%);
+  high content token overlap (63%); significant phrase overlap (61%).
+  Review both skills to determine if they cover genuinely distinct knowledge
+  or should be merged/refactored.
+```
+
+### Suggested actions
+
+| Score range | Interpretation | Suggested action |
+|-------------|----------------|------------------|
+| 55–65% | Moderate overlap | Review; overlap may be intentional |
+| 65–80% | High overlap | Strong candidate for refactoring |
+| 80–100% | Very high overlap | Skills likely describe the same knowledge — merge or differentiate |
+
+---
+
+## Why warnings are informational, not blocking
+
+Duplicate detection is a **quality signal**, not a correctness check.
+
+- Some overlap is intentional.  A skill for *performance reviews* and a skill for *performance improvement plans* will share terminology.
+- The heuristic has false-positive potential for closely related topics.
+- Merging or deleting skills is a human judgment call that should go through the normal review process.
+
+Warnings are emitted after all structural validations and **do not affect the exit code**.  CI passes regardless of the number of duplicate warnings.
+
+Maintainers may choose to make warnings blocking in the future by changing the `validate` script to exit non-zero when `allWarnings.length > 0`.
+
+---
+
+## Limitations
+
+- **No semantic understanding.**  The heuristic is purely lexical.  Two skills covering the same concept but written with very different vocabulary will not be flagged, even if they are functionally identical.
+- **No ML or embeddings.**  Semantic similarity (e.g. "role" vs "position") is not detected.
+- **Stop-word list is static.**  Domain vocabulary evolves; the stop-word list may need periodic updates.
+- **Short skills produce noisy scores.**  A skill with very little unique content after stop-word removal may match many others at a low base rate.
+- **Content-only comparison.**  The detector does not analyse `prompts/` or `examples/` subdirectories.
+
+---
+
+## Running duplicate detection
+
+Duplicate detection runs automatically as part of the standard validation command:
+
+```bash
+bun run validate          # from repo root
+# or
+bun src/validate.ts       # from packages/hr-skills-build/
+```
+
+Warnings are printed after per-skill validation results and before the final pass/fail summary.
+
+---
+
+## Determinism guarantee
+
+The detector is fully deterministic:
+
+- Skills are loaded and compared in alphabetical order.
+- All set and map operations iterate over sorted keys.
+- Pair keys are canonicalised (`skillA < skillB` lexicographically).
+- No timestamps, random values, or external services are used.
+
+Running the validator twice against the same repository state produces byte-for-byte identical warnings.

--- a/packages/hr-skills-build/src/detect-duplicates.ts
+++ b/packages/hr-skills-build/src/detect-duplicates.ts
@@ -1,0 +1,574 @@
+/**
+ * Phase 6.2 — Duplicate-content detection
+ *
+ * Identifies skills whose `description` or `content/` markdown substantially
+ * overlaps with other skills using a deterministic, heuristic approach.
+ *
+ * ## Heuristic overview
+ *
+ * For each pair of skills the detector computes a weighted composite score
+ * from three complementary signals:
+ *
+ * 1. **Description Jaccard (weight 0.35)**
+ *    Normalised token sets of both frontmatter `description` fields are
+ *    compared with Jaccard similarity: |A∩B| / |A∪B|.
+ *
+ * 2. **Content token-overlap (weight 0.40)**
+ *    All markdown files found under `content/` (if present) or the SKILL.md
+ *    body are tokenised after stripping markdown syntax, stop-words, and
+ *    common HR terminology. The resulting token multisets are compared with
+ *    Jaccard similarity.
+ *
+ * 3. **Bigram overlap (weight 0.25)**
+ *    Consecutive token pairs (bigrams) are extracted from the normalised
+ *    content and compared with Jaccard similarity, catching phrase-level
+ *    duplication that single-token overlap misses.
+ *
+ * composite = w1·descJaccard + w2·contentJaccard + w3·bigramJaccard
+ *
+ * A pair is reported when `composite ≥ DUPLICATE_THRESHOLD` (default 0.55).
+ * All three weights and the threshold are exported as named constants so
+ * callers can override them for stricter or more lenient checking.
+ *
+ * ## Stop-word / common-HR-term filtering
+ *
+ * A built-in list of ~70 HR domain stop-words ("employee", "manager",
+ * "process", "team", …) is subtracted before similarity is measured.  This
+ * prevents high vocabulary overlap caused by domain terminology alone from
+ * triggering false-positive warnings.
+ *
+ * ## Determinism guarantee
+ *
+ * The detector:
+ * - performs all set operations on sorted arrays / Maps;
+ * - iterates skill lists in alphabetical order;
+ * - produces pair keys in a canonical `"skillA|||skillB"` form where skillA
+ *   is always lexicographically smaller than skillB;
+ * - never touches timestamps or random values.
+ *
+ * The same repository state therefore always produces exactly the same
+ * warnings in the same order.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { FRONTMATTER_REGEX, SKILLS_DIR } from './constants.js';
+import { dirExists } from './helpers.js';
+import type { SkillValidationIssue } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Configuration — weights and thresholds
+// ---------------------------------------------------------------------------
+
+/** Weight applied to the description-level Jaccard score. */
+export const WEIGHT_DESCRIPTION = 0.35;
+
+/** Weight applied to the content-level token Jaccard score. */
+export const WEIGHT_CONTENT = 0.4;
+
+/** Weight applied to the bigram Jaccard score. */
+export const WEIGHT_BIGRAM = 0.25;
+
+/**
+ * Composite similarity score at or above which a pair is reported as a
+ * potential duplicate.  Range: 0–1.  Default: 0.55.
+ */
+export const DUPLICATE_THRESHOLD = 0.55;
+
+// ---------------------------------------------------------------------------
+// HR domain stop-words
+// ---------------------------------------------------------------------------
+
+/**
+ * Common HR vocabulary that is expected to appear in many skills.
+ * Filtering these terms out prevents domain-vocabulary overlap from
+ * triggering false-positive duplicate warnings.
+ */
+export const HR_STOP_WORDS = new Set([
+	// Generic HR terms
+	'employee',
+	'employees',
+	'employer',
+	'hr',
+	'human',
+	'resources',
+	'manager',
+	'managers',
+	'management',
+	'team',
+	'teams',
+	'staff',
+	'workforce',
+	'personnel',
+	'organization',
+	'organisation',
+	'company',
+	'business',
+	'process',
+	'processes',
+	'policy',
+	'policies',
+	'practice',
+	'practices',
+	'program',
+	'programs',
+	'programme',
+	'programmes',
+	'strategy',
+	'strategies',
+	'plan',
+	'plans',
+	'goal',
+	'goals',
+	'performance',
+	'review',
+	'reviews',
+	'feedback',
+	'support',
+	'role',
+	'roles',
+	'responsibilities',
+	'responsibility',
+	'work',
+	'workplace',
+	'job',
+	'jobs',
+	'position',
+	'positions',
+	'candidate',
+	'candidates',
+	'hire',
+	'hiring',
+	'recruit',
+	'recruiting',
+	'recruitment',
+	'training',
+	'development',
+	'learning',
+	'skill',
+	'skills',
+	'data',
+	'report',
+	'reports',
+	'documentation',
+	'document',
+	'documents',
+	'tool',
+	'tools',
+	'system',
+	'systems',
+	'platform',
+	'platforms',
+	'best',
+	'create',
+	'design',
+	'help',
+	'use',
+	'build',
+	'make',
+	'provide',
+	'ensure',
+	'include',
+	'based',
+	'new',
+	'current',
+	'effective',
+	'clear',
+	'specific',
+	'general',
+	'key',
+	'core',
+	'improve',
+	'increase',
+	'reduce',
+	'identify',
+	'develop',
+	'manage',
+	'track',
+	'monitor',
+	'measure',
+	'implement',
+	'establish',
+	// English stop-words
+	'the',
+	'and',
+	'for',
+	'that',
+	'with',
+	'this',
+	'are',
+	'from',
+	'have',
+	'has',
+	'not',
+	'but',
+	'can',
+	'all',
+	'you',
+	'your',
+	'their',
+	'they',
+	'when',
+	'what',
+	'how',
+	'more',
+	'about',
+	'such',
+	'into',
+	'each',
+	'will',
+	'well',
+	'also',
+	'any',
+	'our',
+	'its',
+	'may',
+	'been',
+	'both',
+	'than',
+	'then',
+	'these',
+	'those',
+	'other',
+	'which',
+	'while',
+	'across',
+	'within',
+	'between',
+	'through',
+]);
+
+// ---------------------------------------------------------------------------
+// Text normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip YAML frontmatter from a markdown string.
+ */
+function stripFrontmatter(text: string): string {
+	return text.replace(FRONTMATTER_REGEX, '').trim();
+}
+
+/**
+ * Remove markdown syntax, code fences, URLs, and punctuation then lower-case.
+ */
+function stripMarkdown(text: string): string {
+	return text
+		.replace(/```[\s\S]*?```/g, ' ') // fenced code blocks
+		.replace(/`[^`]+`/g, ' ') // inline code
+		.replace(/https?:\/\/\S+/g, ' ') // URLs
+		.replace(/#+\s/g, ' ') // headings
+		.replace(/[*_~>|]/g, ' ') // emphasis / table chars
+		.replace(/[^\w\s'-]/g, ' ') // remaining punctuation
+		.replace(/\s+/g, ' ')
+		.toLowerCase()
+		.trim();
+}
+
+/**
+ * Tokenise a normalised string: split on whitespace, remove stop-words and
+ * tokens shorter than 3 characters.  Returns a sorted array for determinism.
+ */
+export function tokenise(text: string): string[] {
+	return stripMarkdown(text)
+		.split(/\s+/)
+		.filter((t) => t.length >= 3 && !HR_STOP_WORDS.has(t))
+		.sort();
+}
+
+/**
+ * Build bigrams (consecutive token pairs) from a token list.
+ * The list must be in its natural (unsorted) order before calling this;
+ * the returned bigrams are sorted for determinism.
+ */
+export function buildBigrams(tokens: string[]): string[] {
+	const bigrams: string[] = [];
+	for (let i = 0; i < tokens.length - 1; i++) {
+		bigrams.push(`${tokens[i]}|${tokens[i + 1]}`);
+	}
+	return bigrams.sort();
+}
+
+// ---------------------------------------------------------------------------
+// Similarity primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * Jaccard similarity between two token arrays treated as multisets.
+ *
+ * |A ∩ B| / |A ∪ B| — both computed from the frequency-aware intersection
+ * so a token appearing twice in A but once in B only contributes 1 to the
+ * intersection.  Returns 0 when both arrays are empty.
+ */
+export function jaccardSimilarity(a: string[], b: string[]): number {
+	if (a.length === 0 && b.length === 0) return 0;
+
+	// Build frequency maps
+	const freqA = new Map<string, number>();
+	for (const t of a) freqA.set(t, (freqA.get(t) ?? 0) + 1);
+
+	const freqB = new Map<string, number>();
+	for (const t of b) freqB.set(t, (freqB.get(t) ?? 0) + 1);
+
+	// Intersection: min(freqA, freqB) per token
+	let intersection = 0;
+	for (const [token, countA] of freqA) {
+		const countB = freqB.get(token) ?? 0;
+		intersection += Math.min(countA, countB);
+	}
+
+	const union = a.length + b.length - intersection;
+	return union === 0 ? 0 : intersection / union;
+}
+
+// ---------------------------------------------------------------------------
+// Skill content extraction
+// ---------------------------------------------------------------------------
+
+/** Parsed representation of a single skill used by the detector. */
+export interface SkillContent {
+	/** Skill directory name, e.g. "hr-onboarding". */
+	name: string;
+	/** Raw frontmatter description string. */
+	description: string;
+	/** Concatenated body text extracted from SKILL.md + content/ files. */
+	body: string;
+}
+
+/**
+ * Extract the frontmatter `description` field from raw SKILL.md content.
+ * Returns an empty string when the field is absent.
+ */
+function extractDescription(raw: string): string {
+	const match = FRONTMATTER_REGEX.exec(raw);
+	if (!match?.[1]) return '';
+	// Look for `description:` — may span multiple lines with YAML folding
+	const descMatch = /^description:\s*(.+?)(?=\n\w|\n---)/ms.exec(match[1]);
+	return descMatch?.[1]?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+/**
+ * Read all markdown files under `<skillDir>/content/` and return their
+ * concatenated text.  Returns an empty string when the directory does not
+ * exist or contains no markdown files.
+ */
+async function readContentFiles(skillDir: string): Promise<string> {
+	const contentDir = join(skillDir, 'content');
+	if (!(await dirExists(contentDir))) return '';
+
+	let entries: string[];
+	try {
+		const raw = await readdir(contentDir, { withFileTypes: true });
+		entries = raw
+			.filter((e) => e.isFile() && e.name.endsWith('.md'))
+			.map((e) => e.name)
+			.sort(); // deterministic order
+	} catch {
+		return '';
+	}
+
+	const parts: string[] = [];
+	for (const entry of entries) {
+		try {
+			parts.push(await readFile(join(contentDir, entry), 'utf8'));
+		} catch {
+			// skip unreadable files
+		}
+	}
+	return parts.join('\n');
+}
+
+/**
+ * Load one skill's textual content for comparison.
+ */
+async function loadSkillContent(skillName: string): Promise<SkillContent> {
+	const skillDir = join(SKILLS_DIR, skillName);
+	const skillMdPath = join(skillDir, 'SKILL.md');
+
+	let raw = '';
+	try {
+		raw = await readFile(skillMdPath, 'utf8');
+	} catch {
+		// fall through — body will be empty
+	}
+
+	const description = extractDescription(raw);
+	const skillMdBody = stripFrontmatter(raw);
+	const contentBody = await readContentFiles(skillDir);
+
+	return {
+		name: skillName,
+		description,
+		body: [skillMdBody, contentBody].filter(Boolean).join('\n'),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Duplicate detection result type
+// ---------------------------------------------------------------------------
+
+/** A single duplicate-detection finding for one pair of skills. */
+export interface DuplicateWarning {
+	/** First skill ID (lexicographically smaller). */
+	skillA: string;
+	/** Second skill ID. */
+	skillB: string;
+	/** Weighted composite similarity score (0–1). */
+	score: number;
+	/** Jaccard similarity of the description tokens alone. */
+	descriptionSimilarity: number;
+	/** Jaccard similarity of the content tokens alone. */
+	contentSimilarity: number;
+	/** Jaccard similarity of the content bigrams alone. */
+	bigramSimilarity: number;
+	/** Human-readable explanation of what drove the score. */
+	explanation: string;
+}
+
+// ---------------------------------------------------------------------------
+// Core detection logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the composite duplicate score for a pair of pre-loaded skills.
+ *
+ * @returns A `DuplicateWarning` when `score >= threshold`, or `null`.
+ */
+export function comparePair(
+	a: SkillContent,
+	b: SkillContent,
+	threshold = DUPLICATE_THRESHOLD,
+): DuplicateWarning | null {
+	// --- Description similarity ---
+	const descTokensA = tokenise(a.description);
+	const descTokensB = tokenise(b.description);
+	const descScore = jaccardSimilarity(descTokensA, descTokensB);
+
+	// --- Content similarity (natural token order for bigrams, then sort) ---
+	const rawBodyTokensA = stripMarkdown(a.body)
+		.split(/\s+/)
+		.filter((t) => t.length >= 3 && !HR_STOP_WORDS.has(t));
+	const rawBodyTokensB = stripMarkdown(b.body)
+		.split(/\s+/)
+		.filter((t) => t.length >= 3 && !HR_STOP_WORDS.has(t));
+
+	const contentScore = jaccardSimilarity(
+		[...rawBodyTokensA].sort(),
+		[...rawBodyTokensB].sort(),
+	);
+
+	// --- Bigram similarity ---
+	const bigramScore = jaccardSimilarity(
+		buildBigrams(rawBodyTokensA),
+		buildBigrams(rawBodyTokensB),
+	);
+
+	// --- Composite ---
+	const composite =
+		WEIGHT_DESCRIPTION * descScore +
+		WEIGHT_CONTENT * contentScore +
+		WEIGHT_BIGRAM * bigramScore;
+
+	if (composite < threshold) return null;
+
+	// Canonical ordering: lexicographically smaller name first
+	const [skillA, skillB] = a.name < b.name ? [a.name, b.name] : [b.name, a.name];
+
+	// Human-readable explanation
+	const parts: string[] = [];
+	if (descScore >= 0.5) parts.push(`high description overlap (${pct(descScore)})`);
+	if (contentScore >= 0.5)
+		parts.push(`high content token overlap (${pct(contentScore)})`);
+	if (bigramScore >= 0.4)
+		parts.push(`significant phrase overlap (${pct(bigramScore)})`);
+	if (parts.length === 0) parts.push('moderate overlap across multiple signals');
+
+	const explanation =
+		`Composite score ${pct(composite)} exceeds threshold ${pct(threshold)}: ` +
+		parts.join('; ') +
+		'. ' +
+		'Review both skills to determine if they cover genuinely distinct knowledge or should be merged/refactored.';
+
+	return {
+		skillA,
+		skillB,
+		score: round(composite),
+		descriptionSimilarity: round(descScore),
+		contentSimilarity: round(contentScore),
+		bigramSimilarity: round(bigramScore),
+		explanation,
+	};
+}
+
+function pct(n: number): string {
+	return `${Math.round(n * 100)}%`;
+}
+
+function round(n: number): number {
+	return Math.round(n * 10000) / 10000;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry-point used by validate.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Run duplicate detection across all provided skill names and emit findings
+ * as `SkillValidationIssue` warnings (message prefix `[duplicate-warning]`).
+ *
+ * Pairs are evaluated in a stable, alphabetically-sorted order.
+ * The function never throws — I/O errors for individual skills are silently
+ * skipped so that other validation can still proceed.
+ *
+ * @param skillNames - Alphabetically-sorted list of skill directory names.
+ * @param warnings   - Mutable array to append warnings into.
+ * @param threshold  - Override the default similarity threshold.
+ */
+export async function detectDuplicates(
+	skillNames: string[],
+	warnings: SkillValidationIssue[],
+	threshold = DUPLICATE_THRESHOLD,
+): Promise<DuplicateWarning[]> {
+	// Load all skills (errors produce empty content — won't match anything)
+	const contents = await Promise.all(
+		[...skillNames].sort().map((name) => loadSkillContent(name)),
+	);
+
+	const findings: DuplicateWarning[] = [];
+
+	for (let i = 0; i < contents.length; i++) {
+		for (let j = i + 1; j < contents.length; j++) {
+			const skillA = contents[i];
+			const skillB = contents[j];
+			if (!skillA || !skillB) continue;
+			const finding = comparePair(skillA, skillB, threshold);
+			if (finding) findings.push(finding);
+		}
+	}
+
+	// Sort findings deterministically: by score desc, then by skillA asc
+	findings.sort((a, b) =>
+		b.score !== a.score
+			? b.score - a.score
+			: a.skillA < b.skillA
+				? -1
+				: a.skillA > b.skillA
+					? 1
+					: 0,
+	);
+
+	// Emit as quality warnings
+	for (const f of findings) {
+		warnings.push({
+			skill: `${f.skillA} ↔ ${f.skillB}`,
+			message:
+				`[duplicate-warning] Similarity score ${pct(f.score)} ` +
+				`(description: ${pct(f.descriptionSimilarity)}, ` +
+				`content: ${pct(f.contentSimilarity)}, ` +
+				`bigrams: ${pct(f.bigramSimilarity)}). ` +
+				f.explanation,
+		});
+	}
+
+	return findings;
+}

--- a/packages/hr-skills-build/src/validate.ts
+++ b/packages/hr-skills-build/src/validate.ts
@@ -16,6 +16,7 @@ import {
 	TASKS_REGEX,
 	TIPS_REGEX,
 } from './constants.js';
+import { detectDuplicates } from './detect-duplicates.js';
 import {
 	countFiles,
 	dirExists,
@@ -454,6 +455,7 @@ async function validate(): Promise<void> {
 	p.log.info(`Found ${skillNames.length} skill directories`);
 
 	const allErrors: SkillValidationIssue[] = [];
+	const allWarnings: SkillValidationIssue[] = [];
 
 	await validateRouterConsistency(skillNames, allErrors);
 	await validateRegistryConsistency(allErrors);
@@ -467,7 +469,21 @@ async function validate(): Promise<void> {
 		}
 	}
 
-	// Report
+	// Phase 6.2 — duplicate-content detection (quality warnings, not failures)
+	await detectDuplicates(skillNames, allWarnings);
+
+	// Report warnings (informational — do not affect exit code)
+	if (allWarnings.length > 0) {
+		p.log.warn(
+			`Duplicate-content warnings: ${allWarnings.length} potential overlap(s) detected`,
+		);
+		for (const w of allWarnings) p.log.warn(`  ${w.skill}: ${w.message}`);
+		p.log.warn(
+			'These are informational. Review the flagged pairs and decide whether to merge or refactor them.',
+		);
+	}
+
+	// Report errors (fatal)
 	if (allErrors.length > 0) {
 		p.log.error('Validation failed');
 
@@ -477,6 +493,7 @@ async function validate(): Promise<void> {
 	}
 
 	p.log.success(`All ${skillNames.length} HR skills are valid`);
+	if (allWarnings.length === 0) p.log.info('No duplicate-content warnings.');
 	p.outro('Done');
 }
 

--- a/packages/hr-skills-build/test/detect-duplicates.test.ts
+++ b/packages/hr-skills-build/test/detect-duplicates.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for Phase 6.2 — duplicate-content detection.
+ *
+ * Covers:
+ * - identical descriptions
+ * - highly overlapping content
+ * - partially overlapping skills
+ * - unrelated skills
+ * - common HR terminology alone does not trigger warnings
+ * - threshold boundary behaviour
+ * - deterministic (stable) output
+ * - bigram similarity
+ * - the full detectDuplicates() pipeline with mocked content
+ */
+import { describe, expect, it } from 'bun:test';
+import type { SkillContent } from '../src/detect-duplicates.js';
+import {
+	buildBigrams,
+	comparePair,
+	DUPLICATE_THRESHOLD,
+	HR_STOP_WORDS,
+	jaccardSimilarity,
+	tokenise,
+	WEIGHT_BIGRAM,
+	WEIGHT_CONTENT,
+	WEIGHT_DESCRIPTION,
+} from '../src/detect-duplicates.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSkill(name: string, description: string, body: string): SkillContent {
+	return { name, description, body };
+}
+
+// ---------------------------------------------------------------------------
+// tokenise()
+// ---------------------------------------------------------------------------
+
+describe('tokenise', () => {
+	it('lowercases and splits on whitespace', () => {
+		const tokens = tokenise('Performance Review Process');
+		// "performance" and "review" are stop-words; "process" is a stop-word too
+		// All three are HR stop-words, so result should be empty
+		expect(tokens).toEqual([]);
+	});
+
+	it('removes tokens shorter than 3 characters', () => {
+		expect(tokenise('an of at be')).toEqual([]);
+	});
+
+	it('strips markdown syntax', () => {
+		// backtick inline code is replaced with a space, so "checklist" becomes a separate token
+		const tokens = tokenise('**Onboarding** for _new_ evaluation employees');
+		// "onboarding", "evaluation" — "employees" is a stop-word
+		expect(tokens).toContain('onboarding');
+		expect(tokens).toContain('evaluation');
+		expect(tokens).not.toContain('employees');
+	});
+
+	it('returns sorted array for determinism', () => {
+		const tokens = tokenise('zebra apple mango banana');
+		const sorted = [...tokens].sort();
+		expect(tokens).toEqual(sorted);
+	});
+
+	it('filters HR stop-words', () => {
+		const tokens = tokenise('employee manager team hr human resources');
+		expect(tokens).toEqual([]);
+	});
+
+	it('preserves meaningful domain terms', () => {
+		const tokens = tokenise('compensation benchmarking equity analysis');
+		expect(tokens).toContain('compensation');
+		expect(tokens).toContain('benchmarking');
+		expect(tokens).toContain('equity');
+		expect(tokens).toContain('analysis');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildBigrams()
+// ---------------------------------------------------------------------------
+
+describe('buildBigrams', () => {
+	it('returns empty array for single token', () => {
+		expect(buildBigrams(['only'])).toEqual([]);
+	});
+
+	it('produces sorted bigrams', () => {
+		const bigrams = buildBigrams(['zebra', 'apple', 'mango']);
+		const sorted = [...bigrams].sort();
+		expect(bigrams).toEqual(sorted);
+	});
+
+	it('builds correct pairs', () => {
+		const bigrams = buildBigrams(['a', 'b', 'c']);
+		expect(bigrams).toContain('a|b');
+		expect(bigrams).toContain('b|c');
+		expect(bigrams.length).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// jaccardSimilarity()
+// ---------------------------------------------------------------------------
+
+describe('jaccardSimilarity', () => {
+	it('returns 1.0 for identical arrays', () => {
+		expect(jaccardSimilarity(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(1);
+	});
+
+	it('returns 0.0 for completely disjoint arrays', () => {
+		expect(jaccardSimilarity(['a', 'b'], ['c', 'd'])).toBe(0);
+	});
+
+	it('returns 0.0 for two empty arrays', () => {
+		expect(jaccardSimilarity([], [])).toBe(0);
+	});
+
+	it('computes correct partial overlap', () => {
+		// A = {a, b, c}, B = {b, c, d}
+		// intersection = 2, union = 4
+		const score = jaccardSimilarity(['a', 'b', 'c'], ['b', 'c', 'd']);
+		expect(score).toBeCloseTo(0.5, 5);
+	});
+
+	it('handles multisets correctly', () => {
+		// A = [a, a, b], B = [a, b, b]
+		// intersection = min(2,1)+min(1,2) = 1+1 = 2
+		// union = 3+3-2 = 4
+		const score = jaccardSimilarity(['a', 'a', 'b'], ['a', 'b', 'b']);
+		expect(score).toBeCloseTo(2 / 4, 5);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// comparePair()
+// ---------------------------------------------------------------------------
+
+describe('comparePair — identical descriptions and body', () => {
+	it('returns a finding with score near 1.0 for identical skills', () => {
+		const desc =
+			'Detailed compensation benchmarking analysis including salary bands and equity adjustments';
+		const body = `
+## Overview
+Compensation benchmarking involves salary banding equity adjustments
+market positioning total rewards analysis.
+
+## Process
+Review salary data against market benchmarks and adjust compensation bands.
+`;
+		const a = makeSkill('hr-comp-a', desc, body);
+		const b = makeSkill('hr-comp-b', desc, body);
+
+		const result = comparePair(a, b);
+		expect(result).not.toBeNull();
+		expect(result?.score).toBeGreaterThan(0.9);
+	});
+
+	it('uses canonical ordering (skillA < skillB)', () => {
+		const s = makeSkill(
+			'hr-z',
+			'compensation analysis equity',
+			'compensation benchmarking salary analysis',
+		);
+		const t = makeSkill(
+			'hr-a',
+			'compensation analysis equity',
+			'compensation benchmarking salary analysis',
+		);
+		const result = comparePair(s, t);
+		expect(result).not.toBeNull();
+		expect(result?.skillA).toBe('hr-a');
+		expect(result?.skillB).toBe('hr-z');
+	});
+});
+
+describe('comparePair — high overlap', () => {
+	it('detects highly overlapping descriptions and content', () => {
+		const descA =
+			'Interview planning toolkit for structured behavioral interviewing and candidate assessment evaluation';
+		const descB =
+			'Interview planning toolkit for structured behavioral interviewing and candidate evaluation assessment';
+		const body = `
+## Behavioral interviewing
+Structured behavioral interviews allow interviewers to assess candidate
+competencies through situation-task-action-result questioning frameworks.
+Assessment rubrics calibrate interviewer scoring consistency.
+`;
+		const a = makeSkill('hr-interview-a', descA, body);
+		const b = makeSkill(
+			'hr-interview-b',
+			descB,
+			`${body}\nAdditional interviewer calibration guidance.`,
+		);
+
+		const result = comparePair(a, b);
+		expect(result).not.toBeNull();
+		expect(result?.score).toBeGreaterThanOrEqual(DUPLICATE_THRESHOLD);
+	});
+});
+
+describe('comparePair — partial overlap', () => {
+	it('returns null for moderately similar skills that share only HR vocabulary', () => {
+		// Both mention "onboarding", but content diverges significantly
+		const a = makeSkill(
+			'hr-onboarding',
+			'Design onboarding experiences for new hires joining the organisation',
+			'Onboarding checklists, orientation schedules, buddy systems, and 30-60-90 day plans.',
+		);
+		const b = makeSkill(
+			'hr-offboarding',
+			'Manage offboarding workflows for departing employees leaving the organisation',
+			'Exit interviews, knowledge transfer, access revocation, final payroll processing.',
+		);
+		// Should NOT be flagged — content is substantially different
+		const result = comparePair(a, b, DUPLICATE_THRESHOLD);
+		// We accept either null or a low score
+		if (result !== null) {
+			expect(result.score).toBeLessThan(DUPLICATE_THRESHOLD);
+		} else {
+			expect(result).toBeNull();
+		}
+	});
+});
+
+describe('comparePair — common HR terminology alone', () => {
+	it('does not flag skills that share only stop-word vocabulary', () => {
+		const a = makeSkill(
+			'hr-payroll',
+			'Manage employee payroll and compensation processes',
+			'Employee payroll management involves team coordination and process documentation.',
+		);
+		const b = makeSkill(
+			'hr-benefits',
+			'Administer employee benefits and compensation programs',
+			'Employee benefits administration requires manager support and process documentation.',
+		);
+		const result = comparePair(a, b);
+		// All unique tokens are HR stop-words or extremely short — should be null or very low score
+		if (result !== null) {
+			expect(result.score).toBeLessThan(DUPLICATE_THRESHOLD);
+		}
+	});
+});
+
+describe('comparePair — unrelated skills', () => {
+	it('returns null for completely unrelated skills', () => {
+		const a = makeSkill(
+			'hr-leave-management',
+			'Automate leave requests and absence tracking with calendar integration',
+			'Leave management covers annual leave, sick leave, parental leave, and unpaid leave. ' +
+				'Absence calendars sync with payroll. Accrual calculations follow statutory requirements.',
+		);
+		const b = makeSkill(
+			'hr-diversity-inclusion',
+			'Build diverse hiring pipelines and inclusive workplace cultures through data and interventions',
+			'Diversity recruiting focuses on underrepresented candidate sourcing through targeted outreach. ' +
+				'Inclusion surveys measure belonging. Bias audits review promotion equity.',
+		);
+		const result = comparePair(a, b);
+		expect(result).toBeNull();
+	});
+});
+
+describe('comparePair — threshold boundary', () => {
+	it('does not report when score is just below threshold', () => {
+		// Use threshold slightly above 1.0 — impossible to reach, so nothing is flagged
+		const a = makeSkill(
+			'hr-a',
+			'compensation analysis equity',
+			'compensation benchmarking salary equity analysis',
+		);
+		const b = makeSkill(
+			'hr-b',
+			'compensation analysis equity',
+			'compensation benchmarking salary equity analysis',
+		);
+		expect(comparePair(a, b, 1.01)).toBeNull();
+	});
+
+	it('reports when score equals threshold', () => {
+		// Force a very low threshold (0.0) to catch anything
+		const a = makeSkill(
+			'hr-a',
+			'onboarding orientation checklist',
+			'new hire orientation checklist workflow',
+		);
+		const b = makeSkill(
+			'hr-b',
+			'onboarding orientation checklist',
+			'new hire orientation checklist workflow',
+		);
+		expect(comparePair(a, b, 0.0)).not.toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe('determinism', () => {
+	it('produces identical results on repeated calls', () => {
+		const desc =
+			'Performance calibration and salary benchmarking for compensation cycles';
+		const body = `
+## Compensation cycle
+Annual compensation calibration involves salary benchmarking against
+market data. Equity adjustments address pay disparity. Merit increases
+reward high performers during the annual review cycle.
+`;
+		const a = makeSkill('hr-comp-x', desc, body);
+		const b = makeSkill('hr-comp-y', desc, body);
+
+		const r1 = comparePair(a, b);
+		const r2 = comparePair(a, b);
+		const r3 = comparePair(a, b);
+
+		expect(r1).toEqual(r2);
+		expect(r2).toEqual(r3);
+	});
+
+	it('tokenise always returns the same sorted array', () => {
+		const text =
+			'Candidate sourcing pipeline diversity recruiting assessment interview';
+		const t1 = tokenise(text);
+		const t2 = tokenise(text);
+		const t3 = tokenise(text);
+		expect(t1).toEqual(t2);
+		expect(t2).toEqual(t3);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Score composition
+// ---------------------------------------------------------------------------
+
+describe('weight constants', () => {
+	it('weights sum to 1.0', () => {
+		const sum = WEIGHT_DESCRIPTION + WEIGHT_CONTENT + WEIGHT_BIGRAM;
+		expect(sum).toBeCloseTo(1.0, 10);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// HR_STOP_WORDS coverage
+// ---------------------------------------------------------------------------
+
+describe('HR_STOP_WORDS', () => {
+	it('includes common HR terms', () => {
+		const mustInclude = [
+			'employee',
+			'manager',
+			'hr',
+			'team',
+			'process',
+			'policy',
+			'hiring',
+		];
+		for (const term of mustInclude) {
+			expect(HR_STOP_WORDS.has(term)).toBe(true);
+		}
+	});
+
+	it('does not include meaningful domain discriminators', () => {
+		const notStop = [
+			'compensation',
+			'benchmarking',
+			'calibration',
+			'sourcing',
+			'onboarding',
+		];
+		for (const term of notStop) {
+			expect(HR_STOP_WORDS.has(term)).toBe(false);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Explanation string
+// ---------------------------------------------------------------------------
+
+describe('comparePair — explanation field', () => {
+	it('includes score and threshold info', () => {
+		const desc =
+			'Compensation benchmarking and salary band analysis for annual cycles';
+		const body = `
+## Process
+Salary benchmarking involves comparing compensation data against market surveys.
+Salary bands define pay ranges for each job level. Annual cycles review and
+adjust compensation structures to maintain market competitiveness.
+`;
+		const a = makeSkill('hr-comp-a', desc, body);
+		const b = makeSkill('hr-comp-b', desc, body);
+		const result = comparePair(a, b);
+
+		if (result) {
+			expect(result.explanation).toContain('Composite score');
+			expect(result.explanation).toContain('threshold');
+			expect(result.explanation).toContain('Review both skills');
+		}
+	});
+});


### PR DESCRIPTION
Implements a deterministic, heuristic duplicate-content detector that identifies skills whose description or content/ markdown substantially overlaps with other skills.

Heuristic: weighted composite of three Jaccard signals
  - description Jaccard (weight 0.35)
  - content token Jaccard (weight 0.40)
  - content bigram Jaccard (weight 0.25) default threshold: 0.55; all weights/threshold are named exports

~70 HR domain stop-words subtracted before comparison to prevent common vocabulary alone from triggering false positives.

Fully deterministic: sorted iteration, canonical pair keys, no timestamps or random values.

Files:
- packages/hr-skills-build/src/detect-duplicates.ts (new)
- packages/hr-skills-build/src/validate.ts (warnings integration)
- packages/hr-skills-build/test/detect-duplicates.test.ts (28 tests)
- docs/duplicate-detection.md (full documentation)