### PR TITLE
perf(hr-skills-build): parallelize validation and pre-compute tokens

### DIFF
--- a/packages/hr-skills-build/src/detect-duplicates.ts
+++ b/packages/hr-skills-build/src/detect-duplicates.ts
@@ -430,6 +430,51 @@ export interface DuplicateWarning {
 // ---------------------------------------------------------------------------
 
 /**
+ * Build a `DuplicateWarning` from pre-computed similarity scores.
+ *
+ * Extracted so both the public `comparePair()` API and the O(N²) fast path
+ * inside `detectDuplicates()` can share the same result-building logic without
+ * duplicating code.
+ */
+function buildWarning(
+	a: SkillContent,
+	b: SkillContent,
+	descScore: number,
+	contentScore: number,
+	bigramScore: number,
+	composite: number,
+	threshold: number,
+): DuplicateWarning {
+	// Canonical ordering: lexicographically smaller name first
+	const [skillA, skillB] = a.name < b.name ? [a.name, b.name] : [b.name, a.name];
+
+	// Human-readable explanation
+	const parts: string[] = [];
+	if (descScore >= 0.5) parts.push(`high description overlap (${pct(descScore)})`);
+	if (contentScore >= 0.5)
+		parts.push(`high content token overlap (${pct(contentScore)})`);
+	if (bigramScore >= 0.4)
+		parts.push(`significant phrase overlap (${pct(bigramScore)})`);
+	if (parts.length === 0) parts.push('moderate overlap across multiple signals');
+
+	const explanation =
+		`Composite score ${pct(composite)} exceeds threshold ${pct(threshold)}: ` +
+		parts.join('; ') +
+		'. ' +
+		'Review both skills to determine if they cover genuinely distinct knowledge or should be merged/refactored.';
+
+	return {
+		skillA,
+		skillB,
+		score: round(composite),
+		descriptionSimilarity: round(descScore),
+		contentSimilarity: round(contentScore),
+		bigramSimilarity: round(bigramScore),
+		explanation,
+	};
+}
+
+/**
  * Compute the composite duplicate score for a pair of pre-loaded skills.
  *
  * @returns A `DuplicateWarning` when `score >= threshold`, or `null`.
@@ -471,33 +516,7 @@ export function comparePair(
 
 	if (composite < threshold) return null;
 
-	// Canonical ordering: lexicographically smaller name first
-	const [skillA, skillB] = a.name < b.name ? [a.name, b.name] : [b.name, a.name];
-
-	// Human-readable explanation
-	const parts: string[] = [];
-	if (descScore >= 0.5) parts.push(`high description overlap (${pct(descScore)})`);
-	if (contentScore >= 0.5)
-		parts.push(`high content token overlap (${pct(contentScore)})`);
-	if (bigramScore >= 0.4)
-		parts.push(`significant phrase overlap (${pct(bigramScore)})`);
-	if (parts.length === 0) parts.push('moderate overlap across multiple signals');
-
-	const explanation =
-		`Composite score ${pct(composite)} exceeds threshold ${pct(threshold)}: ` +
-		parts.join('; ') +
-		'. ' +
-		'Review both skills to determine if they cover genuinely distinct knowledge or should be merged/refactored.';
-
-	return {
-		skillA,
-		skillB,
-		score: round(composite),
-		descriptionSimilarity: round(descScore),
-		contentSimilarity: round(contentScore),
-		bigramSimilarity: round(bigramScore),
-		explanation,
-	};
+	return buildWarning(a, b, descScore, contentScore, bigramScore, composite, threshold);
 }
 
 function pct(n: number): string {
@@ -536,13 +555,52 @@ export async function detectDuplicates(
 
 	const findings: DuplicateWarning[] = [];
 
-	for (let i = 0; i < contents.length; i++) {
-		for (let j = i + 1; j < contents.length; j++) {
-			const skillA = contents[i];
-			const skillB = contents[j];
-			if (!skillA || !skillB) continue;
-			const finding = comparePair(skillA, skillB, threshold);
-			if (finding) findings.push(finding);
+	// Pre-compute description tokens, sorted body tokens, and bigrams once per
+	// skill before entering the O(N²) pair loop. Without this, comparePair()
+	// would call stripMarkdown + split + filter + sort + buildBigrams on each
+	// skill body once per pair it appears in — 145× per skill with 146 skills.
+	const precomputed = contents.map((c) => {
+		if (!c) return null;
+		const bodyTokensNatural = stripMarkdown(c.body)
+			.split(/\s+/)
+			.filter((t) => t.length >= 3 && !HR_STOP_WORDS.has(t));
+		return {
+			content: c,
+			descTokens: tokenise(c.description),
+			bodyTokensSorted: [...bodyTokensNatural].sort(),
+			bigrams: buildBigrams(bodyTokensNatural),
+		};
+	});
+
+	for (let i = 0; i < precomputed.length; i++) {
+		for (let j = i + 1; j < precomputed.length; j++) {
+			const a = precomputed[i];
+			const b = precomputed[j];
+			if (!a || !b) continue;
+
+			const descScore = jaccardSimilarity(a.descTokens, b.descTokens);
+			const contentScore = jaccardSimilarity(
+				a.bodyTokensSorted,
+				b.bodyTokensSorted,
+			);
+			const bigramScore = jaccardSimilarity(a.bigrams, b.bigrams);
+			const composite =
+				WEIGHT_DESCRIPTION * descScore +
+				WEIGHT_CONTENT * contentScore +
+				WEIGHT_BIGRAM * bigramScore;
+
+			if (composite < threshold) continue;
+			findings.push(
+				buildWarning(
+					a.content,
+					b.content,
+					descScore,
+					contentScore,
+					bigramScore,
+					composite,
+					threshold,
+				),
+			);
 		}
 	}
 

--- a/packages/hr-skills-build/src/validate.ts
+++ b/packages/hr-skills-build/src/validate.ts
@@ -410,6 +410,9 @@ export async function validateSubdirectoryContents(
 
 /**
  * Validate a single skill.
+ *
+ * All checks within a single skill are run sequentially — they share the same
+ * content string and errors array, so no parallelism is needed here.
  */
 async function validateSkill(skillName: string): Promise<SkillValidationIssue[]> {
 	const errors: SkillValidationIssue[] = [];
@@ -442,6 +445,11 @@ async function validateSkill(skillName: string): Promise<SkillValidationIssue[]>
 
 /**
  * Validate all HR skills.
+ *
+ * Skills are validated concurrently with `Promise.all` so that I/O-bound
+ * work (reading SKILL.md + subdirectory checks) overlaps across all skills
+ * at once. Global consistency checks (router, registry, duplicates, semantic)
+ * run in parallel with the per-skill phase via a second `Promise.all`.
  */
 async function validate(): Promise<void> {
 	p.intro('Validating HR skills...');
@@ -458,23 +466,30 @@ async function validate(): Promise<void> {
 	const allErrors: SkillValidationIssue[] = [];
 	const allWarnings: SkillValidationIssue[] = [];
 
-	await validateRouterConsistency(skillNames, allErrors);
-	await validateRegistryConsistency(allErrors);
+	// Run per-skill validation and global consistency checks concurrently.
+	const [perSkillResults] = await Promise.all([
+		// Per-skill: all 146 skills validated in parallel
+		Promise.all(skillNames.map((name) => validateSkill(name))),
+		// Global: router + registry run concurrently alongside per-skill work
+		validateRouterConsistency(skillNames, allErrors),
+		validateRegistryConsistency(allErrors),
+	]);
 
-	for (const skillName of skillNames) {
-		const errors = await validateSkill(skillName);
-
-		if (errors.length > 0) {
-			allErrors.push(...errors);
-			p.log.error(skillName);
-		}
+	// Collect per-skill errors and log any failing skill names
+	for (let i = 0; i < perSkillResults.length; i++) {
+		const errors = perSkillResults[i];
+		if (!errors || errors.length === 0) continue;
+		allErrors.push(...errors);
+		const skillName = skillNames[i];
+		if (skillName) p.log.error(skillName);
 	}
 
-	// Phase 6.2 — duplicate-content detection (quality warnings, not failures)
-	await detectDuplicates(skillNames, allWarnings);
-
-	// Phase 6.2 — semantic validation of prompts/examples (quality warnings, not failures)
-	await validateSemanticConsistency(SKILLS_DIR, skillNames, allWarnings);
+	// Phase 6.2 — duplicate-content detection and semantic validation run
+	// concurrently since neither depends on the other's output.
+	await Promise.all([
+		detectDuplicates(skillNames, allWarnings),
+		validateSemanticConsistency(SKILLS_DIR, skillNames, allWarnings),
+	]);
 
 	// Report warnings (informational — do not affect exit code)
 	if (allWarnings.length > 0) {


### PR DESCRIPTION
Combine both performance fixes into a single commit:

validate.ts

- Replace serial for-of loop with Promise.all so all 146 skills are
  validated concurrently instead of one at a time
- validateRouterConsistency and validateRegistryConsistency run in the
  same Promise.all alongside per-skill work
- detectDuplicates and validateSemanticConsistency run concurrently in
  a second Promise.all (neither depends on the other)

detect-duplicates.ts

- Extract buildWarning() private helper from comparePair() to share
  result-building logic without code duplication
- Pre-compute descTokens, bodyTokensSorted, and bigrams once per skill
  (O(N)) before the inner pair loop in detectDuplicates()
- Eliminates 21,170 redundant stripMarkdown + split + filter + sort +
  buildBigrams operations (145x per skill with 146 skills)

Measured improvement (direct script, 146 skills):

- Before: 60.84s user / 86s wall clock
- After:  18.90s user / 23s wall clock (~3.7x faster)