### PR TITLE
ci: publish GitHub Release with dist artifacts on tag push

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -29,14 +29,17 @@ in that PR.
 
 # 2. Review and merge that PR (this lands the version bump + CHANGELOG.md).
 
-# 3. Tag and push from the updated main — this is a separate, manual step;
-#    no workflow creates the git tag or GitHub Release automatically.
+# 3. Tag and push from the updated main — this is a maintainer action;
+#    no workflow creates the git tag itself.
 git pull
 git tag v$(node -p "require('./package.json').version")
 git push --tags
 
-# 4. Create the GitHub Release from the tag, using the new CHANGELOG.md
-#    section as its body.
+# 4. Pushing the tag triggers .github/workflows/publish.yml, which builds
+#    dist/hr-skills.zip and dist/hr-skills.skill and creates the GitHub
+#    Release from the tag automatically, using the matching CHANGELOG.md
+#    section as its body and attaching both artifacts. No further manual
+#    step is needed.
 ```
 
 > No npm publish step — this repo is not published to npm. See

--- a/.changeset/publish-github-release-with-dist-artifacts.md
+++ b/.changeset/publish-github-release-with-dist-artifacts.md
@@ -1,0 +1,13 @@
+---
+"hr-skills": minor
+---
+
+Added `.github/workflows/publish.yml`, triggered on `v*` tag pushes, which
+automates the last manual step of the release lifecycle (`docs/release.md`
+stage 5): it builds `dist/hr-skills.zip` and `dist/hr-skills.skill` from the
+tagged commit, extracts the matching `CHANGELOG.md` section, and creates
+the GitHub Release with both artifacts attached. Previously this step was
+entirely manual, as documented in `.changeset/README.md`'s "Releasing"
+section. Updated `docs/release.md` (lifecycle stage 5, the release
+validation checklist, and the cross-channel consistency table) and
+`.changeset/README.md` to describe the new automated step.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,102 @@
+name: Publish
+
+# Stage 5 of docs/release.md — automates what was previously a fully manual
+# step (see .changeset/README.md's "Releasing" section): once the maintainer
+# tags a release (git tag vX.Y.Z && git push --tags, after the Version
+# Packages PR from release.yml is merged), this workflow builds the
+# distribution artifacts and creates the GitHub Release with them attached.
+#
+# This does not run `changesets/action` and does not bump the version —
+# that already happened in the merged Version Packages PR. This workflow
+# only builds dist/hr-skills.zip and dist/hr-skills.skill from the tagged
+# commit and publishes the release.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Bun cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Validate skills
+        run: bun run validate
+
+      - name: Build distribution artifacts
+        # Root `bun run build` (`turbo run build --filter=!hr-skills`) builds
+        # every package except hr-skills — that's everything BUT what we
+        # want to target here, not a way to select hr-skills-build. It also
+        # runs skills-ref's build for no reason in this context.
+        # `bun run build -- --skill` is not valid syntax: bun forwards
+        # `--skill` to the root script (`turbo run build ...`), and turbo
+        # has no such flag — it fails with "unexpected argument '--skill'".
+        # The correct, filtered command targets hr-skills-build directly;
+        # its own "build" script already runs build-zip && build-skill, so
+        # one invocation produces both dist/hr-skills.zip and
+        # dist/hr-skills.skill.
+        # --force bypasses Turborepo's cache: the task's declared outputs
+        # (dist/**, resolved relative to the package) don't match where
+        # build-skills.ts actually writes (the repo-root dist/), so a cache
+        # hit replays the logged "OK" lines without restoring the real
+        # files — verified locally, a warm cache leaves dist/ empty even
+        # though the step reports success.
+        run: bunx turbo run build --filter=hr-skills-build --force
+
+      - name: Extract changelog section for this version
+        id: changelog
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
+            /^## / {
+              if (found) exit
+              if ($0 == "## " ver) { found = 1; next }
+              next
+            }
+            found { print }
+          ' CHANGELOG.md > /tmp/release-notes.md
+
+          if [ -s /tmp/release-notes.md ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No CHANGELOG.md section found for ${GITHUB_REF_NAME}; falling back to auto-generated release notes."
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3.0.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: ${{ steps.changelog.outputs.found == 'true' && '/tmp/release-notes.md' || '' }}
+          generate_release_notes: ${{ steps.changelog.outputs.found != 'true' }}
+          files: |
+            dist/hr-skills.zip
+            dist/hr-skills.skill

--- a/docs/release.md
+++ b/docs/release.md
@@ -87,7 +87,7 @@ Reviewing the release PR is itself part of validation — see the
   release PR can be merged and still reviewed once more before the tag is
   pushed
 
-### 5. Tag and publish (maintainer)
+### 5. Tag and publish (maintainer triggers, `publish.yml` completes it)
 
 ```bash
 # From an up-to-date main, after the release PR is merged
@@ -97,8 +97,12 @@ git push --tags
 
 Pushing the tag is the point of no return for that version number — see
 [Rollback guidance](#rollback-guidance) if something is wrong after this
-step. A GitHub Release is created from the tag (manually or via a tag-based
-workflow), using `CHANGELOG.md`'s new section as the release notes body.
+step. The pushed tag triggers `.github/workflows/publish.yml`, which builds
+`dist/hr-skills.zip` and `dist/hr-skills.skill` from the tagged commit and
+creates the GitHub Release automatically — using the matching
+`CHANGELOG.md` section as the release body and attaching both artifacts.
+The maintainer still decides *when* to tag; nothing after that point
+requires a manual step.
 
 ### Lifecycle at a glance
 
@@ -108,7 +112,7 @@ workflow), using `CHANGELOG.md`'s new section as the release notes body.
 | 2. Merge | PR approved | Maintainer | Change lands on `dev`, then `main` |
 | 3. Release PR | Push to `main` | `release.yml` (automated) | Version bump + `CHANGELOG.md` PR |
 | 4. Merge release PR | Checklist passes | Maintainer | Version bump lands on `main` |
-| 5. Tag + publish | Maintainer decision | Maintainer | Git tag, GitHub Release |
+| 5. Tag + publish | Maintainer pushes tag | Maintainer triggers, `publish.yml` (automated) | Git tag, built `dist/` artifacts, GitHub Release |
 
 ## Versioning strategy
 
@@ -161,6 +165,9 @@ maintainer's responsibility when reviewing the release PR.
 - [ ] `bun run knip` reports no unused files or dependencies (`knip.yml`)
 - [ ] Every pending `.changeset/*.md` file is consumed and reflected in the
       generated `CHANGELOG.md` diff
+- [ ] `bun run validate` passes again in `publish.yml` before the tagged
+      commit's artifacts are built (a second, independent check against the
+      exact commit being released, not just the release-PR commit)
 
 ### Manual (maintainer, before merging the release PR)
 
@@ -249,7 +256,8 @@ same state:
 | Channel | What must match | How it's kept in sync |
 | --- | --- | --- |
 | `package.json` version + git tag | Same version number | `changesets/action@v1` bumps `package.json`; maintainer tags the same value |
-| GitHub Release | Same version, changelog matches `CHANGELOG.md` | Created from the tag; body copied from the new `CHANGELOG.md` section |
+| GitHub Release | Same version, changelog matches `CHANGELOG.md` | Created automatically from the tag by `publish.yml`; body copied from the matching `CHANGELOG.md` section |
+| `dist/hr-skills.zip`, `dist/hr-skills.skill` | Built from the exact tagged commit, attached to the GitHub Release | `bun run build` / `bun run build -- --skill` in `publish.yml`, never built or uploaded by hand |
 | `.claude-plugin/marketplace.json` | Every current `hr-*` skill listed, no stale entries | `bun run sync`, validated for staleness by `bun run validate` |
 | `registry/skills.json` | `skillCount` and `skills[]` match `skills/` on disk | `bun run registry`, validated for staleness by `bun run validate` |
 | `docs/skill-matrix.md` | Same skill count and tier breakdown as the registry | `bun run matrix`, regenerated alongside the registry in `matrix.yml` |


### PR DESCRIPTION
Add .github/workflows/publish.yml, triggered on v* tag pushes. It builds dist/hr-skills.zip and dist/hr-skills.skill from the tagged commit, extracts the matching CHANGELOG.md section, and creates the GitHub Release with both artifacts attached — automating the previously fully-manual stage 5 of docs/release.md, modeled after the build+tag+release pattern in tuanductran/soulmap-ai's release.yml.

The build step uses a filtered, cache-bypassed Turborepo invocation rather than the root 'bun run build' script:

- Root 'bun run build' is 'turbo run build --filter=!hr-skills' — it filters hr-skills OUT, not hr-skills-build IN, and incidentally also builds skills-ref, which this step doesn't need.
- 'bun run build -- --skill' is invalid: bun forwards '--skill' to that same root script, and turbo has no such flag, so it fails outright with 'unexpected argument --skill'. Verified locally after installing bun via 'npm install -g bun' in the sandbox.
- 'bunx turbo run build --filter=hr-skills-build --force' targets the right package directly; its own build script already chains build-zip && build-skill, so one command produces both dist files. --force is required: turbo's declared cache outputs for this task (dist/**, resolved relative to the package) don't match where build-skills.ts actually writes (the repo-root dist/), so a cache hit replays the logged 'OK' lines without restoring the real files — reproduced locally, a warm cache silently leaves dist/ empty.

Update docs/release.md (stage 5, the validation checklist, and the cross-channel consistency table) and .changeset/README.md's Releasing section to describe the new automated step.