### PR TITLE
fix(hr-skills-build): remove polynomial ReDoS in section/name regexes

### DIFF
--- a/packages/hr-skills-build/src/shared/constants.ts
+++ b/packages/hr-skills-build/src/shared/constants.ts
@@ -21,7 +21,7 @@ export const HR_SKILL_PREFIX = 'hr-';
  * Capture group 1 contains the raw block text.
  */
 export const KEY_PROMPTS_REGEX =
-	/## Key prompts\r?\n\r?\n([\s\S]*?)(?=\r?\n## |\r?\n---\r?\n|$)/;
+	/## Key prompts\r?\n\r?\n((?:(?!\r?\n## |\r?\n---\r?\n)[\s\S])*)/;
 
 /**
  * Matches a numbered or bulleted quoted prompt line inside a Key prompts block,
@@ -49,7 +49,7 @@ export const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
  * Captures the body of a `## Supported tasks` section up to the next `##` heading
  * or end of file. Capture group 1 contains the raw block text.
  */
-export const TASKS_REGEX = /## Supported tasks\r?\n\r?\n([\s\S]*?)(?=\r?\n##|$)/;
+export const TASKS_REGEX = /## Supported tasks\r?\n\r?\n((?:(?!\r?\n##)[\s\S])*)/;
 
 /**
  * The three markdown section headings that every skill SKILL.md must contain.
@@ -67,7 +67,7 @@ export const MIN_CONTENT_LENGTH = 1000;
  * Captures the body of a `## Tips` section up to the next `##` heading or end of file.
  * Capture group 1 contains the raw block text.
  */
-export const TIPS_REGEX = /## Tips\r?\n\r?\n([\s\S]*?)(?=\r?\n##|$)/;
+export const TIPS_REGEX = /## Tips\r?\n\r?\n((?:(?!\r?\n##)[\s\S])*)/;
 
 /**
  * Matches markdown links that reference another skill, e.g.

--- a/packages/hr-skills-build/test/shared/parser.test.ts
+++ b/packages/hr-skills-build/test/shared/parser.test.ts
@@ -20,8 +20,8 @@ metadata:
 
 const SAMPLE_SKILL_CRLF = SAMPLE_SKILL.replaceAll('\n', '\r\n');
 
-const NAME_REGEX = /^name:[ \t]*(.+)$/m;
-const NAME_REGEX_NON_MATCHING = /^missing:[ \t]*(.+)$/m;
+const NAME_REGEX = /^name:[ \t]*(\S.*)$/m;
+const NAME_REGEX_NON_MATCHING = /^missing:[ \t]*(\S.*)$/m;
 
 describe('extractMatch', () => {
 	it('returns the first capture group when regex matches', () => {


### PR DESCRIPTION
Replace ambiguous lazy [\s\S]*? + lookahead quantifiers in KEY_PROMPTS_REGEX, TASKS_REGEX, and TIPS_REGEX with a deterministic negative-lookahead single-character loop, eliminating the overlapping backtracking paths CodeQL flagged as polynomial-time ReDoS (js/polynomial-redos).

Also tighten NAME_REGEX and NAME_REGEX_NON_MATCHING in parser.test.ts by requiring the captured value to start with a non-whitespace character, removing the same class of ambiguity between [ \t]* and .+.

Behavior is unchanged for all valid inputs; verified against sample SKILL.md sections and CRLF variants.

Fixes GHSL alert [#15](https://github.com/tuanductran/hr-skills/security/code-scanning/15).