### PR TITLE
feat(build): ship JSON-only .claude-plugin and add usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Create competency-based interview questions for a Senior Product Manager.
 
 Multiple skills can be combined to support more complex HR workflows.
 
+### Downloaded a package?
+
+If you have `hr-skills.zip` or `hr-skills.skill` instead of a clone of this
+repository, see [`docs/usage-guide.md`](docs/usage-guide.md) — it covers
+loading the package into Claude, ChatGPT, and other AI tools.
+
 ### Examples
 
 See [`examples/`](examples/README.md) for practical, end-to-end usage:

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1,0 +1,69 @@
+# Usage guide
+
+This guide explains how to load this package into Claude, ChatGPT, or
+another AI tool so you can start asking HR questions right away.
+
+## What's in this package
+
+| File / folder | What it is |
+| --- | --- |
+| `SKILL.md` | The root skill router — an overview of every HR skill included |
+| `skills/hr-*/` | One folder per HR skill, each with its own `SKILL.md` and optional `content/`, `prompts/`, `examples/` files |
+| `LICENSE` | Usage license for the content |
+| `docs/usage-guide.md` | This file |
+| `.claude-plugin/marketplace.json` | Only present in `.skill` packages — a manifest Claude's marketplace tooling reads; not needed for manual upload |
+
+## Using it with Claude
+
+Claude has a dedicated Skills feature that reads `SKILL.md` frontmatter
+directly.
+
+**claude.ai:**
+
+1. Go to **Settings > Features > Skills** (or **Settings > Customize >
+   Skills**, depending on your plan).
+2. Upload this package.
+3. Claude reads the `SKILL.md` files automatically and lists the available
+   HR skills. Skills activate automatically when your question matches a
+   skill's description, or you can enable/disable individual skills from
+   the Skills menu in a chat.
+
+**Claude Code:**
+
+```bash
+# Extract the archive first, then copy the skills you want
+cp -r skills/hr-recruiting ~/.claude/skills/   # one skill
+cp -r skills/hr-* ~/.claude/skills/             # the full set
+```
+
+Once copied, simply describe your HR task — Claude Code automatically
+discovers and loads the most relevant skill.
+
+If you don't have Skills access, any `SKILL.md` (and its `content/`,
+`prompts/`, `examples/` files) is also plain Markdown — upload it as
+Project Knowledge instead and reference it directly in chat.
+
+## Using it with ChatGPT
+
+ChatGPT doesn't read Claude's `SKILL.md` frontmatter, but it can still use
+the content as reference material through a custom GPT's Knowledge:
+
+1. Create a custom GPT (or open an existing one) and go to **Configure >
+   Knowledge**.
+2. Upload this package as a zip file.
+3. Ask questions in chat — the GPT retrieves relevant HR skill content to
+   answer them.
+
+Two limits to keep in mind: knowledge uploads share a per-account storage
+cap, and very large zip files have occasionally failed to extract for some
+users — if that happens, zip and upload a single skill folder (for example
+just `skills/hr-recruiting/`) instead of the whole package.
+
+## Using it with other AI tools
+
+Any tool that accepts file or zip uploads for a knowledge base (self-hosted
+RAG tools, other vendor assistants, IDE-integrated agents) can generally
+use this package the same way as ChatGPT: upload it, and let the tool's own
+retrieval index the Markdown content. Tools that implement the open Agent
+Skills specification can read `SKILL.md` frontmatter directly, the same way
+Claude does.

--- a/packages/hr-skills-build/src/build/build-skills.ts
+++ b/packages/hr-skills-build/src/build/build-skills.ts
@@ -15,12 +15,15 @@
  * -------
  * hr-skills.zip
  *     Standard distribution zip for manual extraction and document-based tools.
- *     Includes root SKILL.md, LICENSE, and the full skills/ tree.
- *     Excludes .claude-plugin/ (internal tooling, not shipped in the zip).
+ *     Includes root SKILL.md, LICENSE, docs/usage-guide.md, and the full
+ *     skills/ tree. Excludes .claude-plugin/ (internal tooling, not shipped
+ *     in the zip).
  *
  * hr-skills.skill
  *     Skill-oriented archive with the same core knowledge files as the zip.
- *     Also includes the full .claude-plugin/ directory.
+ *     Also includes the .claude-plugin/ JSON manifests only (for example
+ *     marketplace.json) — non-JSON files such as .claude-plugin/README.md
+ *     are internal-repo documentation and are never packaged.
  *
  * Ported from soulmap-ai/src/soulmap/devtools/packaging/build_skill.py
  */
@@ -221,7 +224,7 @@ async function walkFiles(dir: string): Promise<string[]> {
 
 /**
  * Core knowledge files shared by both archive formats.
- * Includes SKILL.md, LICENSE, and the full skills/ tree.
+ * Includes SKILL.md, LICENSE, docs/usage-guide.md, and the full skills/ tree.
  */
 async function iterInputs(repoRoot: string): Promise<string[]> {
 	const paths: string[] = [];
@@ -230,6 +233,9 @@ async function iterInputs(repoRoot: string): Promise<string[]> {
 		const candidate = join(repoRoot, name);
 		if (existsSync(candidate)) paths.push(candidate);
 	}
+
+	const usageGuide = join(repoRoot, 'docs', 'usage-guide.md');
+	if (existsSync(usageGuide)) paths.push(usageGuide);
 
 	const skillsDir = join(repoRoot, 'skills');
 	if (existsSync(skillsDir)) {
@@ -241,11 +247,14 @@ async function iterInputs(repoRoot: string): Promise<string[]> {
 
 /**
  * .claude-plugin files — included only in the .skill archive.
+ * Only .json manifests (e.g. marketplace.json) are shipped; documentation
+ * files such as README.md are internal-repo-only and excluded here.
  */
 async function iterClaudePluginInputs(repoRoot: string): Promise<string[]> {
 	const base = join(repoRoot, '.claude-plugin');
 	if (!existsSync(base)) return [];
-	return (await walkFiles(base)).sort();
+	const all = await walkFiles(base);
+	return all.filter((p) => p.endsWith('.json')).sort();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- .claude-plugin packaging in the .skill archive now includes only .json manifests (marketplace.json); README.md and any other non-JSON file are internal repo documentation and are no longer packaged.
- Add docs/usage-guide.md: an end-user guide for loading a downloaded package into Claude, ChatGPT, or another AI tool. Written to be self-contained for someone who only has the extracted archive (SKILL.md, skills/, LICENSE) — no references to bun, TypeScript, the build script, or other repo docs that aren't shipped in the package.
- Ship docs/usage-guide.md in both dist/hr-skills.zip and dist/hr-skills.skill via iterInputs, alongside SKILL.md and LICENSE.
- Link the new guide from README.md's Quick Start section (this link is repo-only and does not ship in the package).