### PR TITLE
feat(validation): phase 6.2 - semantic validation for prompts/examples

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -353,10 +353,14 @@ Extend validation beyond the current structural/format checks
 
 * Duplicate content detection — flag skills with substantially
   overlapping `description`/`content/` before they're merged, not just
-  overlapping directory names
+  overlapping directory names. Delivered — see
+  [`docs/duplicate-detection.md`](duplicate-detection.md)
 * Semantic validation — check that a skill's `prompts/` and `examples/`
   are actually consistent with its `description` and `content/`, beyond
-  today's non-empty-directory structural check
+  today's non-empty-directory structural check. Delivered — see
+  [`docs/semantic-validation.md`](semantic-validation.md) for the
+  heuristics, calibrated thresholds, determinism guarantees, and
+  maintainer guidance
 * Automated content quality scoring — a repeatable score (clarity,
   completeness, example coverage) usable as a review aid, not a merge
   gate, so a low score prompts a closer look rather than an automatic

--- a/docs/semantic-validation.md
+++ b/docs/semantic-validation.md
@@ -1,0 +1,217 @@
+# Semantic validation of prompts and examples (Phase 6.2)
+
+The repository validates structural correctness, metadata, and
+[duplicate content](duplicate-detection.md) on every run. Phase 6.2 adds a
+third quality layer: **deterministic semantic validation** that checks
+whether a skill's `prompts/` and `examples/` material actually stays
+consistent with what the skill claims to do.
+
+---
+
+## Purpose
+
+`prompts/` and `examples/` are supposed to exercise the capability a skill
+documents in its frontmatter `description` and `content/`. Today's
+structural check only confirms those directories are non-empty — it says
+nothing about whether their content is *about the right thing*.
+
+Semantic validation catches the failure modes that slip past a structural
+check:
+
+- Prompts that exercise an unrelated HR capability (wrong file dropped
+  into the wrong skill directory).
+- Examples describing a completely different workflow.
+- `prompts/` or `examples/` content that reads like it was copied from
+  another skill and never adapted.
+- A skill whose supporting material never actually touches the core
+  concepts named in its own description.
+
+As with duplicate detection, the goal is to surface a **review signal**
+early, not to prove semantic drift with certainty. A maintainer still
+makes the final call.
+
+---
+
+## What is analysed
+
+For each skill the validator reads:
+
+| Source | Used for |
+|--------|----------|
+| Frontmatter `description` field | The skill's documented purpose, and the source of its "primary concept" keywords |
+| Body of `SKILL.md` (after stripping frontmatter) | Purpose vocabulary |
+| All `.md` files under `content/` (if present) | Purpose vocabulary, and concept-coverage support |
+| All `.md` files under `prompts/` (if present) | Compared against purpose vocabulary |
+| All `.md` files under `examples/` (if present) | Compared against purpose vocabulary |
+
+Text normalisation, tokenisation, stop-word filtering, and Jaccard
+similarity are all shared with [duplicate detection](duplicate-detection.md)
+— both checks call the same `tokenise()` and `jaccardSimilarity()`
+functions from `detect-duplicates.ts`, so there is exactly one definition
+of "how similar is this text" in the codebase.
+
+---
+
+## The four heuristics
+
+Each is independent, deterministic, and reported separately so a finding
+always says exactly which check triggered and why.
+
+### 1. Prompt drift
+
+Computes `Jaccard(purposeTokens, promptsTokens)`. If the score falls below
+`PROMPT_DRIFT_THRESHOLD` (default `0.015`), the prompts share almost no
+vocabulary with the skill's own description/content — a strong signal the
+prompts belong to a different capability entirely.
+
+### 2. Example drift
+
+Same idea, applied to `examples/` against `EXAMPLE_DRIFT_THRESHOLD`
+(default `0.03`).
+
+### 3. Possible copy (prompts / examples)
+
+For a skill's `prompts/` (or `examples/`) tokens, the validator computes:
+
+- **own score** — Jaccard against the skill's *own* purpose tokens.
+- **best-other score** — the highest Jaccard against *any other* skill's
+  purpose tokens.
+
+If `bestOtherScore - ownScore >= COPY_MARGIN` (default `0.06`) **and**
+`bestOtherScore >= COPY_MIN_OTHER_SCORE` (default `0.12`), the material is
+flagged as possibly copied or adapted from that other skill without being
+updated for the current one.
+
+This is checked independently for `prompts/` and `examples/`, so a finding
+always names the specific subdirectory and the specific other skill it
+matches better.
+
+### 4. Missing concept coverage
+
+The top `TOP_KEYWORD_COUNT` (default `5`) most frequent non-stop-word
+tokens in the `description` are treated as the skill's primary concepts
+(ties broken alphabetically for determinism). The validator checks how
+many of them appear anywhere across `prompts/`, `examples/`, and
+`content/` combined.
+
+If fewer than `MIN_COVERAGE_RATIO` (default `0.3`, i.e. 30%) of the
+keywords are covered, the finding lists exactly which keywords are
+missing — a quick pointer to what the supporting material should
+reinforce but currently doesn't.
+
+---
+
+## Threshold calibration
+
+Every default threshold above was calibrated against this repository's
+actual skill corpus — 146 skills, all with `examples/`, most with
+`prompts/` — so that, as of calibration, **zero findings** are produced
+against genuine, on-topic material:
+
+| Constant | Default | Calibration basis |
+|----------|---------|--------------------|
+| `PROMPT_DRIFT_THRESHOLD` | `0.015` | Below the lowest legitimate prompt-vs-purpose score observed (~0.018) |
+| `EXAMPLE_DRIFT_THRESHOLD` | `0.03` | Below the lowest legitimate example-vs-purpose score observed (~0.041) |
+| `COPY_MARGIN` | `0.06` | Above the highest legitimate cross-skill margin observed (~0.059) |
+| `COPY_MIN_OTHER_SCORE` | `0.12` | Keeps low-score-vs-low-score pairs from triggering on margin alone |
+| `MIN_COVERAGE_RATIO` | `0.3` | Below the lowest legitimate keyword-coverage ratio observed (0.4) |
+| `TOP_KEYWORD_COUNT` | `5` | Small enough to stay focused on genuinely primary concepts |
+| `MIN_PURPOSE_TOKENS` | `5` | Skips skills whose description/content is too small to compare against reliably |
+
+All constants are exported from `semantic-validation.ts` so they can be
+tuned by maintainers if the corpus grows or drifts.
+
+---
+
+## Interpreting warnings
+
+A finding looks like this in the validator output:
+
+```text
+WARN  hr-onboarding: [semantic-warning] (possible-copy-prompts, confidence 42%) prompts/:
+  prompts/ matches "hr-payroll"'s description/content (Jaccard 58%) more closely
+  than it matches "hr-onboarding"'s own (Jaccard 16%). This material may have
+  been copied or adapted from "hr-payroll" without updating it for this skill.
+```
+
+### Suggested maintainer action per heuristic
+
+| Heuristic | What it means | Suggested action |
+|-----------|----------------|-------------------|
+| `prompt-drift` | `prompts/` is nearly unrelated to the skill's own purpose | Confirm the prompts weren't misfiled; rewrite or relocate them |
+| `example-drift` | `examples/` describes an unrelated workflow | Confirm the example matches this skill's actual use case |
+| `possible-copy-prompts` / `possible-copy-examples` | Content reads closer to another named skill | Compare against that skill; adapt the wording to this skill's domain, or genuinely deduplicate |
+| `missing-coverage` | Core description concepts never show up in supporting material | Add a prompt or example that actually exercises the missing concept(s) |
+
+---
+
+## Why warnings are informational, not blocking
+
+Semantic validation is a **quality signal**, not a correctness check, for
+the same reasons given in [duplicate detection](duplicate-detection.md):
+
+- Two closely related skills can legitimately share vocabulary.
+- The heuristic is purely lexical — it cannot understand meaning, only
+  measure vocabulary overlap.
+- Deciding whether to rewrite, relocate, or leave content as-is is a
+  human judgment call.
+
+Findings are emitted after per-skill structural validation and
+duplicate-content detection, and **do not affect the exit code**. CI
+passes regardless of how many semantic warnings are reported.
+
+---
+
+## Limitations
+
+- **No semantic understanding.** Like duplicate detection, this is purely
+  lexical (token/Jaccard) — two skills covering the same idea with very
+  different vocabulary will not be flagged, and two skills using similar
+  wording for genuinely different purposes could be.
+- **No ML, embeddings, or external calls.** By design (see
+  [`docs/ROADMAP.md`](ROADMAP.md#62-quality-automation)), this stays
+  fully local, dependency-free, and network-free.
+- **Small-sample noise.** Very short `description` or `prompts/`/`examples/`
+  files produce coarse similarity scores; `MIN_PURPOSE_TOKENS` mitigates
+  but does not eliminate this.
+- **Static thresholds.** As the skill corpus grows, thresholds calibrated
+  against today's 146 skills may need revisiting — see the constants
+  table above.
+- **Cross-skill copy check is O(n²).** For each skill's `prompts/` or
+  `examples/`, the best-other-match search compares against every other
+  skill's purpose tokens. This is cheap at the current corpus size but is
+  worth revisiting if the skill count grows an order of magnitude.
+
+---
+
+## Running semantic validation
+
+Semantic validation runs automatically as part of the standard validation
+command, immediately after duplicate-content detection:
+
+```bash
+bun run validate          # from repo root
+# or
+bun src/validate.ts       # from packages/hr-skills-build/
+```
+
+Warnings from duplicate detection and semantic validation are merged into
+one `Quality warnings` summary, printed after per-skill validation
+results and before the final pass/fail summary.
+
+---
+
+## Determinism guarantee
+
+The validator is fully deterministic:
+
+- Skills are loaded and processed in alphabetical order.
+- `content/`, `prompts/`, and `examples/` files are read in alphabetical
+  filename order before being concatenated.
+- The best-other-match search for possible-copy findings iterates skills
+  in a fixed, pre-sorted order.
+- Findings are sorted by skill name, then by heuristic name.
+- No timestamps, random values, or external services are used.
+
+Running the validator twice against the same repository state produces
+byte-for-byte identical warnings.

--- a/packages/hr-skills-build/src/semantic-validation.ts
+++ b/packages/hr-skills-build/src/semantic-validation.ts
@@ -1,0 +1,491 @@
+/**
+ * Phase 6.2 — Semantic validation for prompts and examples
+ *
+ * Checks whether each skill's `prompts/` and `examples/` material is
+ * actually consistent with the skill's documented purpose (frontmatter
+ * `description` + SKILL.md body + `content/`), using the same deterministic,
+ * heuristic approach established by `detect-duplicates.ts`.
+ *
+ * This module reuses `tokenise()` and `jaccardSimilarity()` from
+ * `detect-duplicates.ts` so both quality checks share one normalisation and
+ * similarity implementation — there is exactly one definition of "how
+ * similar are two pieces of HR-skill text" in the codebase.
+ *
+ * ## Heuristic overview
+ *
+ * For every skill the validator builds three token sets:
+ *
+ * - **purpose** — normalised tokens from `description` + SKILL.md body +
+ *   `content/*.md` (the skill's documented intent).
+ * - **prompts** — normalised tokens from `prompts/*.md`.
+ * - **examples** — normalised tokens from `examples/*.md`.
+ *
+ * Four independent, explainable checks are run per skill:
+ *
+ * 1. **Prompt drift** — Jaccard(purpose, prompts) below
+ *    {@link PROMPT_DRIFT_THRESHOLD} means the prompts share almost no
+ *    vocabulary with the skill's own purpose.
+ * 2. **Example drift** — Jaccard(purpose, examples) below
+ *    {@link EXAMPLE_DRIFT_THRESHOLD}, same idea for `examples/`.
+ * 3. **Possible copy** — for `prompts/` and `examples/` independently: if
+ *    the token set matches *another* skill's purpose tokens meaningfully
+ *    better than it matches its own (by at least {@link COPY_MARGIN}, and
+ *    the other skill's score clears {@link COPY_MIN_OTHER_SCORE}), the
+ *    material likely originated from that other skill.
+ * 4. **Missing concept coverage** — the top
+ *    {@link TOP_KEYWORD_COUNT} most frequent non-stop-word tokens in the
+ *    `description` are extracted as the skill's "primary concepts". If
+ *    fewer than {@link MIN_COVERAGE_RATIO} of them appear anywhere across
+ *    `prompts/`, `examples/`, and `content/` combined, the supporting
+ *    material is flagged for not reinforcing the skill's stated focus.
+ *
+ * All four checks are deterministic: same repository content always
+ * produces the same findings, in the same order (skills processed
+ * alphabetically; findings sorted by skill, then by heuristic name).
+ *
+ * ## Threshold calibration
+ *
+ * The default thresholds were calibrated against this repository's actual
+ * skill corpus (146 skills with `prompts/`, all with `examples/`) so that,
+ * as of the calibration date, zero findings are produced against genuine,
+ * on-topic content — every threshold sits below the worst (lowest
+ * legitimate) score observed in the corpus. This keeps the check
+ * conservative: it is tuned to catch obviously unrelated or copied
+ * material, not to nitpick loosely-related phrasing.
+ *
+ * ## Severity
+ *
+ * All findings are reported as **warnings** (informational quality
+ * signals), matching duplicate-content detection and the same rationale
+ * given in `docs/duplicate-detection.md`: keyword/Jaccard heuristics are a
+ * useful review aid but cannot reliably prove semantic drift beyond doubt,
+ * so they should prompt a maintainer look rather than fail the build.
+ *
+ * ## Constraints honoured
+ *
+ * No network access, no AI/LLM calls, no embeddings, no vector search — the
+ * entire check is pure, synchronous-friendly string/set arithmetic over
+ * files already read from disk.
+ */
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { jaccardSimilarity, tokenise } from './detect-duplicates.js';
+import type { SkillValidationIssue } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Configuration — thresholds
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum Jaccard similarity between a skill's purpose tokens and its
+ * `prompts/` tokens. Below this, prompts are considered drifted from the
+ * skill's documented purpose. Calibrated below the lowest legitimate score
+ * (~0.018) observed across this repository's skills.
+ */
+export const PROMPT_DRIFT_THRESHOLD = 0.015;
+
+/**
+ * Minimum Jaccard similarity between a skill's purpose tokens and its
+ * `examples/` tokens. Calibrated below the lowest legitimate score
+ * (~0.041) observed across this repository's skills.
+ */
+export const EXAMPLE_DRIFT_THRESHOLD = 0.03;
+
+/**
+ * Minimum margin by which another skill's purpose tokens must out-score a
+ * skill's own purpose tokens (against the same prompts/examples tokens)
+ * before the material is flagged as possibly copied. Calibrated above the
+ * highest legitimate margin (~0.059) observed across this repository.
+ */
+export const COPY_MARGIN = 0.06;
+
+/**
+ * Minimum absolute similarity to the *other* skill's purpose tokens
+ * required before a possible-copy finding is reported, so two skills that
+ * both score near-zero against everything don't trigger on margin alone.
+ */
+export const COPY_MIN_OTHER_SCORE = 0.12;
+
+/** Number of top description keywords used for the concept-coverage check. */
+const TOP_KEYWORD_COUNT = 5;
+
+/**
+ * Minimum fraction of top description keywords that must appear somewhere
+ * in `prompts/` + `examples/` + `content/` combined. Calibrated below the
+ * lowest legitimate ratio (0.4) observed across this repository.
+ */
+export const MIN_COVERAGE_RATIO = 0.3;
+
+/**
+ * Skills whose purpose token set is smaller than this are skipped for
+ * drift/coverage checks — too little documented text to compare against
+ * reliably, so flagging would be noise rather than signal.
+ */
+export const MIN_PURPOSE_TOKENS = 5;
+
+// ---------------------------------------------------------------------------
+// Skill semantic content
+// ---------------------------------------------------------------------------
+
+/** One skill's token sets and raw description, used for semantic checks. */
+export interface SkillSemanticContent {
+	/** Skill directory name, e.g. "hr-onboarding". */
+	name: string;
+	/** Raw frontmatter description string (pre-tokenisation). */
+	description: string;
+	/** Normalised tokens from description + SKILL.md body + content/. */
+	purposeTokens: string[];
+	/** Normalised tokens from prompts/*.md. Empty when prompts/ is absent. */
+	promptsTokens: string[];
+	/** Normalised tokens from examples/*.md. Empty when examples/ is absent. */
+	examplesTokens: string[];
+	/** Normalised tokens from content/*.md alone. Empty when content/ is absent. */
+	contentTokens: string[];
+	/** Whether prompts/ exists and contains at least one .md file. */
+	hasPrompts: boolean;
+	/** Whether examples/ exists and contains at least one .md file. */
+	hasExamples: boolean;
+}
+
+async function dirExists(path: string): Promise<boolean> {
+	try {
+		return (await stat(path)).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Read and concatenate all `.md` files directly inside `dir`, in
+ * alphabetical filename order. Returns an empty string when the directory
+ * does not exist or contains no markdown files.
+ */
+async function readAllMarkdown(dir: string): Promise<string> {
+	if (!(await dirExists(dir))) return '';
+
+	let entries: string[];
+	try {
+		entries = (await readdir(dir, { withFileTypes: true }))
+			.filter((e) => e.isFile() && e.name.endsWith('.md'))
+			.map((e) => e.name)
+			.sort();
+	} catch {
+		return '';
+	}
+
+	const parts: string[] = [];
+	for (const entry of entries) {
+		try {
+			parts.push(await readFile(join(dir, entry), 'utf8'));
+		} catch {
+			// skip unreadable files
+		}
+	}
+	return parts.join('\n');
+}
+
+/** Extract the frontmatter `description` field from raw SKILL.md content. */
+function extractDescription(raw: string): string {
+	const frontmatterMatch = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw);
+	if (!frontmatterMatch?.[1]) return '';
+	const descMatch = /^description:\s*(.+?)(?=\n\w|\n---)/ms.exec(frontmatterMatch[1]);
+	return descMatch?.[1]?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+/** Strip YAML frontmatter from a markdown string. */
+function stripFrontmatter(raw: string): string {
+	return raw.replace(/^---\r?\n[\s\S]*?\r?\n---/, '').trim();
+}
+
+/**
+ * Load one skill's semantic content: purpose/prompts/examples token sets.
+ *
+ * @param skillsDir - Absolute path to the repository's `skills/` directory.
+ * @param skillName - The skill's directory name (e.g. `"hr-onboarding"`).
+ */
+export async function loadSkillSemanticContent(
+	skillsDir: string,
+	skillName: string,
+): Promise<SkillSemanticContent> {
+	const skillDir = join(skillsDir, skillName);
+	const skillMdPath = join(skillDir, 'SKILL.md');
+
+	let raw = '';
+	try {
+		raw = await readFile(skillMdPath, 'utf8');
+	} catch {
+		// fall through — everything stays empty
+	}
+
+	const description = extractDescription(raw);
+	const body = stripFrontmatter(raw);
+	const contentBody = await readAllMarkdown(join(skillDir, 'content'));
+	const promptsBody = await readAllMarkdown(join(skillDir, 'prompts'));
+	const examplesBody = await readAllMarkdown(join(skillDir, 'examples'));
+
+	return {
+		name: skillName,
+		description,
+		purposeTokens: tokenise(
+			[description, body, contentBody].filter(Boolean).join('\n'),
+		),
+		promptsTokens: tokenise(promptsBody),
+		examplesTokens: tokenise(examplesBody),
+		contentTokens: tokenise(contentBody),
+		hasPrompts: promptsBody.trim().length > 0,
+		hasExamples: examplesBody.trim().length > 0,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Primary-concept keyword extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the top `count` most frequent normalised tokens from `description`.
+ * Ties are broken alphabetically so the result is deterministic.
+ */
+export function topKeywords(description: string, count = TOP_KEYWORD_COUNT): string[] {
+	const tokens = tokenise(description);
+	const freq = new Map<string, number>();
+	for (const t of tokens) freq.set(t, (freq.get(t) ?? 0) + 1);
+
+	return [...freq.entries()]
+		.sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+		.slice(0, count)
+		.map(([token]) => token);
+}
+
+// ---------------------------------------------------------------------------
+// Finding type
+// ---------------------------------------------------------------------------
+
+/** Which of the four heuristics produced a given finding. */
+type SemanticHeuristic =
+	| 'prompt-drift'
+	| 'example-drift'
+	| 'possible-copy-prompts'
+	| 'possible-copy-examples'
+	| 'missing-coverage';
+
+/** A single semantic-consistency finding for one skill. */
+export interface SemanticFinding {
+	/** Affected skill's directory name. */
+	skill: string;
+	/** Affected subdirectory/file, e.g. "prompts/", "examples/". */
+	file: string;
+	/** Which heuristic triggered this finding. */
+	heuristic: SemanticHeuristic;
+	/** Deterministic confidence score in [0, 1] — higher means more confident. */
+	confidence: number;
+	/** Human-readable explanation, including the heuristic and suggested action. */
+	explanation: string;
+}
+
+function round(n: number): number {
+	return Math.round(n * 10000) / 10000;
+}
+
+function pct(n: number): string {
+	return `${Math.round(n * 100)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Per-skill checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Check `prompts/` and `examples/` for drift against a skill's own purpose
+ * tokens (checks 1 and 2), skipping skills whose purpose vocabulary is too
+ * small to compare against reliably.
+ */
+export function checkDrift(skill: SkillSemanticContent): SemanticFinding[] {
+	const findings: SemanticFinding[] = [];
+	if (skill.purposeTokens.length < MIN_PURPOSE_TOKENS) return findings;
+
+	if (skill.hasPrompts) {
+		const score = jaccardSimilarity(skill.purposeTokens, skill.promptsTokens);
+		if (score < PROMPT_DRIFT_THRESHOLD) {
+			findings.push({
+				skill: skill.name,
+				file: 'prompts/',
+				heuristic: 'prompt-drift',
+				confidence: round(1 - score / PROMPT_DRIFT_THRESHOLD),
+				explanation:
+					`prompts/ shares almost no vocabulary with this skill's description/content ` +
+					`(Jaccard ${pct(score)}, below the ${pct(PROMPT_DRIFT_THRESHOLD)} threshold). ` +
+					`Review whether these prompts actually belong to a different HR capability.`,
+			});
+		}
+	}
+
+	if (skill.hasExamples) {
+		const score = jaccardSimilarity(skill.purposeTokens, skill.examplesTokens);
+		if (score < EXAMPLE_DRIFT_THRESHOLD) {
+			findings.push({
+				skill: skill.name,
+				file: 'examples/',
+				heuristic: 'example-drift',
+				confidence: round(1 - score / EXAMPLE_DRIFT_THRESHOLD),
+				explanation:
+					`examples/ shares almost no vocabulary with this skill's description/content ` +
+					`(Jaccard ${pct(score)}, below the ${pct(EXAMPLE_DRIFT_THRESHOLD)} threshold). ` +
+					`Review whether these examples describe a different workflow entirely.`,
+			});
+		}
+	}
+
+	return findings;
+}
+
+/**
+ * Check whether `prompts/` or `examples/` match another skill's purpose
+ * tokens meaningfully better than they match their own skill (check 3).
+ *
+ * @param skill - The skill whose supporting material is being checked.
+ * @param allSkills - All skills' semantic content, used to find the best
+ *   cross-skill match. Must include `skill` itself (it is skipped).
+ */
+export function checkPossibleCopy(
+	skill: SkillSemanticContent,
+	allSkills: SkillSemanticContent[],
+): SemanticFinding[] {
+	const findings: SemanticFinding[] = [];
+	if (skill.purposeTokens.length < MIN_PURPOSE_TOKENS) return findings;
+
+	const others = allSkills.filter((s) => s.name !== skill.name);
+
+	const check = (
+		tokens: string[],
+		file: string,
+		heuristic: 'possible-copy-prompts' | 'possible-copy-examples',
+	): void => {
+		if (tokens.length === 0) return;
+
+		const ownScore = jaccardSimilarity(tokens, skill.purposeTokens);
+
+		let bestOtherScore = -1;
+		let bestOtherName = '';
+		// Iterate in a fixed (alphabetical, pre-sorted) order for determinism.
+		for (const other of others) {
+			const score = jaccardSimilarity(tokens, other.purposeTokens);
+			if (score > bestOtherScore) {
+				bestOtherScore = score;
+				bestOtherName = other.name;
+			}
+		}
+
+		if (
+			bestOtherScore >= COPY_MIN_OTHER_SCORE &&
+			bestOtherScore - ownScore >= COPY_MARGIN
+		) {
+			findings.push({
+				skill: skill.name,
+				file,
+				heuristic,
+				confidence: round(Math.min(1, bestOtherScore - ownScore)),
+				explanation:
+					`${file} matches "${bestOtherName}"'s description/content (Jaccard ${pct(bestOtherScore)}) ` +
+					`more closely than it matches "${skill.name}"'s own (Jaccard ${pct(ownScore)}). ` +
+					`This material may have been copied or adapted from "${bestOtherName}" without updating it for this skill.`,
+			});
+		}
+	};
+
+	check(skill.promptsTokens, 'prompts/', 'possible-copy-prompts');
+	check(skill.examplesTokens, 'examples/', 'possible-copy-examples');
+
+	return findings;
+}
+
+/**
+ * Check that the skill's top description keywords are actually covered
+ * somewhere in its supporting material (check 4).
+ */
+export function checkConceptCoverage(skill: SkillSemanticContent): SemanticFinding[] {
+	const keywords = topKeywords(skill.description);
+	if (keywords.length === 0) return [];
+
+	const supportTokens = new Set([
+		...skill.promptsTokens,
+		...skill.examplesTokens,
+		...skill.contentTokens,
+	]);
+	const covered = keywords.filter((k) => supportTokens.has(k));
+	const ratio = covered.length / keywords.length;
+
+	if (ratio >= MIN_COVERAGE_RATIO) return [];
+
+	const missing = keywords.filter((k) => !covered.includes(k));
+
+	return [
+		{
+			skill: skill.name,
+			file: 'prompts/ + examples/ + content/',
+			heuristic: 'missing-coverage',
+			confidence: round(1 - ratio),
+			explanation:
+				`Only ${covered.length}/${keywords.length} primary description keywords ` +
+				`(missing: ${missing.join(', ')}) appear anywhere in prompts/, examples/, or content/ ` +
+				`(coverage ${pct(ratio)}, below the ${pct(MIN_COVERAGE_RATIO)} threshold). ` +
+				`Consider adding prompts, examples, or content that exercise these core concepts.`,
+		},
+	];
+}
+
+// ---------------------------------------------------------------------------
+// Main entry-point used by validate.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Run semantic consistency validation across all provided skill names and
+ * emit findings as `SkillValidationIssue` warnings (message prefix
+ * `[semantic-warning]`).
+ *
+ * Skills are processed in alphabetically-sorted order and findings are
+ * sorted by skill name, then by heuristic name, so the same repository
+ * state always produces identical output.
+ *
+ * The function never throws — I/O errors for individual skills simply
+ * result in empty token sets, which cannot spuriously trigger a finding
+ * (empty prompts/examples are skipped; empty purpose is below
+ * {@link MIN_PURPOSE_TOKENS} and skipped too).
+ *
+ * @param skillsDir - Absolute path to the repository's `skills/` directory.
+ * @param skillNames - List of skill directory names to validate.
+ * @param warnings - Mutable array to append warnings into.
+ */
+export async function validateSemanticConsistency(
+	skillsDir: string,
+	skillNames: string[],
+	warnings: SkillValidationIssue[],
+): Promise<SemanticFinding[]> {
+	const sortedNames = [...skillNames].sort();
+	const allSkills = await Promise.all(
+		sortedNames.map((name) => loadSkillSemanticContent(skillsDir, name)),
+	);
+
+	const findings: SemanticFinding[] = [];
+	for (const skill of allSkills) {
+		findings.push(...checkDrift(skill));
+		findings.push(...checkPossibleCopy(skill, allSkills));
+		findings.push(...checkConceptCoverage(skill));
+	}
+
+	// Deterministic ordering: by skill name, then by heuristic name.
+	findings.sort((a, b) => {
+		if (a.skill !== b.skill) return a.skill < b.skill ? -1 : 1;
+		if (a.heuristic !== b.heuristic) return a.heuristic < b.heuristic ? -1 : 1;
+		return 0;
+	});
+
+	for (const f of findings) {
+		warnings.push({
+			skill: f.skill,
+			message: `[semantic-warning] (${f.heuristic}, confidence ${pct(f.confidence)}) ${f.file}: ${f.explanation}`,
+		});
+	}
+
+	return findings;
+}

--- a/packages/hr-skills-build/src/validate.ts
+++ b/packages/hr-skills-build/src/validate.ts
@@ -33,6 +33,7 @@ import {
 	validateSensitivePaths,
 	validateSuspiciousUrls,
 } from './security.js';
+import { validateSemanticConsistency } from './semantic-validation.js';
 import type { SkillValidationIssue } from './types.js';
 import { validateRegistryConsistency } from './validate-registry.js';
 
@@ -472,14 +473,15 @@ async function validate(): Promise<void> {
 	// Phase 6.2 — duplicate-content detection (quality warnings, not failures)
 	await detectDuplicates(skillNames, allWarnings);
 
+	// Phase 6.2 — semantic validation of prompts/examples (quality warnings, not failures)
+	await validateSemanticConsistency(SKILLS_DIR, skillNames, allWarnings);
+
 	// Report warnings (informational — do not affect exit code)
 	if (allWarnings.length > 0) {
-		p.log.warn(
-			`Duplicate-content warnings: ${allWarnings.length} potential overlap(s) detected`,
-		);
+		p.log.warn(`Quality warnings: ${allWarnings.length} potential issue(s) detected`);
 		for (const w of allWarnings) p.log.warn(`  ${w.skill}: ${w.message}`);
 		p.log.warn(
-			'These are informational. Review the flagged pairs and decide whether to merge or refactor them.',
+			'These are informational. Review the flagged skills and decide whether to merge, refactor, or update them.',
 		);
 	}
 
@@ -493,7 +495,7 @@ async function validate(): Promise<void> {
 	}
 
 	p.log.success(`All ${skillNames.length} HR skills are valid`);
-	if (allWarnings.length === 0) p.log.info('No duplicate-content warnings.');
+	if (allWarnings.length === 0) p.log.info('No quality warnings.');
 	p.outro('Done');
 }
 

--- a/packages/hr-skills-build/test/semantic-validation.test.ts
+++ b/packages/hr-skills-build/test/semantic-validation.test.ts
@@ -1,0 +1,675 @@
+/**
+ * Tests for Phase 6.2 — semantic validation of prompts/examples.
+ *
+ * Covers:
+ * - fully consistent skills (no findings)
+ * - unrelated prompts (prompt-drift)
+ * - unrelated examples (example-drift)
+ * - copied examples / copied prompts (possible-copy)
+ * - partially matching content
+ * - metadata / keyword-coverage inconsistencies (missing-coverage)
+ * - threshold boundaries
+ * - deterministic behaviour
+ * - stable validation output across repeated calls
+ * - the full validateSemanticConsistency() pipeline via a mocked directory
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	COPY_MARGIN,
+	COPY_MIN_OTHER_SCORE,
+	checkConceptCoverage,
+	checkDrift,
+	checkPossibleCopy,
+	EXAMPLE_DRIFT_THRESHOLD,
+	loadSkillSemanticContent,
+	MIN_COVERAGE_RATIO,
+	MIN_PURPOSE_TOKENS,
+	PROMPT_DRIFT_THRESHOLD,
+	type SkillSemanticContent,
+	topKeywords,
+	validateSemanticConsistency,
+} from '../src/semantic-validation.js';
+import type { SkillValidationIssue } from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSkill(overrides: Partial<SkillSemanticContent> = {}): SkillSemanticContent {
+	return {
+		name: 'hr-test',
+		description: 'compensation benchmarking equity analysis salary bands',
+		purposeTokens: [
+			'analysis',
+			'bands',
+			'benchmarking',
+			'compensation',
+			'equity',
+			'salary',
+		],
+		promptsTokens: ['analysis', 'bands', 'benchmarking', 'compensation', 'equity'],
+		examplesTokens: ['analysis', 'benchmarking', 'compensation', 'equity', 'salary'],
+		contentTokens: [],
+		hasPrompts: true,
+		hasExamples: true,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// topKeywords()
+// ---------------------------------------------------------------------------
+
+describe('topKeywords', () => {
+	it('returns the most frequent non-stop-word tokens', () => {
+		const desc =
+			'Compensation benchmarking and compensation analysis for compensation cycles';
+		const keywords = topKeywords(desc, 3);
+		expect(keywords[0]).toBe('compensation');
+	});
+
+	it('breaks ties alphabetically for determinism', () => {
+		const desc = 'zebra apple mango banana';
+		const keywords = topKeywords(desc, 4);
+		expect(keywords).toEqual(['apple', 'banana', 'mango', 'zebra']);
+	});
+
+	it('returns an empty array for an empty description', () => {
+		expect(topKeywords('')).toEqual([]);
+	});
+
+	it('respects the requested count', () => {
+		const desc = 'alpha beta gamma delta epsilon zeta';
+		expect(topKeywords(desc, 2)).toHaveLength(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// checkDrift() — fully consistent skills
+// ---------------------------------------------------------------------------
+
+describe('checkDrift — consistent skills', () => {
+	it('produces no findings when prompts/examples share purpose vocabulary', () => {
+		const skill = makeSkill();
+		expect(checkDrift(skill)).toEqual([]);
+	});
+
+	it('skips skills whose purpose token set is too small', () => {
+		const skill = makeSkill({
+			purposeTokens: ['tiny'],
+			promptsTokens: ['completely', 'unrelated', 'cooking', 'recipe'],
+		});
+		expect(skill.purposeTokens.length).toBeLessThan(MIN_PURPOSE_TOKENS);
+		expect(checkDrift(skill)).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// checkDrift() — unrelated prompts / examples
+// ---------------------------------------------------------------------------
+
+describe('checkDrift — unrelated prompts', () => {
+	it('flags prompt-drift when prompts share no vocabulary with purpose', () => {
+		const skill = makeSkill({
+			purposeTokens: [
+				'compensation',
+				'benchmarking',
+				'equity',
+				'salary',
+				'bands',
+				'analysis',
+			],
+			promptsTokens: ['cooking', 'recipe', 'kitchen', 'oven', 'bake'],
+		});
+		const findings = checkDrift(skill);
+		expect(findings).toHaveLength(1);
+		expect(findings[0]?.heuristic).toBe('prompt-drift');
+		expect(findings[0]?.file).toBe('prompts/');
+	});
+
+	it('does not flag prompt-drift when prompts/ is absent', () => {
+		const skill = makeSkill({ hasPrompts: false, promptsTokens: [] });
+		const findings = checkDrift(skill);
+		expect(findings.find((f) => f.heuristic === 'prompt-drift')).toBeUndefined();
+	});
+});
+
+describe('checkDrift — unrelated examples', () => {
+	it('flags example-drift when examples share no vocabulary with purpose', () => {
+		const skill = makeSkill({
+			purposeTokens: [
+				'compensation',
+				'benchmarking',
+				'equity',
+				'salary',
+				'bands',
+				'analysis',
+			],
+			examplesTokens: ['gardening', 'flowers', 'soil', 'compost', 'seeds'],
+		});
+		const findings = checkDrift(skill);
+		expect(findings.some((f) => f.heuristic === 'example-drift')).toBe(true);
+	});
+
+	it('does not flag example-drift when examples/ is absent', () => {
+		const skill = makeSkill({ hasExamples: false, examplesTokens: [] });
+		const findings = checkDrift(skill);
+		expect(findings.find((f) => f.heuristic === 'example-drift')).toBeUndefined();
+	});
+
+	it('can flag both prompt-drift and example-drift simultaneously', () => {
+		const skill = makeSkill({
+			purposeTokens: [
+				'compensation',
+				'benchmarking',
+				'equity',
+				'salary',
+				'bands',
+				'analysis',
+			],
+			promptsTokens: ['cooking', 'recipe', 'kitchen'],
+			examplesTokens: ['gardening', 'flowers', 'soil'],
+		});
+		const findings = checkDrift(skill);
+		expect(findings).toHaveLength(2);
+		const heuristics = findings.map((f) => f.heuristic).sort();
+		expect(heuristics).toEqual(['example-drift', 'prompt-drift']);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// checkPossibleCopy()
+// ---------------------------------------------------------------------------
+
+describe('checkPossibleCopy — copied prompts', () => {
+	it('flags prompts that match another skill far better than their own', () => {
+		const target = makeSkill({
+			name: 'hr-onboarding',
+			purposeTokens: [
+				'onboarding',
+				'orientation',
+				'checklist',
+				'new',
+				'hire',
+				'plan',
+			],
+			promptsTokens: [
+				'payroll',
+				'compensation',
+				'salary',
+				'benchmarking',
+				'equity',
+				'bands',
+			],
+			examplesTokens: [],
+			hasExamples: false,
+		});
+		const otherSkill = makeSkill({
+			name: 'hr-payroll',
+			purposeTokens: [
+				'payroll',
+				'compensation',
+				'salary',
+				'benchmarking',
+				'equity',
+				'bands',
+			],
+			promptsTokens: [],
+			examplesTokens: [],
+			hasPrompts: false,
+			hasExamples: false,
+		});
+
+		const findings = checkPossibleCopy(target, [target, otherSkill]);
+		expect(findings).toHaveLength(1);
+		expect(findings[0]?.heuristic).toBe('possible-copy-prompts');
+		expect(findings[0]?.explanation).toContain('hr-payroll');
+	});
+});
+
+describe('checkPossibleCopy — copied examples', () => {
+	it('flags examples that match another skill far better than their own', () => {
+		const target = makeSkill({
+			name: 'hr-recognition',
+			purposeTokens: [
+				'recognition',
+				'appreciation',
+				'reward',
+				'awards',
+				'praise',
+				'peer',
+			],
+			promptsTokens: [],
+			examplesTokens: [
+				'offboarding',
+				'exit',
+				'interview',
+				'transition',
+				'departure',
+				'knowledge',
+			],
+			hasPrompts: false,
+		});
+		const otherSkill = makeSkill({
+			name: 'hr-offboarding',
+			purposeTokens: [
+				'offboarding',
+				'exit',
+				'interview',
+				'transition',
+				'departure',
+				'knowledge',
+			],
+			promptsTokens: [],
+			examplesTokens: [],
+			hasPrompts: false,
+			hasExamples: false,
+		});
+
+		const findings = checkPossibleCopy(target, [target, otherSkill]);
+		expect(findings).toHaveLength(1);
+		expect(findings[0]?.heuristic).toBe('possible-copy-examples');
+		expect(findings[0]?.explanation).toContain('hr-offboarding');
+	});
+});
+
+describe('checkPossibleCopy — no false positive on genuinely own content', () => {
+	it('does not flag when own score is close to or better than any other skill', () => {
+		const target = makeSkill();
+		const unrelatedOther = makeSkill({
+			name: 'hr-other',
+			purposeTokens: [
+				'completely',
+				'different',
+				'topic',
+				'area',
+				'field',
+				'domain',
+			],
+		});
+		expect(checkPossibleCopy(target, [target, unrelatedOther])).toEqual([]);
+	});
+
+	it('does not flag when own score is at least as good as the best other match', () => {
+		// Prompts share more with their own purpose tokens than with the other skill's.
+		const target = makeSkill({
+			purposeTokens: ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta'],
+			promptsTokens: ['alpha', 'beta', 'gamma', 'delta'],
+		});
+		const other = makeSkill({
+			name: 'hr-other',
+			purposeTokens: ['alpha', 'beta'],
+		});
+		const findings = checkPossibleCopy(target, [target, other]);
+		expect(findings.every((f) => f.heuristic !== 'possible-copy-prompts')).toBe(true);
+	});
+
+	it('skips skills whose purpose token set is too small', () => {
+		const target = makeSkill({ purposeTokens: ['tiny'] });
+		const other = makeSkill({ name: 'hr-other' });
+		expect(checkPossibleCopy(target, [target, other])).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// checkConceptCoverage()
+// ---------------------------------------------------------------------------
+
+describe('checkConceptCoverage', () => {
+	it('produces no finding when top keywords are covered', () => {
+		const skill = makeSkill({
+			description: 'compensation benchmarking equity salary bands',
+		});
+		expect(checkConceptCoverage(skill)).toEqual([]);
+	});
+
+	it('flags missing-coverage when keywords are absent from supporting material', () => {
+		const skill = makeSkill({
+			description: 'compensation benchmarking equity salary bands analysis',
+			promptsTokens: ['unrelated', 'terms', 'only'],
+			examplesTokens: ['nothing', 'shared', 'here'],
+			contentTokens: [],
+		});
+		const findings = checkConceptCoverage(skill);
+		expect(findings).toHaveLength(1);
+		expect(findings[0]?.heuristic).toBe('missing-coverage');
+	});
+
+	it('counts content/ tokens toward coverage', () => {
+		const skill = makeSkill({
+			description: 'compensation benchmarking equity salary bands analysis',
+			promptsTokens: [],
+			examplesTokens: [],
+			contentTokens: ['compensation', 'benchmarking', 'equity', 'salary', 'bands'],
+		});
+		expect(checkConceptCoverage(skill)).toEqual([]);
+	});
+
+	it('returns no finding for an empty description', () => {
+		const skill = makeSkill({ description: '' });
+		expect(checkConceptCoverage(skill)).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Threshold boundaries
+// ---------------------------------------------------------------------------
+
+describe('threshold boundaries', () => {
+	it('PROMPT_DRIFT_THRESHOLD, EXAMPLE_DRIFT_THRESHOLD, COPY_MARGIN, COPY_MIN_OTHER_SCORE, MIN_COVERAGE_RATIO are within [0, 1]', () => {
+		for (const value of [
+			PROMPT_DRIFT_THRESHOLD,
+			EXAMPLE_DRIFT_THRESHOLD,
+			COPY_MARGIN,
+			COPY_MIN_OTHER_SCORE,
+			MIN_COVERAGE_RATIO,
+		]) {
+			expect(value).toBeGreaterThan(0);
+			expect(value).toBeLessThan(1);
+		}
+	});
+
+	it('does not flag drift when Jaccard is exactly at the threshold', () => {
+		// Construct token sets whose Jaccard similarity is defined and check
+		// that a skill scoring above threshold is not flagged.
+		const skill = makeSkill({
+			purposeTokens: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'],
+			promptsTokens: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'],
+		});
+		// Perfect overlap — Jaccard 1.0, well above PROMPT_DRIFT_THRESHOLD.
+		expect(checkDrift(skill).some((f) => f.heuristic === 'prompt-drift')).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe('determinism', () => {
+	it('checkDrift produces identical results on repeated calls', () => {
+		const skill = makeSkill({
+			purposeTokens: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'],
+			promptsTokens: ['cooking', 'recipe', 'kitchen'],
+		});
+		const r1 = checkDrift(skill);
+		const r2 = checkDrift(skill);
+		const r3 = checkDrift(skill);
+		expect(r1).toEqual(r2);
+		expect(r2).toEqual(r3);
+	});
+
+	it('checkPossibleCopy produces identical results on repeated calls', () => {
+		const target = makeSkill({
+			name: 'hr-onboarding',
+			purposeTokens: [
+				'onboarding',
+				'orientation',
+				'checklist',
+				'new',
+				'hire',
+				'plan',
+			],
+			promptsTokens: [
+				'payroll',
+				'compensation',
+				'salary',
+				'benchmarking',
+				'equity',
+			],
+		});
+		const other = makeSkill({
+			name: 'hr-payroll',
+			purposeTokens: [
+				'payroll',
+				'compensation',
+				'salary',
+				'benchmarking',
+				'equity',
+			],
+		});
+		const r1 = checkPossibleCopy(target, [target, other]);
+		const r2 = checkPossibleCopy(target, [target, other]);
+		expect(r1).toEqual(r2);
+	});
+
+	it('topKeywords always returns the same array for the same input', () => {
+		const desc = 'compensation benchmarking equity salary bands analysis';
+		expect(topKeywords(desc)).toEqual(topKeywords(desc));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// validateSemanticConsistency() — full pipeline against a temp fixture repo
+// ---------------------------------------------------------------------------
+
+describe('validateSemanticConsistency — full pipeline', () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), 'semantic-validation-test-'));
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	async function writeSkill(
+		skillsDir: string,
+		name: string,
+		opts: {
+			description: string;
+			body?: string;
+			prompts?: string;
+			examples?: string;
+			content?: string;
+		},
+	): Promise<void> {
+		const dir = join(skillsDir, name);
+		await mkdir(dir, { recursive: true });
+		const skillMd = [
+			'---',
+			`name: ${name}`,
+			`description: ${opts.description}`,
+			'metadata:',
+			'  author: Test Author',
+			'  version: "1.0.0"',
+			'---',
+			'',
+			opts.body ?? '## Overview\n\nDetails here.',
+		].join('\n');
+		await writeFile(join(dir, 'SKILL.md'), skillMd, 'utf8');
+
+		if (opts.prompts) {
+			await mkdir(join(dir, 'prompts'), { recursive: true });
+			await writeFile(join(dir, 'prompts', 'prompts.md'), opts.prompts, 'utf8');
+		}
+		if (opts.examples) {
+			await mkdir(join(dir, 'examples'), { recursive: true });
+			await writeFile(join(dir, 'examples', 'example.md'), opts.examples, 'utf8');
+		}
+		if (opts.content) {
+			await mkdir(join(dir, 'content'), { recursive: true });
+			await writeFile(join(dir, 'content', 'content.md'), opts.content, 'utf8');
+		}
+	}
+
+	it('produces no warnings for a fully consistent skill', async () => {
+		await writeSkill(tmpDir, 'hr-compensation', {
+			description:
+				'Compensation benchmarking and equity analysis for salary bands and market positioning',
+			body: '## Overview\n\nCompensation benchmarking compares salary bands against market equity data.',
+			prompts:
+				'# Prompts\n\n- How do I benchmark compensation against market salary bands?\n- What equity analysis should I run for salary bands?',
+			examples:
+				'# Example\n\nCompensation benchmarking example showing salary band equity analysis in practice.',
+		});
+
+		const warnings: SkillValidationIssue[] = [];
+		const findings = await validateSemanticConsistency(
+			tmpDir,
+			['hr-compensation'],
+			warnings,
+		);
+		expect(findings).toEqual([]);
+		expect(warnings).toEqual([]);
+	});
+
+	it('flags a skill whose prompts are copied from an unrelated skill', async () => {
+		await writeSkill(tmpDir, 'hr-onboarding', {
+			description:
+				'Onboarding orientation checklists and structured new hire welcome plans',
+			body: '## Overview\n\nOnboarding orientation checklists guide new hire welcome plans.',
+			prompts:
+				'# Prompts\n\n- How do I benchmark compensation against market salary bands?\n- What equity analysis should I run for salary bands and market positioning?',
+		});
+		await writeSkill(tmpDir, 'hr-payroll', {
+			description:
+				'Compensation benchmarking and equity analysis for salary bands and market positioning',
+			body: '## Overview\n\nCompensation benchmarking compares salary bands against market equity data and positioning.',
+		});
+
+		const warnings: SkillValidationIssue[] = [];
+		const findings = await validateSemanticConsistency(
+			tmpDir,
+			['hr-onboarding', 'hr-payroll'],
+			warnings,
+		);
+
+		const copyFindings = findings.filter(
+			(f) => f.skill === 'hr-onboarding' && f.heuristic === 'possible-copy-prompts',
+		);
+		expect(copyFindings.length).toBeGreaterThan(0);
+		expect(warnings.some((w) => w.message.includes('[semantic-warning]'))).toBe(true);
+	});
+
+	it('sorts findings deterministically by skill then heuristic', async () => {
+		await writeSkill(tmpDir, 'hr-alpha', {
+			description:
+				'Compensation benchmarking equity analysis salary bands market positioning',
+			body: '## Overview\n\nCompensation benchmarking equity analysis salary bands market positioning details.',
+			prompts:
+				'# Prompts\n\n- Completely unrelated cooking recipe kitchen oven bake question?',
+			examples:
+				'# Example\n\nGardening flowers soil compost seeds unrelated example content.',
+		});
+
+		const warnings: SkillValidationIssue[] = [];
+		const findings = await validateSemanticConsistency(
+			tmpDir,
+			['hr-alpha'],
+			warnings,
+		);
+
+		const sorted = [...findings].sort((a, b) => {
+			if (a.skill !== b.skill) return a.skill < b.skill ? -1 : 1;
+			if (a.heuristic !== b.heuristic) return a.heuristic < b.heuristic ? -1 : 1;
+			return 0;
+		});
+		expect(findings).toEqual(sorted);
+	});
+
+	it('produces identical output across repeated runs (determinism)', async () => {
+		await writeSkill(tmpDir, 'hr-alpha', {
+			description:
+				'Compensation benchmarking equity analysis salary bands market positioning',
+			body: '## Overview\n\nCompensation benchmarking equity analysis salary bands details.',
+			prompts:
+				'# Prompts\n\n- Completely unrelated cooking recipe kitchen oven bake question?',
+		});
+
+		const w1: SkillValidationIssue[] = [];
+		const w2: SkillValidationIssue[] = [];
+		const f1 = await validateSemanticConsistency(tmpDir, ['hr-alpha'], w1);
+		const f2 = await validateSemanticConsistency(tmpDir, ['hr-alpha'], w2);
+
+		expect(f1).toEqual(f2);
+		expect(w1).toEqual(w2);
+	});
+
+	it('handles a skill with no prompts/ or examples/ directories gracefully', async () => {
+		await writeSkill(tmpDir, 'hr-bare', {
+			description:
+				'A bare skill with only a description and body, no subdirectories',
+		});
+
+		const warnings: SkillValidationIssue[] = [];
+		const findings = await validateSemanticConsistency(tmpDir, ['hr-bare'], warnings);
+		expect(findings.some((f) => f.heuristic === 'prompt-drift')).toBe(false);
+		expect(findings.some((f) => f.heuristic === 'example-drift')).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// loadSkillSemanticContent()
+// ---------------------------------------------------------------------------
+
+describe('loadSkillSemanticContent', () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), 'semantic-load-test-'));
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it('returns empty tokens and false flags for a missing skill directory', async () => {
+		const content = await loadSkillSemanticContent(tmpDir, 'hr-does-not-exist');
+		expect(content.purposeTokens).toEqual([]);
+		expect(content.hasPrompts).toBe(false);
+		expect(content.hasExamples).toBe(false);
+	});
+
+	it('reads description, body, prompts, examples, and content correctly', async () => {
+		const dir = join(tmpDir, 'hr-sample');
+		await mkdir(join(dir, 'prompts'), { recursive: true });
+		await mkdir(join(dir, 'examples'), { recursive: true });
+		await mkdir(join(dir, 'content'), { recursive: true });
+
+		await writeFile(
+			join(dir, 'SKILL.md'),
+			[
+				'---',
+				'name: hr-sample',
+				'description: Compensation benchmarking equity analysis for salary bands',
+				'metadata:',
+				'  author: Test Author',
+				'  version: "1.0.0"',
+				'---',
+				'',
+				'## Overview',
+				'',
+				'Body text about compensation.',
+			].join('\n'),
+			'utf8',
+		);
+		await writeFile(
+			join(dir, 'prompts', 'p.md'),
+			'- What compensation benchmarking should I run?',
+			'utf8',
+		);
+		await writeFile(
+			join(dir, 'examples', 'e.md'),
+			'# Example\n\nCompensation benchmarking example.',
+			'utf8',
+		);
+		await writeFile(
+			join(dir, 'content', 'c.md'),
+			'Extra compensation content details.',
+			'utf8',
+		);
+
+		const content = await loadSkillSemanticContent(tmpDir, 'hr-sample');
+		expect(content.name).toBe('hr-sample');
+		expect(content.description).toContain('Compensation benchmarking');
+		expect(content.hasPrompts).toBe(true);
+		expect(content.hasExamples).toBe(true);
+		expect(content.purposeTokens.length).toBeGreaterThan(0);
+		expect(content.contentTokens.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
Adds a deterministic semantic-consistency check for each skill's prompts/ and examples/, extending validation beyond today's non-empty-directory structural check (issue #157).

- semantic-validation.ts: four independent heuristics reusing tokenise()/jaccardSimilarity() from detect-duplicates.ts
  - prompt-drift / example-drift: Jaccard(purpose, prompts|examples) below threshold
  - possible-copy-prompts / possible-copy-examples: material matches another skill's purpose better than its own
  - missing-coverage: top description keywords absent from prompts/examples/content combined
- All thresholds calibrated against the current 146-skill corpus so zero warnings are produced against genuine, on-topic content
- Wired into validate.ts as non-fatal quality warnings, merged with duplicate-content warnings under one 'Quality warnings' summary
- docs/semantic-validation.md documents the heuristics, thresholds, determinism guarantees, and maintainer guidance
- docs/ROADMAP.md marks Phase 6.2 semantic validation as delivered
- 32 new tests covering consistent skills, drift, possible-copy, coverage, threshold boundaries, and determinism