### PR TITLE
docs: dedupe AGENTS.md content into single-owner .agents skills

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,65 +1,39 @@
 # Project overview
 
-> This is a condensed, agent-optimized digest of the canonical [`/AGENTS.md`](../AGENTS.md) at the repository root. If the two ever disagree, the root file wins — update it first, then reflect the change here.
+> This is the routing index for agent workflows in this repository. The canonical, human-facing entry point is [`/AGENTS.md`](../AGENTS.md) at the repository root — keep that short; every workflow below lives in exactly one skill file here, not restated in either place.
 
-This repository is a Bun + Turborepo monorepo hosting HR AI skills for Claude Code and claude.ai. Each skill lives in `skills/hr-*/SKILL.md`. The project uses Bun as the runtime and Turborepo for orchestration.
+This repository is a Bun + Turborepo monorepo hosting HR AI skills for Claude Code and claude.ai. Each skill lives in `skills/hr-*/SKILL.md`.
 
-Essential commands
+## Critical rule
 
-| Command | Purpose |
+Never develop on `main` — branch from and open pull requests against `dev`.
+
+## Skill index
+
+| When you need to... | Load |
 |---|---|
-| `bun install` | install dependencies |
-| `bun run validate` | validate all SKILL.md files |
-| `bun run sync` | sync metadata after adding/removing a skill |
-| `bun run matrix` | generate `docs/skill-matrix.md` skill maturity snapshot |
-| `bun run build` | build all workspace packages |
-| `bun run test` | run tests |
-| `bun run typecheck` | type-check all packages |
-| `bun run lint` | Biome checks with auto-fix |
-| `bun run lint:md` | markdownlint + case-police |
-| `bun run lint:md:fix` | markdownlint with auto-fix |
+| Run or find a `bun run` / `turbo run` command | [`skills/turbo/SKILL.md`](skills/turbo/SKILL.md), [`skills/bun/SKILL.md`](skills/bun/SKILL.md) |
+| Write a commit message or split changes into commits | [`skills/github-awesome-copilot-git-commit/SKILL.md`](skills/github-awesome-copilot-git-commit/SKILL.md) |
+| Create, edit, or validate a `skills/hr-*/SKILL.md` package | [`skills/hr-skills-maintaining/SKILL.md`](skills/hr-skills-maintaining/SKILL.md) |
+| Update the root `SKILL.md` router (add/remove/move a skill entry) | [`skills/hr-root-router-maintaining/SKILL.md`](skills/hr-root-router-maintaining/SKILL.md) |
+| Write or fix Markdown — formatting, content-design rules, links | [`skills/markdown/SKILL.md`](skills/markdown/SKILL.md) |
+| Security-review a `SKILL.md` before installing or publishing | [`skills/skill-vetter/SKILL.md`](skills/skill-vetter/SKILL.md) |
+| Decide if a PR needs a changeset, or write one | [`skills/changeset/SKILL.md`](skills/changeset/SKILL.md) |
+| Write or review TypeScript in `packages/*` | [`skills/typescript/SKILL.md`](skills/typescript/SKILL.md) |
+| Configure or debug Biome lint/format rules | [`skills/biome/SKILL.md`](skills/biome/SKILL.md) |
+| Define or validate a schema with Valibot | [`skills/valibot/SKILL.md`](skills/valibot/SKILL.md) |
+| Rewrite AI-sounding prose to read more naturally | [`skills/humanizer/SKILL.md`](skills/humanizer/SKILL.md) |
+| Generate or fill a PDF | [`skills/pdf/SKILL.md`](skills/pdf/SKILL.md) |
 
-Workflow when adding a new skill
+## Fastest path: adding a new skill
 
-1. Create `skills/hr-<name>/SKILL.md`
+1. Create `skills/hr-<name>/SKILL.md` (or run the `/new-skill` command in `.claude/commands/new-skill.md`, which scaffolds this for you)
 2. Run `bun run sync`
 3. Run `bun run validate`
 
-SKILL.md required structure
+For the full required structure, frontmatter rules, and pre-publish checklist, load `skills/hr-skills-maintaining/SKILL.md` — don't guess, and don't duplicate its content here.
 
-- YAML frontmatter: `name`, `description`, `metadata.author` (must be "Tuan Duc Tran"), `metadata.version`
-- `name` must match directory name exactly
-- `description` minimum 50 characters and include realistic HR trigger phrases
-- `description` value must be wrapped in one pair of double quotes; trigger phrases inside are plain comma-separated text, never individually quoted
-- Required sections: `## Supported tasks`, `## Key prompts`, `## Tips`
-- `## Supported tasks`: 8-12 bullet items
-- `## Key prompts`: 3-6 named subtopics, 4-7 prompts each, use `[placeholders]`
-- `## Tips`: 4-6 bullet items
-- Max 500 lines total
-- No time-sensitive content (laws, versions, vendor-specific details)
-- Always leave a blank line between a heading or bold label and the list that follows
+## Workspace packages
 
-Content standards (Atlassian guidelines)
-
-- Sentence case for all headings
-- Do not use `e.g.`, `i.e.`, `etc.` or `&` — write "for example", "that is", "and so on", "and"
-- No periods at the end of headings
-- Avoid gerunds in headings (use "Add a skill" not "Adding a skill")
-- Use "they/their" for unknown gender
-
-Branch and commit rules
-
-- Never develop on `main` — use `dev` branch
-- Use Conventional Commits format: `<type>(<scope>): <summary>`
-- Types: feat, fix, chore, docs, refactor, style, test, build, ci
-- Scope examples: `hr-recruiting`, `skills-ref`, `hr-skills-build`
-- Summary under 72 characters, imperative mood
-
-Workspace packages
-
-- `packages/hr-skills-build` — validation, sync, and zip tooling
+- `packages/hr-skills-build` — validation, sync, registry/planner/runtime generation, and packaging tooling
 - `packages/skills-ref` — TypeScript library for reading and validating skill files
-
-Notes
-
-Keep SKILL.md files concise and follow the repository's lint and validation scripts before opening a pull request to `dev`.

--- a/.agents/skills/hr-skills-maintaining/SKILL.md
+++ b/.agents/skills/hr-skills-maintaining/SKILL.md
@@ -3,7 +3,7 @@ name: hr-skills-maintaining
 description: "Repository-level skill describing metadata, directory structure, workflows, and conventions for the hr-skills monorepo. Use this skill when validating, creating, editing, or maintaining HR skill packages, including SKILL.md, content/, prompts/, and examples/."
 metadata:
   author: Tuan Duc Tran
-  version: "1.2.0"
+  version: "1.3.0"
 ---
 
 # HR Skills repository guide
@@ -37,6 +37,40 @@ Each file has a single responsibility.
 - `examples/` demonstrates realistic end-to-end HR workflows and business scenarios.
 
 Supporting files should complement each other instead of repeating the same information.
+
+## Content quality standards
+
+- **HR-domain only** — prompts and guidance must cover HR-specific patterns and best practices, not generic management or business advice.
+- **No obvious content** — avoid widely-known basics. Focus on nuanced guidance that HR professionals actually need AI assistance with.
+- **`SKILL.md` is for AI agents** — be concise; context window is a shared resource. Assume the agent is smart; only include what it doesn't already know. Use progressive disclosure — `SKILL.md` is an overview, not an exhaustive manual.
+- **Trigger phrases matter** — the `description` field determines when a skill activates. Include specific, realistic HR trigger phrases like "Write a PIP", "Conduct a stay interview", "Analyze turnover".
+
+## Checklist before publishing a skill
+
+### Core quality
+
+- [ ] `description` is specific and includes key HR trigger phrases
+- [ ] `description` covers both what the skill does and when to use it
+- [ ] `SKILL.md` body is under 500 lines
+- [ ] Prompts are grouped by meaningful subtopics
+- [ ] No time-sensitive information (laws, tools, versions)
+- [ ] Consistent HR terminology throughout
+- [ ] Prompts use `[placeholders]` for variable inputs
+- [ ] Each subtopic has 4-7 focused prompts
+- [ ] Tips section provides actionable professional guidance
+
+### Frontmatter
+
+- [ ] `name` matches the skill directory name exactly
+- [ ] `description` is wrapped in a single pair of double quotes, with trigger phrases as plain comma-separated text (not individually quoted)
+- [ ] `metadata.author` is set to `Tuan Duc Tran`
+- [ ] `metadata.version` is set
+
+### Structure
+
+- [ ] `## Supported tasks` lists 8-12 concrete tasks
+- [ ] `## Key prompts` is divided into logical subtopic sections
+- [ ] `## Tips` has 4-6 professional best-practice tips
 
 ## Supported tasks
 

--- a/.agents/skills/markdown/SKILL.md
+++ b/.agents/skills/markdown/SKILL.md
@@ -3,7 +3,7 @@ name: markdown
 description: "Repository guidance for writing, formatting, and validating Markdown documentation using markdownlint-cli, case-police, and markdown-link-check within the hr-skills monorepo."
 metadata:
   author: Tuan Duc Tran
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Markdown
@@ -43,6 +43,27 @@ Repository documentation should:
 - remain readable in both source and rendered form
 
 Markdown quality is validated through formatting, capitalization, and link verification.
+
+## Content design rules
+
+All documentation and skill content follows [Atlassian's content design guidelines](https://atlassian.design/foundations/content/):
+
+- Use sentence case for all headings — capitalize the first word and proper nouns only
+- Don't use `e.g.`, `i.e.`, `etc.`, or `&` in prose — write "for example", "that is", "and so on", "and"
+- Don't use periods at the end of headings
+- Avoid gerunds in headings — prefer "Add a skill" over "Adding a skill"
+- Phrase list items in parallel: fragments get a lowercase first letter and no period, complete sentences get a capital first letter and a period
+- Use "they/their" instead of gendered pronouns when the person's identity isn't known
+- Avoid idioms or culturally specific expressions that don't translate well
+- Be clear, concise, and direct; use contractions ("don't", "can't") for a conversational tone
+
+## Blank line before lists
+
+Always leave a blank line between a heading or bold label and the list that follows it. Missing blank lines can break rendering, and the skill validator (`bun run validate`) enforces this rule for `SKILL.md` files specifically.
+
+This applies to every Markdown file in the repository — `AGENTS.md`, `README.md`, `SKILL.md`, `docs/*.md`, and generated files. AI tools in particular must insert a blank line every time a heading (`##`, `###`) or a bold label (`**Label:**`) is immediately followed by a list — this is easy to get wrong when generating Markdown programmatically.
+
+Run `bun run validate` (for `SKILL.md` files) and `bun run lint:md` (for everything else) before committing any Markdown change.
 
 ## Repository tooling
 

--- a/.agents/skills/turbo/SKILL.md
+++ b/.agents/skills/turbo/SKILL.md
@@ -85,6 +85,48 @@ Generate the skill maturity matrix.
 bun run matrix
 ```
 
+Generate the machine-readable skill registry.
+
+```bash
+bun run registry
+```
+
+Generate usage-informed relevance signals from evaluation golden fixtures.
+
+```bash
+bun run signals
+```
+
+Search the generated registry by text or domain.
+
+```bash
+bun run discover "<query>"
+```
+
+Get related-skill recommendations for a skill ID.
+
+```bash
+bun run recommend <skill-id>
+```
+
+Generate an execution plan for a user intent.
+
+```bash
+bun run plan "<intent>"
+```
+
+Generate a plan and run it through the workflow runtime.
+
+```bash
+bun run execute "<intent>"
+```
+
+Run the evaluation framework against `eval/datasets`.
+
+```bash
+bun run evaluate
+```
+
 Run every test suite.
 
 ```bash

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,13 @@
 			"Bash(bun run lint:links)",
 			"Bash(bun run matrix)",
 			"Bash(bun run knip)",
+			"Bash(bun run registry)",
+			"Bash(bun run signals)",
+			"Bash(bun run discover:*)",
+			"Bash(bun run recommend:*)",
+			"Bash(bun run plan:*)",
+			"Bash(bun run execute:*)",
+			"Bash(bun run evaluate)",
 			"Read(**)"
 		],
 		"deny": ["Write(node_modules/**)", "Write(dist/**)", "Write(.turbo/**)"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 `hr-skills` is a Bun + Turborepo monorepo of domain-specific Agent Skills for HR and talent acquisition, distributed for Claude Code and claude.ai. Each skill lives at `skills/hr-*/SKILL.md`. Two internal TypeScript packages, `packages/hr-skills-build` and `packages/skills-ref`, validate, sync, and package the skills. Generated artifacts — `docs/skill-matrix.md`, `registry/skills.json`, `.claude-plugin/marketplace.json` — are derived from skill frontmatter and must never be hand-edited; regenerate them with the corresponding `bun run` command instead.
 
-This file is the canonical, tool-agnostic guide for both human contributors and AI agents. `CLAUDE.md` is a symlink to this file — edit `AGENTS.md` only.
+This file is the canonical, tool-agnostic entry point for both human contributors and AI agents. `CLAUDE.md` is a symlink to this file — edit `AGENTS.md` only. The detailed, day-to-day workflow guidance this file used to duplicate now lives in [`.agents/`](.agents/AGENTS.md) — see [Where things live](#where-things-live) below.
 
 ## Branch strategy
 
@@ -20,88 +20,33 @@ This file is the canonical, tool-agnostic guide for both human contributors and 
 | `main` | Publishing (`npx skills add tuanductran/hr-skills`) | Forbidden |
 | `dev` | Development, tests, experiments | Via PR only |
 
-## Commit convention
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-```text
-<type>(<scope>): <short summary>
-```
-
-### Types
-
-| Type | When to use |
-|------|-------------|
-| `feat` | Add a new skill or a new feature to the tooling |
-| `fix` | Fix a bug in a skill's content or in the tooling |
-| `chore` | Maintenance tasks — deps, config, CI, `.gitignore` |
-| `docs` | Changes to `docs/`, `README.md`, `AGENTS.md`, or any other documentation |
-| `refactor` | Code restructuring with no behaviour change |
-| `style` | Formatting, whitespace, markdownlint fixes |
-| `test` | Add or update tests |
-| `build` | Changes to the build system (`packages/`, `tsconfig`, `bun.lock`) |
-| `ci` | Changes to GitHub Actions workflows |
-
-### Scopes (optional)
-
-Use the skill name or package name as scope when the change is isolated:
-
-```text
-feat(hr-recruiting): add ATS integration prompts
-fix(hr-compliance): correct FMLA section length
-chore(skills-ref): update bun dependency
-docs(installation): add claude.ai paste method
-```
-
-### Rules
-
-- Use the **imperative mood** in the summary: "add", "fix", "update" — not "added" or "fixes"
-- Keep the summary under 72 characters
-- Reference issues in the body when relevant: `Closes #42`
-- Breaking changes: append `!` after the type and explain in the body
-
-### Examples
-
-```text
-feat(hr-onboarding): add virtual onboarding prompts
-fix(hr-analytics): correct turnover formula in tips
-chore: upgrade markdownlint-cli to latest
-docs: add skill-format specification to docs/
-build(skills-ref): switch build target to bun
-ci: add Biome job to hr-skills-ci workflow
-```
-
-Use these project commands from the repository root. After completing any task, validate the affected area and run the relevant lint checks:
+## Quick start
 
 ```bash
 bun install          # Install all dependencies (run once, or after package changes)
-bun run sync         # Sync generated skill references after adding/removing a skill
-bun run validate     # Validate all skill SKILL.md files
-bun run matrix       # Generate docs/skill-matrix.md — snapshot of every skill's maturity tier
-bun run registry     # Generate registry/skills.json — machine-readable skill registry (see docs/registry.md)
-bun run discover "<query>"  # Search the generated registry by text/domain (see docs/search.md)
-bun run recommend <skill-id>  # Get related-skill recommendations (see docs/recommendations.md)
-bun run plan "<intent>"  # Generate execution plan for a user intent (see docs/planner.md)
-bun run execute "<intent>"  # Generate a plan and run it through the Workflow Runtime (see docs/runtime.md)
-bun run evaluate     # Run the evaluation framework against eval/datasets (see docs/evaluation.md)
-bun run test         # Run tests across workspace packages
-bun run typecheck    # Run type-checking across workspace packages
-bun run build        # Run all workspace build tasks through Turborepo
-bun run check        # Run Biome checks without writing changes
-bun run lint         # Run Biome checks with auto-fix
-bun run format       # Format files with Biome formatter
-bun run lint:md      # markdownlint + case-police on Markdown files
-bun run lint:md:fix  # Markdown lint with auto-fix
-bun run lint:links   # Check Markdown links in content, docs, and skills
-bun run knip         # Detect unused files and dependencies
-bun run release      # Release only: bump version, generate changelog, commit, tag, and push
+bun run validate      # Validate all skill SKILL.md files
+bun run test          # Run tests across workspace packages
 ```
 
-Build, test, typecheck, validate, and sync tasks are orchestrated through Turborepo.
+Every other command — the full list, plus what each one does and when to use it — is documented once, in [`.agents/skills/turbo/SKILL.md`](.agents/skills/turbo/SKILL.md) and [`.agents/skills/bun/SKILL.md`](.agents/skills/bun/SKILL.md), not repeated here.
 
-Tasks may run in parallel and use local caching based on `turbo.jsonc`.
+## Where things live
 
-When you add a new skill directory (for example `skills/hr-new-skill/SKILL.md`), run `bun run sync` first. It auto-discovers `hr-*` skill directories from `skills/`, then updates `.claude-plugin/marketplace.json` — no manual edits needed.
+This file stays intentionally short. Everything below is a **workflow**, not a one-time fact about the project — and workflows are owned by a single skill file under [`.agents/skills/`](.agents/skills/), so they can be loaded on demand and updated in one place instead of drifting across copies.
+
+| Topic | Owned by |
+|-------|----------|
+| Full `bun run` / `turbo run` command reference | [`.agents/skills/turbo/SKILL.md`](.agents/skills/turbo/SKILL.md), [`.agents/skills/bun/SKILL.md`](.agents/skills/bun/SKILL.md) |
+| Commit message format and Conventional Commits types | [`.agents/skills/github-awesome-copilot-git-commit/SKILL.md`](.agents/skills/github-awesome-copilot-git-commit/SKILL.md) |
+| `SKILL.md` required structure, frontmatter, and pre-publish checklist | [`.agents/skills/hr-skills-maintaining/SKILL.md`](.agents/skills/hr-skills-maintaining/SKILL.md) |
+| Markdown formatting, content-design rules, and the blank-line-before-list rule | [`.agents/skills/markdown/SKILL.md`](.agents/skills/markdown/SKILL.md) |
+| Maintaining the root `SKILL.md` router | [`.agents/skills/hr-root-router-maintaining/SKILL.md`](.agents/skills/hr-root-router-maintaining/SKILL.md) |
+| Security review of skill content | [`.agents/skills/skill-vetter/SKILL.md`](.agents/skills/skill-vetter/SKILL.md) |
+| Whether a change needs a changeset | [`.agents/skills/changeset/SKILL.md`](.agents/skills/changeset/SKILL.md) |
+| TypeScript, Biome, and Valibot conventions in `packages/*` | [`.agents/skills/typescript/SKILL.md`](.agents/skills/typescript/SKILL.md), [`.agents/skills/biome/SKILL.md`](.agents/skills/biome/SKILL.md), [`.agents/skills/valibot/SKILL.md`](.agents/skills/valibot/SKILL.md) |
+| Everything above, indexed in one place | [`.agents/AGENTS.md`](.agents/AGENTS.md) |
+
+When you add a new skill directory (for example `skills/hr-new-skill/SKILL.md`), run `bun run sync` first — it auto-discovers `hr-*` skill directories from `skills/` and updates `.claude-plugin/marketplace.json`. No manual edits needed.
 
 ## Project structure
 
@@ -115,83 +60,11 @@ When you add a new skill directory (for example `skills/hr-new-skill/SKILL.md`),
 | `docs/skill-matrix.md` | Generated skill maturity snapshot — do not edit manually, run `bun run matrix` |
 | `docs/evaluation.md` | Evaluation framework architecture, dataset format, and golden fixture workflow |
 | `packages/hr-skills-build/eval/datasets/` | Hand-authored evaluation datasets (planning scenarios) |
-| `packages/hr-skills-build/eval/golden/` | Committed golden fixtures — expected planner/workflow outcomes, regenerate with `bun src/run-evaluation.ts --update-golden` from `packages/hr-skills-build` |
+| `packages/hr-skills-build/eval/golden/` | Committed golden fixtures — regenerate with `bun run evaluate -- --update-golden` from the repo root |
 | `docs/registry.md` | Skill Registry architecture, schema, and extension guide |
 | `registry/skills.json` | Generated machine-readable skill registry — do not edit manually, run `bun run registry` |
 | `.claude-plugin/marketplace.json` | Generated marketplace metadata synced from skill frontmatter |
-| `packages/hr-skills-build` | Build and maintenance tooling for validation, sync, and packaging support |
+| `packages/hr-skills-build` | Build and maintenance tooling — validation, sync, registry/planner/runtime generation, and packaging |
 | `packages/skills-ref` | TypeScript library for reading, validating, and generating prompts from skill files |
 
-## Packages
-
-This repository uses Bun workspaces with Turborepo task orchestration. All packages are located in `packages/*`.
-
-Generated files and package build outputs are cached through Turborepo based on the task configuration in `turbo.jsonc`.
-
-| Package | Description |
-|---------|-------------|
-| `packages/hr-skills-build` | Build and maintenance tooling for validating skills, syncing metadata, and packaging skill distributions |
-| `packages/skills-ref` | TypeScript library (`skills-ref`) for reading, validating, and generating prompts from skill files |
-
-## Content standards
-
-All documentation and skill content follows [Atlassian's content design guidelines](https://atlassian.design/foundations/content/). The key rules that apply to this project:
-
-**Language and grammar** — [atlassian.design/foundations/content/language-and-grammar](https://atlassian.design/foundations/content/language-and-grammar/)
-
-- Use sentence case for all headings: capitalize the first word and proper nouns only.
-- Don't use `e.g.`, `i.e.`, `etc.`, or `&` in prose — write "for example", "that is", "and so on", "and".
-- Don't use periods at the end of headings.
-- Avoid gerunds in headings — prefer "Add a skill" over "Adding a skill".
-- Phrase list items in parallel. Fragmented items: lowercase first letter, no period. Complete sentences: capital first letter, period at end.
-
-**Voice and tone** — [atlassian.design/foundations/content/voice-tone](https://atlassian.design/foundations/content/voice-tone/)
-
-- Be clear, concise, and direct — get to the point and get out of the way.
-- Use contractions ("don't", "can't") for a conversational, friendly tone.
-- Adjust tone to context: practical and precise in technical sections, approachable in onboarding content.
-
-**Inclusive writing** — [atlassian.design/foundations/content/inclusive-writing](https://atlassian.design/foundations/content/inclusive-writing/)
-
-- Use "they/their" instead of gendered pronouns when the person's identity isn't known.
-- Avoid idioms or culturally specific expressions that don't translate well.
-
-## Common pitfalls and best practices
-
-- **Blank line before lists:** Always leave a blank line between a heading or paragraph and the list that follows. Missing blank lines can cause rendering issues and the skill validator enforces this rule for `SKILL.md` files.
-
-  **For AI tools specifically:** every time you write a heading (`##`, `###`) or a bold label (`**Label:**`) that is immediately followed by a list, you MUST insert a blank line in between. This applies to every file in the project — `AGENTS.md`, `README.md`, `SKILL.md`, `docs/*.md`, and generated files. Run `bun run validate` and `bun run lint:md` before committing when Markdown or skills change.
-- **HR-domain only:** Prompts and guidance must cover HR-specific patterns and best practices, not generic management or business advice.
-- **No obvious content:** Avoid widely-known basics. Focus on nuanced guidance that HR professionals actually need AI assistance with.
-- **Required structure:** Each `SKILL.md` needs frontmatter (`name`, `description`, `metadata`), `## Supported tasks`, `## Key prompts` (grouped by subtopic), and `## Tips`.
-- **SKILL.md is for AI agents:** Be concise — context window is a shared resource. Assume the agent is smart; only include what it doesn't already know. Use progressive disclosure — `SKILL.md` is an overview, not an exhaustive manual.
-- **Trigger phrases matter:** The `description` field is what determines when the skill activates. Include specific, realistic HR trigger phrases like "Write a PIP", "Conduct a stay interview", "Analyze turnover".
-
-## Checklist for effective skills
-
-Before publishing a skill, verify:
-
-### Core quality
-
-- [ ] `description` is specific and includes key HR trigger phrases
-- [ ] `description` covers both what the skill does and when to use it
-- [ ] `SKILL.md` body is under 500 lines
-- [ ] Prompts are grouped by meaningful subtopics
-- [ ] No time-sensitive information (laws, tools, versions)
-- [ ] Consistent HR terminology throughout
-- [ ] Prompts use `[placeholders]` for variable inputs
-- [ ] Each subtopic has 4-7 focused prompts
-- [ ] Tips section provides actionable professional guidance
-
-### Frontmatter
-
-- [ ] `name` matches the skill directory name exactly
-- [ ] `description` is wrapped in a single pair of double quotes, with trigger phrases as plain comma-separated text (not individually quoted)
-- [ ] `metadata.author` is set to `Tuan Duc Tran`
-- [ ] `metadata.version` is set
-
-### Structure
-
-- [ ] `## Supported tasks` lists 8-12 concrete tasks
-- [ ] `## Key prompts` is divided into logical subtopic sections
-- [ ] `## Tips` has 4-6 professional best-practice tips
+This repository uses Bun workspaces with Turborepo task orchestration; both packages above live under `packages/*`, and their build outputs are cached through Turborepo based on `turbo.jsonc`.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -67,7 +67,7 @@ they govern, rather than being duplicated here:
 | --- | --- |
 | New or updated skill | [`docs/contributing/skill-authoring.md`](docs/contributing/skill-authoring.md), [`docs/format.md`](docs/format.md) |
 | Documentation | [`docs/contributing/workflow.md`](docs/contributing/workflow.md), this repository's Markdown/link-lint conventions |
-| Tooling / tests (`packages/*`) | `CONTRIBUTING.md`'s "Improving the build tooling" section, `AGENTS.md`'s Packages table |
+| Tooling / tests (`packages/*`) | `CONTRIBUTING.md`'s "Improving the build tooling" section, `AGENTS.md`'s Project structure table |
 | Pull requests (general) | `.github/pull_request_template.md`, `AGENTS.md`'s branch and commit conventions |
 
 If you're unsure which applies, start at

--- a/docs/contributing/onboarding.md
+++ b/docs/contributing/onboarding.md
@@ -64,7 +64,7 @@ table and confirmed by inspecting the files on disk.
   since the skill already exists in the routing table.
 - **Fix a factual or formatting error in an existing skill** — smallest, lowest-risk PR type.
 - **Improve tooling** in `packages/hr-skills-build` or `packages/skills-ref` — requires
-  TypeScript and Bun familiarity; see AGENTS.md's "Packages" table.
+  TypeScript and Bun familiarity; see AGENTS.md's "Project structure" table.
 - **Improve documentation** — see `docs/contributing/workflow.md` for documentation
   maintenance conventions.
 

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -44,7 +44,10 @@ bun install
 | `bun run validate` | Validates every `SKILL.md` against the spec in `docs/format.md` (backed by `packages/hr-skills-build/src/validation/validate.ts`) |
 | `bun run sync` | Regenerates `.claude-plugin/marketplace.json` from skill frontmatter |
 | `bun run matrix` | Regenerates `docs/skill-matrix.md` |
-| `bun run registry` | Regenerates `registry/skills.json` |
+| `bun run registry` | Regenerates `registry/skills.json` (see `docs/registry.md`) |
+| `bun run signals` | Regenerates `registry/relevance-signals.json` from evaluation golden fixtures (see `docs/usage-informed-relevance.md`) |
+| `bun run discover "<query>"` | Searches the generated registry by text/domain (see `docs/search.md`) |
+| `bun run recommend <skill-id>` | Related-skill recommendations from the registry (see `docs/recommendations.md`) |
 | `bun run check` | Biome check, no writes |
 | `bun run lint` | Biome check with auto-fix |
 | `bun run format` | Biome formatter |
@@ -56,12 +59,18 @@ bun install
 | `bun run test` | Tests across workspace packages |
 | `bun run knip` | Detects unused files/dependencies |
 | `bun run plan "<intent>"` | Generates an execution plan for a user intent (see `docs/planner.md`) |
-| `bun run execute "<intent>"` | AGENTS.md-documented; generates a plan and runs it through the workflow runtime (see `docs/runtime.md`) |
+| `bun run execute "<intent>"` | Generates a plan and runs it through the workflow runtime (see `docs/runtime.md`) |
 | `bun run evaluate` | Runs the evaluation framework (see `docs/evaluation.md`) |
 | `bun run changeset` / `bun run release` | Versioning/release |
 
-All of the above is **[Existing]**, taken directly from `package.json` scripts and
-cross-checked against AGENTS.md's own command list, which matches exactly.
+All of the above is **[Existing]**, taken directly from `package.json` scripts. `AGENTS.md`
+itself keeps only a two-command quick start and points to
+[`.agents/skills/turbo/SKILL.md`](../../.agents/skills/turbo/SKILL.md) for the full reference
+of Turborepo-orchestrated tasks (`build`, `validate`, `sync`, `matrix`, `registry`, `signals`,
+`discover`, `recommend`, `plan`, `execute`, `evaluate`, `test`, `typecheck`,
+`dev`) — every one of those appears in this table too, verified by diff. The remaining rows
+here (`check`, `lint`, `format`, `knip`, `changeset`, `release`) are plain Bun scripts with no
+Turborepo task of their own; `.agents/skills/bun/SKILL.md` covers those.
 
 **[Existing]** CI (`.github/workflows/`) runs `knip.yml`, `lint.yml`, `matrix.yml`,
 `release.yml`, `test.yml`, `typecheck.yml`, and `validate.yml` as separate jobs.

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"discover": "turbo run discover --filter=hr-skills-build --",
 		"recommend": "turbo run recommend --filter=hr-skills-build --",
 		"execute": "turbo run execute --filter=hr-skills-build --",
-		"evaluate": "turbo run evaluate --filter=hr-skills-build",
+		"evaluate": "turbo run evaluate --filter=hr-skills-build --",
 		"changeset": "changeset",
 		"release": "changeset version",
 		"prepare": "lefthook install",


### PR DESCRIPTION
Root AGENTS.md and .agents/AGENTS.md had drifted into restating the same rules in multiple places — most concretely, root AGENTS.md's commit-type table was missing 'perf' and 'revert' relative to
@commitlint/config-conventional (the actual enforced config), while .agents/skills/github-awesome-copilot-git-commit/SKILL.md already had the correct, complete list. Root AGENTS.md also listed the same 2 packages twice, in its own 'Project structure' and 'Packages' sections.

Consolidates each topic into exactly one owning file:

  - Atlassian content-design rules + the blank-line-before-list rule (previously only in root AGENTS.md) move into .agents/skills/markdown/SKILL.md, which is now the single home for all Markdown/content-writing rules in the repo.
  - The HR content-quality checklist (previously only in root AGENTS.md's 'Common pitfalls'/'Checklist' sections) moves into .agents/skills/hr-skills-maintaining/SKILL.md, alongside the structural checklist it already had.
  - .agents/skills/turbo/SKILL.md's 'Common commands' gains the registry/ signals/discover/recommend/plan/execute/evaluate commands it was missing, so it's now genuinely the complete command reference (previously only build/dev/validate/sync/matrix/test/typecheck).

Root AGENTS.md shrinks from 197 to ~90 lines: keeps the project overview, the branch-strategy safety rule, a 2-command quick start, a merged 'Project structure' table (dedupes the repeated package descriptions), and a 'Where things live' table pointing to the one skill file that owns each workflow topic instead of restating it.

.agents/AGENTS.md is rewritten as an explicit routing index rather than a 'condensed digest of root' — its job is now to route an agent to the right skill file fast, not to restate content that would drift out of sync with it again.

Also fixes cross-references broken by removing root AGENTS.md's standalone 'Packages' section (GOVERNANCE.md, docs/contributing/onboarding.md now point at 'Project structure' instead), corrects a stale claim in docs/contributing/workflow.md that its command table 'matches exactly' against AGENTS.md (AGENTS.md no longer carries its own command list; the claim is rephrased and verified against turbo/SKILL.md's task list specifically), and adds a '--' passthrough to the root 'evaluate' script in package.json for consistency with plan/discover/recommend/execute.

.claude/settings.json's permission allow-list gets the registry/signals/ discover/recommend/plan/execute/evaluate commands it was missing, even though those commands already existed — another instance of the same 'added a command, forgot to sync every place that lists commands' pattern this change is meant to fix structurally.

Verified: markdownlint clean, case-police clean, every relative Markdown link in the edited files resolves (checked manually — lint:links doesn't cover AGENTS.md/.agents/), 403/403 tests pass, typecheck clean, biome clean.