### PR TITLE
chore: dedupe validation/cli code, add clack/jscpd skills, fix doc drift

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -21,6 +21,9 @@ Never develop on `main` — branch from and open pull requests against `dev`.
 | Decide if a PR needs a changeset, or write one | [`skills/changeset/SKILL.md`](skills/changeset/SKILL.md) |
 | Write or review TypeScript in `packages/*` | [`skills/typescript/SKILL.md`](skills/typescript/SKILL.md) |
 | Configure or debug Biome lint/format rules | [`skills/biome/SKILL.md`](skills/biome/SKILL.md) |
+| Add/review CLI output (intro/spinner/note/outro) in `cli/*.ts` | [`skills/clack/SKILL.md`](skills/clack/SKILL.md) |
+| Detect copy-paste duplication in `packages/*` TypeScript source | [`skills/jscpd/SKILL.md`](skills/jscpd/SKILL.md) |
+| Refactor duplicated code found by jscpd (extract function/module/constant/type) | [`skills/dry-refactoring/SKILL.md`](skills/dry-refactoring/SKILL.md) |
 | Define or validate a schema with Valibot | [`skills/valibot/SKILL.md`](skills/valibot/SKILL.md) |
 | Rewrite AI-sounding prose to read more naturally | [`skills/humanizer/SKILL.md`](skills/humanizer/SKILL.md) |
 | Generate or fill a PDF | [`skills/pdf/SKILL.md`](skills/pdf/SKILL.md) |

--- a/.agents/skills/changeset/SKILL.md
+++ b/.agents/skills/changeset/SKILL.md
@@ -8,11 +8,11 @@ compatibility: hr-skills monorepo
 
 ## Purpose
 
-Use this skill whenever a pull request introduces **user-visible changes*- that should be included in the next release of the `hr-skills` repository.
+Use this skill whenever a pull request introduces **user-visible changes** that should be included in the next release of the `hr-skills` repository.
 
 A changeset records release notes, determines semantic version bumps, and drives `CHANGELOG.md` generation through Changesets.
 
-Do **not*- create a changeset for internal-only work that has no effect on repository users.
+Do **not** create a changeset for internal-only work that has no effect on repository users.
 
 ---
 
@@ -35,9 +35,9 @@ Create a changeset for changes such as:
 - User-visible documentation improvements that change repository capabilities.
 - Any change that should appear in release notes.
 
-### A changeset is usually **not*- required
+### A changeset is usually **not** required
 
-Do **not*- create a changeset for work such as:
+Do **not** create a changeset for work such as:
 
 - Typo fixes.
 - Markdown formatting.
@@ -133,7 +133,7 @@ Examples:
 
 ## Writing Guidelines
 
-A good changeset explains **what changed*- and **why it matters**, not how it was implemented.
+A good changeset explains **what changed** and **why it matters**, not how it was implemented.
 
 ### General Rules
 

--- a/.agents/skills/clack/SKILL.md
+++ b/.agents/skills/clack/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: clack
+description: "Repository guidance for @clack/prompts usage in packages/hr-skills-build/src/cli/* and src/build/*. Covers the intro/spinner/note/outro/log CLI-output pattern this repo actually uses — not clack's interactive text/select/confirm prompts, which this repo does not use."
+metadata:
+  author: Tuan Duc Tran
+  version: "1.0.0"
+---
+
+# clack
+
+Repository guidance for [`@clack/prompts`](https://github.com/bombshell-dev/clack) (`^1.7.0`, see `package.json`) as used across `packages/hr-skills-build/src/cli/*.ts` and `src/build/sync.ts`.
+
+> **This repo's clack usage is narrow and deliberate.** Every CLI here (`discover`, `recommend`, `execute-plan`, `generate-plan`, `run-evaluation`, `sync`, `validate`) is a single-shot, non-interactive script driven by `process.argv` — none of them collect input via clack's interactive prompts. Full upstream docs: [Getting Started](https://bomb.sh/docs/clack/basics/getting-started/), [Prompts](https://bomb.sh/docs/clack/packages/prompts/), [Best Practices](https://bomb.sh/docs/clack/guides/best-practices/).
+
+## What this repo actually uses
+
+Only five clack APIs appear anywhere in this codebase — confirmed by grepping `packages/hr-skills-build/src`:
+
+| API | Purpose | Used in |
+|---|---|---|
+| `p.intro(title)` | Announce the CLI at start | Every `cli/*.ts` entry point |
+| `p.outro(message)` | Announce completion at end | Every `cli/*.ts` entry point |
+| `p.spinner()` / `.start()` / `.stop()` | Show progress during `buildRegistry()`, plan generation, etc. | `execute-plan.ts`, `generate-plan.ts`, `recommend.ts` |
+| `p.note(message, title?)` | Print a multi-line info block (search results, recommendations) | `discover.ts`, `recommend.ts` |
+| `p.log.{info,error,warn,success,message}` | Single-line status/error output | All `cli/*.ts`, routed through `cli/cli-bootstrap.ts` |
+
+## What this repo does NOT use — do not introduce it
+
+- **No `text()`, `select()`, `confirm()`, `multiselect()`, `password()`, or any other interactive prompt.** These CLIs must stay scriptable (CI, `bunx`, piped output); blocking on stdin input would break that. If a task genuinely needs a human choice, that belongs in `.claude/commands/*.md` (Claude Code slash commands), not in `packages/hr-skills-build`'s CLIs.
+- **No `isCancel()`.** It only matters when interactive prompts are in play — irrelevant here. Don't add it "for safety"; it signals dead code review comments.
+- **No `@clack/core` low-level primitives** (`TextPrompt`, custom `Prompt` subclasses). `@clack/prompts` alone covers everything this repo needs.
+
+If a future CLI genuinely needs interactive input, that's a deliberate scope change — flag it explicitly rather than silently adding `text()`/`select()` to keep the "always scriptable" invariant intact.
+
+## Repository pattern
+
+Every CLI entry point in `src/cli/*.ts` follows this shape (see `cli/cli-bootstrap.ts`):
+
+```typescript
+import * as p from '@clack/prompts';
+import { printUsageAndExit, runCli } from './cli-bootstrap.js';
+
+async function main() {
+	const intent = process.argv[2];
+	if (!intent) {
+		printUsageAndExit(
+			'Usage: bun src/my-command.ts "<argument>"',
+			'  bun src/my-command.ts "example"',
+		);
+	}
+
+	p.intro('My Command');
+
+	const spinner = p.spinner();
+	spinner.start('Building Skill Registry...');
+	const registry = await buildRegistry();
+	spinner.stop(`Registry ready (${registry.skillCount} skills)`);
+
+	// ... do the work, p.note(...) for structured output ...
+
+	p.outro('Done');
+}
+
+runCli(main);
+```
+
+- `printUsageAndExit` / `runCli` (from `cli/cli-bootstrap.ts`) standardize the "missing arg" and "uncaught error" paths — see [`cli-bootstrap`](../../../packages/hr-skills-build/src/cli/cli-bootstrap.ts). Don't hand-roll `p.log.error(...); process.exit(1);` again; that duplication is exactly what `cli-bootstrap.ts` was extracted to remove (see [`dry-refactoring`](../dry-refactoring/SKILL.md)).
+- `p.intro`/`p.outro` bookend the whole run — call each exactly once.
+- `spinner.stop(message)` should report a concrete result (count, duration), not just "Done" — matches the existing `Registry ready (${registry.skillCount} skills)` style.
+
+## Key prompts
+
+### Adding a new CLI
+
+- "Scaffold a new `src/cli/*.ts` entry point following this repo's clack pattern."
+- "Wire this new CLI through `cli-bootstrap.ts`'s `runCli`/`printUsageAndExit`."
+
+### Reviewing clack usage
+
+- "Check whether this CLI change introduces an interactive prompt that would break scriptability."
+- "Review this `p.spinner()` usage for a concrete stop message."
+- "Is this `p.log.*` call redundant with what `cli-bootstrap.ts` already provides?"
+
+## Tips
+
+- Keep `p.intro`/`p.outro` messages short — they're a visual bookend, not a status report.
+- Prefer `p.note()` over multiple `p.log.message()` calls when printing a related block (search results, a plan summary) — it groups visually.
+- Never gate a `cli/*.ts` script on user input; that's the one hard rule this skill exists to protect.

--- a/.agents/skills/dry-refactoring/SKILL.md
+++ b/.agents/skills/dry-refactoring/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: dry-refactoring
+description: "Guided workflow to eliminate copy-paste duplication in packages/hr-skills-build and packages/skills-ref, detected by jscpd. Extract shared functions, constants, and types into their own files instead of growing an existing one."
+metadata:
+  author: Tuan Duc Tran
+  version: "1.0.0"
+---
+
+# dry-refactoring
+
+Guided workflow to eliminate copy-paste duplication in `packages/*` TypeScript source. Use after [`jscpd`](../jscpd/SKILL.md) has produced a clone list.
+
+## Prerequisites
+
+Run jscpd first — see [`jscpd`](../jscpd/SKILL.md) for the exact command this repo uses:
+
+```bash
+bunx jscpd@5 packages --reporters ai --format typescript
+```
+
+## Workflow
+
+1. Run jscpd, scoped to `packages/` only (never `skills/`, see the `jscpd` skill for why).
+2. Parse each clone line to identify the two duplicated locations (file + line range).
+3. Read both code fragments and understand what they do — don't refactor blind.
+4. Decide the refactor target using the placement rules below.
+5. Extract the shared logic; update **all** call sites, not just the two jscpd reported.
+6. Run `bun run typecheck` and `bun run test` (repo-wide or `--filter` to the affected package — see [`turbo`](../turbo/SKILL.md)).
+7. Re-run jscpd to confirm the clone is gone.
+8. Repeat, highest-impact cluster first (most repeated pattern, not just the first line in the report).
+
+## Where extracted code goes in this repo
+
+This repo already separates code by domain under `packages/hr-skills-build/src/{shared,validation,cli,planner,runtime,registry,search,build,evaluation}/` and `packages/skills-ref/src/`. Follow that structure — don't dump extracted helpers into whichever file happens to be open:
+
+- **Duplicated logic used by 2+ files in the same domain folder** (e.g. two files under `src/validation/`) → new file in that same folder, e.g. `src/validation/security-helpers.ts`, imported by both.
+- **Duplicated logic used across domain folders** (e.g. `src/cli/*` and `src/evaluation/*`) → `src/shared/`, alongside the existing `shared/constants.ts`, `shared/helpers.ts`, `shared/schema.ts`, `shared/types.ts`.
+- **Duplicated logic across packages** (`hr-skills-build` and `skills-ref` both define it) → do **not** create a third copy in either package. Prefer keeping a single canonical definition in the package it conceptually belongs to (`skills-ref` for skill-file parsing primitives, `hr-skills-build` for build/registry/CLI concerns) and importing it from the other, or promote it to a small shared internal package if both genuinely need to own it independently. Never resolve this by copy-pasting into a third location.
+- **Constants** → their own `constants.ts` in the relevant folder; don't fold them into a file that already holds functions or types.
+- **Types/interfaces** → their own `types.ts` (or `*.types.ts` if `types.ts` already exists and would grow unrelated concerns) in the relevant folder — never appended to a functions file "for now."
+
+## Naming collisions
+
+Before extracting, `grep -rn "export (const|function|type|interface) <name>" packages` for the name you're about to reuse. If a same-named export already exists elsewhere in the monorepo:
+
+- Prefer a more specific name over a generic one (e.g. `parseSkillFrontmatter` over `parse`) rather than renaming the existing export and risking unrelated churn.
+- If both are genuinely the same concept split across two files, that's itself a duplication signal — consolidate into one export instead of two similarly-named ones.
+
+## Refactoring strategies
+
+**Extract function** — duplicate is a block of logic → shared function, called from both places.
+
+**Extract module** — duplicate spans multiple files in the same or related domains → shared file per the placement rules above, imported by all call sites.
+
+**Extract constant** — duplicate is repeated literal data or config → named constant in the domain's `constants.ts`.
+
+**Extract type/interface** — duplicate or near-duplicate shape appears in two files → single definition in the domain's `types.ts`, both files import it.
+
+Avoid the **template/base class** strategy in this codebase unless a real inheritance hierarchy already exists — this repo favors small composable functions and Valibot schemas (see [`valibot`](../valibot/SKILL.md)) over class hierarchies.
+
+## Tips
+
+- All call sites updated, not just the two jscpd reported — `grep` for other near-identical blocks jscpd's thresholds may have missed.
+- Tests still pass after refactoring (`bun run test`), and `bun run typecheck` is clean.
+- The extracted abstraction has a clear, descriptive name — see naming collisions above.
+- If the duplication is between `packages/hr-skills-build` and `packages/skills-ref`, check whether a changeset is needed — see [`changeset`](../changeset/SKILL.md).
+- Format with Biome after refactoring (`bun run format` or let `lefthook` catch it on commit) — see [`biome`](../biome/SKILL.md).

--- a/.agents/skills/jscpd/SKILL.md
+++ b/.agents/skills/jscpd/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: jscpd
+description: "Copy-paste detector for the hr-skills TypeScript packages (packages/hr-skills-build, packages/skills-ref). Run jscpd to detect duplicated code and measure duplication percentages before refactoring."
+metadata:
+  author: Tuan Duc Tran
+  version: "1.0.0"
+---
+
+# jscpd
+
+Copy-paste detector for source code. Use this skill to run jscpd against `packages/*` in this repo and understand its output before handing clones to [`dry-refactoring`](../dry-refactoring/SKILL.md).
+
+> Not to be confused with `packages/hr-skills-build/src/validation/detect-duplicates.ts`, which detects duplicated **HR skill content** (`skills/hr-*/SKILL.md`) at publish time. `jscpd` here targets **TypeScript source code** in `packages/*` only — keep the two concerns separate and never merge their logic.
+
+## Quick start
+
+This repo uses Bun, so prefer `bunx` over `npx`:
+
+```bash
+# Scope to the TypeScript packages only — skip skills/ (markdown) and generated output
+bunx jscpd@5 packages \
+  --format typescript \
+  --mode strict \
+  --min-lines 3 \
+  --min-tokens 20 \
+  --reporters console,json,markdown \
+  --output duplicate-report \
+  --ignore "**/node_modules/**,**/dist/**,**/*.md"
+
+# Compact output optimized for agents
+bunx jscpd@5 packages --reporters ai --format typescript
+```
+
+`duplicate-report/` is a generated artifact — do not commit it; add it to `.gitignore` if it isn't already covered.
+
+## AI reporter output format
+
+The `ai` reporter produces compact, token-efficient output:
+
+```text
+Clones:
+packages/hr-skills-build/src/ validate.ts:53-59 ~ security.ts:89-94
+---
+N clones · X% duplication
+```
+
+- **Same directory**: shared path prefix factored out
+- **Different paths**: full path shown for both sides
+
+## Options used in this repo
+
+| Option | Value here | Why |
+|--------|------------|-----|
+| `--format typescript` | scoped to `.ts` | `skills/**/*.md` content duplication is handled by `detect-duplicates.ts`, not jscpd |
+| `--mode strict` | exact-match clones | avoids false positives from formatting-only similarity (Biome already normalizes formatting) |
+| `--min-lines 3` / `--min-tokens 20` | low thresholds | this is a small, young codebase; catch clones early before they compound |
+| `--ignore` | `node_modules`, `dist`, `*.md` | matches `.gitignore` / build output conventions |
+
+Full option reference: `bunx jscpd@5 --help`, or the [upstream configuration docs](https://jscpd.dev/getting-started/configuration).
+
+## When to run
+
+- Before opening a PR that adds or edits code under `packages/hr-skills-build/src/**` or `packages/skills-ref/src/**`
+- After a large refactor, to confirm clones were actually eliminated (re-run, don't assume)
+- Optionally wired into `lefthook.yml` as a pre-push (not pre-commit — it's slower than `biome`) step; see [CI and hooks](https://jscpd.dev/ci-and-hooks) for the pattern this repo's `lefthook.yml` follows for other tools
+
+## Tips
+
+- Run jscpd against `packages/`, never against the full repo root — `skills/hr-*/SKILL.md` files are prompt content, not code, and will produce noisy, irrelevant clones.
+- Test files (`packages/*/test/**`) legitimately duplicate `describe`/`it`/`expect` scaffolding — don't chase 100% duplication-free tests. Prioritize `src/**` clones.
+- Hand the clone list to [`dry-refactoring`](../dry-refactoring/SKILL.md) rather than refactoring ad hoc; it enforces "extract, don't just rename."

--- a/.claude/commands/new-skill.md
+++ b/.claude/commands/new-skill.md
@@ -41,10 +41,7 @@ Use this exact template for `skills/<full-name>/SKILL.md` (canonical source: [`.
 ````markdown
 ---
 name: <full-name>
-description: >
-  A concise description of at least 50 characters that explains what this skill
-  covers and when to use it. Include HR trigger phrases such as "write a [task]",
-  "create a [deliverable]", or "analyze [topic]".
+description: "A concise description of at least 50 characters that explains what this skill covers and when to use it. Include HR trigger phrases such as write a [task], create a [deliverable], or analyze [topic]."
 metadata:
   author: Tuan Duc Tran
   version: "1.0.0"

--- a/.github/skill-template.md
+++ b/.github/skill-template.md
@@ -14,10 +14,7 @@ See [`docs/format.md`](../docs/format.md) for the full specification.
 ```markdown
 ---
 name: <full-name>
-description: >
-  A concise description of at least 50 characters that explains what this skill
-  covers and when to use it. Include HR trigger phrases such as "write a [task]",
-  "create a [deliverable]", or "analyze [topic]".
+description: "A concise description of at least 50 characters that explains what this skill covers and when to use it. Include HR trigger phrases such as write a [task], create a [deliverable], or analyze [topic]."
 metadata:
   author: Tuan Duc Tran
   version: "1.0.0"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 execution-plan.json
 execution-result.json
 eval-report.json
+duplicate-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ This file stays intentionally short. Everything below is a **workflow**, not a o
 | Security review of skill content | [`.agents/skills/skill-vetter/SKILL.md`](.agents/skills/skill-vetter/SKILL.md) |
 | Whether a change needs a changeset | [`.agents/skills/changeset/SKILL.md`](.agents/skills/changeset/SKILL.md) |
 | TypeScript, Biome, and Valibot conventions in `packages/*` | [`.agents/skills/typescript/SKILL.md`](.agents/skills/typescript/SKILL.md), [`.agents/skills/biome/SKILL.md`](.agents/skills/biome/SKILL.md), [`.agents/skills/valibot/SKILL.md`](.agents/skills/valibot/SKILL.md) |
+| CLI output patterns (`@clack/prompts`) in `src/cli/*.ts` | [`.agents/skills/clack/SKILL.md`](.agents/skills/clack/SKILL.md) |
+| Detecting and refactoring copy-paste duplication in `packages/*` | [`.agents/skills/jscpd/SKILL.md`](.agents/skills/jscpd/SKILL.md), [`.agents/skills/dry-refactoring/SKILL.md`](.agents/skills/dry-refactoring/SKILL.md) |
 | Everything above, indexed in one place | [`.agents/AGENTS.md`](.agents/AGENTS.md) |
 
 When you add a new skill directory (for example `skills/hr-new-skill/SKILL.md`), run `bun run sync` first — it auto-discovers `hr-*` skill directories from `skills/` and updates `.claude-plugin/marketplace.json`. No manual edits needed.

--- a/packages/hr-skills-build/src/cli/cli-bootstrap.ts
+++ b/packages/hr-skills-build/src/cli/cli-bootstrap.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared bootstrap helpers for `src/cli/*.ts` entry points.
+ *
+ * `execute-plan.ts`, `generate-plan.ts`, `run-evaluation.ts`, `discover.ts`,
+ * and `recommend.ts` each ended with the identical
+ * `main().catch((err) => { p.log.error(...); process.exit(1); })` block, and
+ * several also repeated the same "print usage, print an example, exit 1"
+ * shape when a required argument was missing (jscpd flagged multiple pairs
+ * across these files). Both now live here once.
+ */
+
+import * as p from '@clack/prompts';
+
+/**
+ * Run a CLI `main()` function, logging uncaught errors through `@clack/prompts`
+ * and exiting with status 1. Every `cli/*.ts` entry point should end with
+ * `runCli(main);` instead of hand-rolling its own `.catch(...)`.
+ */
+export function runCli(main: () => Promise<void>): void {
+	main().catch((err: unknown) => {
+		const message = err instanceof Error ? err.message : String(err);
+		p.log.error(`Error: ${message}`);
+		process.exit(1);
+	});
+}
+
+/**
+ * Print a "missing required argument" usage message (usage line + one
+ * example invocation) and exit with status 1. Call this when `value` is
+ * falsy; callers keep control of the exact wording since each CLI's usage
+ * differs, only the three-line shape is shared.
+ */
+export function printUsageAndExit(usageLine: string, exampleLine: string): never {
+	p.log.error(usageLine);
+	p.log.info('Example:');
+	p.log.message(exampleLine);
+	process.exit(1);
+}

--- a/packages/hr-skills-build/src/cli/discover.ts
+++ b/packages/hr-skills-build/src/cli/discover.ts
@@ -20,6 +20,7 @@ import type { SkillCategory } from '../registry/classifier.js';
 import { InvalidSearchQueryError, searchSkills } from '../search/search.js';
 import { ROOT_DIR } from '../shared/constants.js';
 import type { Registry, SkillSearchQuery } from '../shared/types.js';
+import { printUsageAndExit, runCli } from './cli-bootstrap.js';
 
 const REGISTRY_PATH = join(ROOT_DIR, 'registry', 'skills.json');
 
@@ -37,12 +38,10 @@ async function main() {
 	const text = process.argv[2];
 
 	if (!text || text.startsWith('--')) {
-		p.log.error(
+		printUsageAndExit(
 			'Usage: bun src/discover.ts "<query>" [--domain <domain>] [--limit N] [--no-fuzzy]',
+			'  bun src/discover.ts "onboard new hires"',
 		);
-		p.log.info('Example:');
-		p.log.message('  bun src/discover.ts "onboard new hires"');
-		process.exit(1);
 	}
 
 	const domain = parseFlag('domain') as SkillCategory | undefined;
@@ -92,7 +91,4 @@ async function main() {
 	}
 }
 
-main().catch((err) => {
-	p.log.error(`Error: ${err.message}`);
-	process.exit(1);
-});
+runCli(main);

--- a/packages/hr-skills-build/src/cli/execute-plan.ts
+++ b/packages/hr-skills-build/src/cli/execute-plan.ts
@@ -22,6 +22,7 @@ import { generateExecutionPlan } from '../planner/planner.js';
 import { buildRegistry } from '../registry/registry.js';
 import { executeWorkflow } from '../runtime/runtime.js';
 import type { ExecutionStep, RuntimeContext } from '../shared/types.js';
+import { printUsageAndExit, runCli } from './cli-bootstrap.js';
 
 /**
  * A stub step executor for CLI demonstration purposes. Real integrations
@@ -40,12 +41,10 @@ async function main() {
 	const intent = process.argv[2];
 
 	if (!intent) {
-		p.log.error('Usage: bun src/execute-plan.ts "<user intent>"');
-		p.log.info('Example:');
-		p.log.message(
+		printUsageAndExit(
+			'Usage: bun src/execute-plan.ts "<user intent>"',
 			'  bun src/execute-plan.ts "Create interview questions for a senior manager"',
 		);
-		process.exit(1);
 	}
 
 	p.intro('Workflow Runtime');
@@ -106,7 +105,4 @@ async function main() {
 	process.exit(result.status === 'completed' ? 0 : 1);
 }
 
-main().catch((err) => {
-	p.log.error(`Error: ${err.message}`);
-	process.exit(1);
-});
+runCli(main);

--- a/packages/hr-skills-build/src/cli/generate-plan.ts
+++ b/packages/hr-skills-build/src/cli/generate-plan.ts
@@ -17,17 +17,16 @@ import {
 	suggestPlanImprovements,
 	validateExecutionPlan,
 } from '../validation/validate-planner.js';
+import { printUsageAndExit, runCli } from './cli-bootstrap.js';
 
 async function main() {
 	const intent = process.argv[2];
 
 	if (!intent) {
-		p.log.error('Usage: bun src/generate-plan.ts "<user intent>"');
-		p.log.info('Example:');
-		p.log.message(
+		printUsageAndExit(
+			'Usage: bun src/generate-plan.ts "<user intent>"',
 			'  bun src/generate-plan.ts "Create interview questions for a senior manager"',
 		);
-		process.exit(1);
 	}
 
 	p.intro('Execution Plan Generator');
@@ -128,7 +127,4 @@ ${plan.notes && plan.notes.length > 0 ? `Notes:\n${plan.notes.map((note) => `  â
 	process.exit(validation.isValid ? 0 : 1);
 }
 
-main().catch((err) => {
-	p.log.error(`Error: ${err.message}`);
-	process.exit(1);
-});
+runCli(main);

--- a/packages/hr-skills-build/src/cli/recommend.ts
+++ b/packages/hr-skills-build/src/cli/recommend.ts
@@ -11,15 +11,16 @@
 import * as p from '@clack/prompts';
 import { buildRegistry, loadRelevanceSignalTable } from '../registry/registry.js';
 import { getRecommendations, UnknownSkillError } from '../search/recommendations.js';
+import { printUsageAndExit, runCli } from './cli-bootstrap.js';
 
 async function main() {
 	const skillId = process.argv[2];
 
 	if (!skillId) {
-		p.log.error('Usage: bun src/recommend.ts <skill-id> [--limit N]');
-		p.log.info('Example:');
-		p.log.message('  bun src/recommend.ts hr-onboarding');
-		process.exit(1);
+		printUsageAndExit(
+			'Usage: bun src/recommend.ts <skill-id> [--limit N]',
+			'  bun src/recommend.ts hr-onboarding',
+		);
 	}
 
 	const limitFlagIndex = process.argv.indexOf('--limit');
@@ -69,7 +70,4 @@ async function main() {
 	}
 }
 
-main().catch((err) => {
-	p.log.error(`Error: ${err.message}`);
-	process.exit(1);
-});
+runCli(main);

--- a/packages/hr-skills-build/src/cli/run-evaluation.ts
+++ b/packages/hr-skills-build/src/cli/run-evaluation.ts
@@ -22,6 +22,7 @@ import {
 } from '../evaluation/evaluation-datasets.js';
 import { buildRegistry } from '../registry/registry.js';
 import type { EvaluationReport } from '../shared/types.js';
+import { runCli } from './cli-bootstrap.js';
 
 async function main() {
 	const updateGolden = process.argv.includes('--update-golden');
@@ -105,7 +106,4 @@ async function main() {
 	process.exit(0);
 }
 
-main().catch((err) => {
-	p.log.error(`Error: ${err.message}`);
-	process.exit(1);
-});
+runCli(main);

--- a/packages/hr-skills-build/src/cli/skill-review.ts
+++ b/packages/hr-skills-build/src/cli/skill-review.ts
@@ -21,7 +21,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
-
+import { GITHUB_BLOB_BASE_URL } from '../shared/constants.js';
 import { readSkillContent } from '../shared/helpers.js';
 import type { SkillValidationIssue } from '../shared/types.js';
 import { type SkillQualityScore, scoreSkills } from '../validation/quality-scoring.js';
@@ -83,7 +83,7 @@ function renderReport(
 	lines.push('### 🔎 Deterministic skill review (skill-vetter + quality scoring)');
 	lines.push('');
 	lines.push(
-		'This is an automated, non-blocking report — a review aid, not a merge gate. See [`docs/quality-scoring.md`](../docs/quality-scoring.md) and [`.agents/skills/skill-vetter/SKILL.md`](../.agents/skills/skill-vetter/SKILL.md).',
+		`This is an automated, non-blocking report — a review aid, not a merge gate. See [\`docs/quality-scoring.md\`](${GITHUB_BLOB_BASE_URL}/docs/quality-scoring.md) and [\`.agents/skills/skill-vetter/SKILL.md\`](${GITHUB_BLOB_BASE_URL}/.agents/skills/skill-vetter/SKILL.md).`,
 	);
 	lines.push('');
 	lines.push('| Skill | Security | Quality |');

--- a/packages/hr-skills-build/src/shared/constants.ts
+++ b/packages/hr-skills-build/src/shared/constants.ts
@@ -9,6 +9,15 @@ export const ROOT_DIR = join(__dirname, '../../../..');
 /** Absolute path to the `skills/` directory at the repo root. */
 export const SKILLS_DIR = join(ROOT_DIR, 'skills');
 
+/**
+ * Base URL for linking to a file in this repo on GitHub, e.g. for use in
+ * generated Markdown that's posted somewhere with no "current file" context
+ * (a PR comment, a Slack message) where a relative link like `../docs/x.md`
+ * cannot resolve. Append a repo-root-relative path, e.g.
+ * `` `${GITHUB_BLOB_BASE_URL}/docs/quality-scoring.md` ``.
+ */
+export const GITHUB_BLOB_BASE_URL = 'https://github.com/tuanductran/hr-skills/blob/main';
+
 /** Matches a markdown task-list item line, e.g. `- some task`. */
 export const TASK_ITEM_REGEX = /^- /;
 

--- a/packages/hr-skills-build/src/validation/detect-duplicates.ts
+++ b/packages/hr-skills-build/src/validation/detect-duplicates.ts
@@ -50,11 +50,15 @@
  * warnings in the same order.
  */
 
-import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { FRONTMATTER_REGEX, SKILLS_DIR } from '../shared/constants.js';
-import { dirExists } from '../shared/helpers.js';
+import { SKILLS_DIR } from '../shared/constants.js';
 import type { SkillValidationIssue } from '../shared/types.js';
+import {
+	extractDescription,
+	readAllMarkdown,
+	readRawSkillMd,
+	stripFrontmatter,
+} from './skill-content-loading.js';
 
 // ---------------------------------------------------------------------------
 // Configuration — weights and thresholds
@@ -243,13 +247,6 @@ export const HR_STOP_WORDS = new Set([
 // ---------------------------------------------------------------------------
 
 /**
- * Strip YAML frontmatter from a markdown string.
- */
-function stripFrontmatter(text: string): string {
-	return text.replace(FRONTMATTER_REGEX, '').trim();
-}
-
-/**
  * Remove markdown syntax, code fences, URLs, and punctuation then lower-case.
  */
 function stripMarkdown(text: string): string {
@@ -336,65 +333,15 @@ export interface SkillContent {
 }
 
 /**
- * Extract the frontmatter `description` field from raw SKILL.md content.
- * Returns an empty string when the field is absent.
- */
-function extractDescription(raw: string): string {
-	const match = FRONTMATTER_REGEX.exec(raw);
-	if (!match?.[1]) return '';
-	// Look for `description:` — may span multiple lines with YAML folding
-	const descMatch = /^description:\s*(.+?)(?=\n\w|\n---)/ms.exec(match[1]);
-	return descMatch?.[1]?.replace(/\s+/g, ' ').trim() ?? '';
-}
-
-/**
- * Read all markdown files under `<skillDir>/content/` and return their
- * concatenated text.  Returns an empty string when the directory does not
- * exist or contains no markdown files.
- */
-async function readContentFiles(skillDir: string): Promise<string> {
-	const contentDir = join(skillDir, 'content');
-	if (!(await dirExists(contentDir))) return '';
-
-	let entries: string[];
-	try {
-		const raw = await readdir(contentDir, { withFileTypes: true });
-		entries = raw
-			.filter((e) => e.isFile() && e.name.endsWith('.md'))
-			.map((e) => e.name)
-			.sort(); // deterministic order
-	} catch {
-		return '';
-	}
-
-	const parts: string[] = [];
-	for (const entry of entries) {
-		try {
-			parts.push(await readFile(join(contentDir, entry), 'utf8'));
-		} catch {
-			// skip unreadable files
-		}
-	}
-	return parts.join('\n');
-}
-
-/**
  * Load one skill's textual content for comparison.
  */
 async function loadSkillContent(skillName: string): Promise<SkillContent> {
 	const skillDir = join(SKILLS_DIR, skillName);
-	const skillMdPath = join(skillDir, 'SKILL.md');
-
-	let raw = '';
-	try {
-		raw = await readFile(skillMdPath, 'utf8');
-	} catch {
-		// fall through — body will be empty
-	}
+	const raw = await readRawSkillMd(skillDir);
 
 	const description = extractDescription(raw);
 	const skillMdBody = stripFrontmatter(raw);
-	const contentBody = await readContentFiles(skillDir);
+	const contentBody = await readAllMarkdown(join(skillDir, 'content'));
 
 	return {
 		name: skillName,

--- a/packages/hr-skills-build/src/validation/issue-helpers.ts
+++ b/packages/hr-skills-build/src/validation/issue-helpers.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared helper for recording `SkillValidationIssue`s.
+ *
+ * Every validator in `validate.ts` and `security.ts` repeated the same
+ * `errors.push({ skill: skillName, message })` shape (jscpd flagged this as
+ * duplicated across 10+ locations). Extracted here so the shape only exists
+ * once — if `SkillValidationIssue` ever grows a field, only this file needs
+ * to change.
+ */
+
+import type { SkillValidationIssue } from '../shared/types.js';
+
+/**
+ * Record a validation issue for `skillName` on `errors`.
+ *
+ * Kept intentionally trivial — this is not a place for extra logic
+ * (formatting, dedupe, etc.). Callers stay responsible for deciding
+ * *whether* to report; this only standardizes *how*.
+ */
+export function pushIssue(
+	errors: SkillValidationIssue[],
+	skillName: string,
+	message: string,
+): void {
+	errors.push({ skill: skillName, message });
+}
+
+/** A single named pattern check, as used by the `security.ts` pattern lists. */
+export interface LabeledPattern {
+	pattern: RegExp;
+	label: string;
+}
+
+/**
+ * Test `text` against every entry in `patterns` and report one issue per
+ * match via `messageFor(label)`.
+ *
+ * `security.ts` had this same `for (const { pattern, label } of LIST) { if
+ * (pattern.test(text)) { ...push... } }` shape in three places
+ * (`validateSecurityCommands`, `validateSensitivePaths`,
+ * `validateCredentialLeaks`) — jscpd flagged each pair. Each caller keeps its
+ * own list and message wording; only the iterate-and-report shape is shared.
+ */
+export function checkPatternList(
+	errors: SkillValidationIssue[],
+	skillName: string,
+	text: string,
+	patterns: readonly LabeledPattern[],
+	messageFor: (label: string) => string,
+): void {
+	for (const { pattern, label } of patterns) {
+		if (pattern.test(text)) {
+			pushIssue(errors, skillName, messageFor(label));
+		}
+	}
+}

--- a/packages/hr-skills-build/src/validation/security.ts
+++ b/packages/hr-skills-build/src/validation/security.ts
@@ -13,6 +13,7 @@
  */
 
 import type { SkillValidationIssue } from '../shared/types.js';
+import { checkPatternList, pushIssue } from './issue-helpers.js';
 
 // ---------------------------------------------------------------------------
 // 1. Dangerous shell command patterns
@@ -60,14 +61,14 @@ export function validateSecurityCommands(
 	const blocks = [...content.matchAll(codeBlockRegex)].map((m) => m[1] ?? '');
 
 	for (const block of blocks) {
-		for (const { pattern, label } of DANGEROUS_COMMANDS) {
-			if (pattern.test(block)) {
-				errors.push({
-					skill: skillName,
-					message: `Security: dangerous shell pattern detected in code block — ${label}`,
-				});
-			}
-		}
+		checkPatternList(
+			errors,
+			skillName,
+			block,
+			DANGEROUS_COMMANDS,
+			(label) =>
+				`Security: dangerous shell pattern detected in code block — ${label}`,
+		);
 	}
 }
 
@@ -96,14 +97,13 @@ export function validateSensitivePaths(
 
 	if (!codeOnly) return;
 
-	for (const { pattern, label } of SENSITIVE_PATHS) {
-		if (pattern.test(codeOnly)) {
-			errors.push({
-				skill: skillName,
-				message: `Security: sensitive path write detected in code block — ${label}`,
-			});
-		}
-	}
+	checkPatternList(
+		errors,
+		skillName,
+		codeOnly,
+		SENSITIVE_PATHS,
+		(label) => `Security: sensitive path write detected in code block — ${label}`,
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -178,13 +178,13 @@ export function validateSuspiciousUrls(
 				continue;
 			}
 
-			errors.push({
-				skill: skillName,
-				message:
-					suspicious === 'raw IP address'
-						? 'Security: raw IP address URL found'
-						: `Security: suspicious external host detected — "${suspicious}"`,
-			});
+			pushIssue(
+				errors,
+				skillName,
+				suspicious === 'raw IP address'
+					? 'Security: raw IP address URL found'
+					: `Security: suspicious external host detected — "${suspicious}"`,
+			);
 		} catch {
 			// Ignore malformed URLs.
 		}
@@ -192,10 +192,11 @@ export function validateSuspiciousUrls(
 
 	// requestbin is commonly referenced as plain text instead of a hostname.
 	if (/\brequestbin\b/i.test(content)) {
-		errors.push({
-			skill: skillName,
-			message: 'Security: suspicious external host detected — "requestbin"',
-		});
+		pushIssue(
+			errors,
+			skillName,
+			'Security: suspicious external host detected — "requestbin"',
+		);
 	}
 }
 
@@ -235,14 +236,13 @@ export function validateCredentialLeaks(
 	content: string,
 	errors: SkillValidationIssue[],
 ): void {
-	for (const { pattern, label } of CREDENTIAL_PATTERNS) {
-		if (pattern.test(content)) {
-			errors.push({
-				skill: skillName,
-				message: `Security: ${label} detected — remove or replace with a placeholder`,
-			});
-		}
-	}
+	checkPatternList(
+		errors,
+		skillName,
+		content,
+		CREDENTIAL_PATTERNS,
+		(label) => `Security: ${label} detected — remove or replace with a placeholder`,
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -268,11 +268,11 @@ export function validateHiddenUnicode(
 ): void {
 	for (const pattern of HIDDEN_UNICODE_RANGES) {
 		if (pattern.test(content)) {
-			errors.push({
-				skill: skillName,
-				message:
-					'Security: hidden Unicode character detected — potential prompt injection or encoding attack',
-			});
+			pushIssue(
+				errors,
+				skillName,
+				'Security: hidden Unicode character detected — potential prompt injection or encoding attack',
+			);
 			// Report once per skill, not once per character type
 			return;
 		}

--- a/packages/hr-skills-build/src/validation/semantic-validation.ts
+++ b/packages/hr-skills-build/src/validation/semantic-validation.ts
@@ -68,10 +68,15 @@
  * files already read from disk.
  */
 
-import { readdir, readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { SkillValidationIssue } from '../shared/types.js';
 import { jaccardSimilarity, tokenise } from './detect-duplicates.js';
+import {
+	extractDescription,
+	readAllMarkdown,
+	readRawSkillMd,
+	stripFrontmatter,
+} from './skill-content-loading.js';
 
 // ---------------------------------------------------------------------------
 // Configuration — thresholds
@@ -148,56 +153,6 @@ export interface SkillSemanticContent {
 	hasExamples: boolean;
 }
 
-async function dirExists(path: string): Promise<boolean> {
-	try {
-		return (await stat(path)).isDirectory();
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Read and concatenate all `.md` files directly inside `dir`, in
- * alphabetical filename order. Returns an empty string when the directory
- * does not exist or contains no markdown files.
- */
-async function readAllMarkdown(dir: string): Promise<string> {
-	if (!(await dirExists(dir))) return '';
-
-	let entries: string[];
-	try {
-		entries = (await readdir(dir, { withFileTypes: true }))
-			.filter((e) => e.isFile() && e.name.endsWith('.md'))
-			.map((e) => e.name)
-			.sort();
-	} catch {
-		return '';
-	}
-
-	const parts: string[] = [];
-	for (const entry of entries) {
-		try {
-			parts.push(await readFile(join(dir, entry), 'utf8'));
-		} catch {
-			// skip unreadable files
-		}
-	}
-	return parts.join('\n');
-}
-
-/** Extract the frontmatter `description` field from raw SKILL.md content. */
-function extractDescription(raw: string): string {
-	const frontmatterMatch = /^---\r?\n([\s\S]*?)\r?\n---/.exec(raw);
-	if (!frontmatterMatch?.[1]) return '';
-	const descMatch = /^description:\s*(.+?)(?=\n\w|\n---)/ms.exec(frontmatterMatch[1]);
-	return descMatch?.[1]?.replace(/\s+/g, ' ').trim() ?? '';
-}
-
-/** Strip YAML frontmatter from a markdown string. */
-function stripFrontmatter(raw: string): string {
-	return raw.replace(/^---\r?\n[\s\S]*?\r?\n---/, '').trim();
-}
-
 /**
  * Load one skill's semantic content: purpose/prompts/examples token sets.
  *
@@ -209,14 +164,7 @@ export async function loadSkillSemanticContent(
 	skillName: string,
 ): Promise<SkillSemanticContent> {
 	const skillDir = join(skillsDir, skillName);
-	const skillMdPath = join(skillDir, 'SKILL.md');
-
-	let raw = '';
-	try {
-		raw = await readFile(skillMdPath, 'utf8');
-	} catch {
-		// fall through — everything stays empty
-	}
+	const raw = await readRawSkillMd(skillDir);
 
 	const description = extractDescription(raw);
 	const body = stripFrontmatter(raw);

--- a/packages/hr-skills-build/src/validation/skill-content-loading.ts
+++ b/packages/hr-skills-build/src/validation/skill-content-loading.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared SKILL.md content loading/parsing helpers.
+ *
+ * `detect-duplicates.ts` and `semantic-validation.ts` each re-implemented
+ * `extractDescription`, `stripFrontmatter`, and a "read every .md file in a
+ * directory, sorted, concatenated" helper (jscpd flagged all three as
+ * duplicated). Both now import from here instead.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { FRONTMATTER_REGEX } from '../shared/constants.js';
+import { dirExists } from '../shared/helpers.js';
+
+/**
+ * Extract the frontmatter `description` field from raw SKILL.md content.
+ * Returns an empty string when the field or frontmatter block is absent.
+ */
+export function extractDescription(raw: string): string {
+	const frontmatterMatch = FRONTMATTER_REGEX.exec(raw);
+	if (!frontmatterMatch?.[1]) return '';
+	const descMatch = /^description:\s*(.+?)(?=\n\w|\n---)/ms.exec(frontmatterMatch[1]);
+	return descMatch?.[1]?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+/**
+ * Strip YAML frontmatter from a markdown string.
+ */
+export function stripFrontmatter(text: string): string {
+	return text.replace(FRONTMATTER_REGEX, '').trim();
+}
+
+/**
+ * Read and concatenate all `.md` files directly inside `dir`, in
+ * alphabetical filename order. Returns an empty string when the directory
+ * does not exist or contains no markdown files.
+ */
+export async function readAllMarkdown(dir: string): Promise<string> {
+	if (!(await dirExists(dir))) return '';
+
+	let entries: string[];
+	try {
+		entries = (await readdir(dir, { withFileTypes: true }))
+			.filter((e) => e.isFile() && e.name.endsWith('.md'))
+			.map((e) => e.name)
+			.sort(); // deterministic order
+	} catch {
+		return '';
+	}
+
+	const parts: string[] = [];
+	for (const entry of entries) {
+		try {
+			parts.push(await readFile(join(dir, entry), 'utf8'));
+		} catch {
+			// skip unreadable files
+		}
+	}
+	return parts.join('\n');
+}
+
+/**
+ * Read a skill's raw `SKILL.md` file. Returns an empty string (rather than
+ * throwing) when the file is missing or unreadable — callers treat that as
+ * "everything derived from this skill stays empty" instead of failing.
+ */
+export async function readRawSkillMd(skillDir: string): Promise<string> {
+	try {
+		return await readFile(join(skillDir, 'SKILL.md'), 'utf8');
+	} catch {
+		return '';
+	}
+}

--- a/packages/hr-skills-build/src/validation/validate.ts
+++ b/packages/hr-skills-build/src/validation/validate.ts
@@ -28,6 +28,7 @@ import {
 import { parseSkillFrontmatter } from '../shared/parser.js';
 import type { SkillValidationIssue } from '../shared/types.js';
 import { detectDuplicates } from './detect-duplicates.js';
+import { pushIssue } from './issue-helpers.js';
 import {
 	validateCredentialLeaks,
 	validateHiddenUnicode,
@@ -52,10 +53,7 @@ function validateCore(
 	const refErrors = validateRef(skillDir);
 
 	for (const error of refErrors) {
-		errors.push({
-			skill: skillName,
-			message: `Core validation error: ${error}`,
-		});
+		pushIssue(errors, skillName, `Core validation error: ${error}`);
 	}
 }
 
@@ -70,36 +68,29 @@ export function validateFrontmatter(
 	const frontmatter = parseSkillFrontmatter(content);
 
 	if (!frontmatter.name) {
-		errors.push({
-			skill: skillName,
-			message: 'Missing frontmatter: name',
-		});
+		pushIssue(errors, skillName, 'Missing frontmatter: name');
 	} else if (frontmatter.name !== skillName) {
-		errors.push({
-			skill: skillName,
-			message: `Frontmatter name mismatch: expected "${skillName}", received "${frontmatter.name}"`,
-		});
+		pushIssue(
+			errors,
+			skillName,
+			`Frontmatter name mismatch: expected "${skillName}", received "${frontmatter.name}"`,
+		);
 	}
 
 	if (!frontmatter.description) {
-		errors.push({
-			skill: skillName,
-			message: 'Missing frontmatter: description',
-		});
+		pushIssue(errors, skillName, 'Missing frontmatter: description');
 	} else if (frontmatter.description.length < MIN_DESCRIPTION_LENGTH) {
-		errors.push({
-			skill: skillName,
-			message: `Description is too short (minimum ${MIN_DESCRIPTION_LENGTH} characters)`,
-		});
+		pushIssue(
+			errors,
+			skillName,
+			`Description is too short (minimum ${MIN_DESCRIPTION_LENGTH} characters)`,
+		);
 	}
 
 	validateAuthor(skillName, frontmatter.metadata?.author, errors);
 
 	if (!frontmatter.metadata?.version) {
-		errors.push({
-			skill: skillName,
-			message: 'Missing metadata.version',
-		});
+		pushIssue(errors, skillName, 'Missing metadata.version');
 	}
 }
 
@@ -113,10 +104,7 @@ export function validateRequiredSections(
 ): void {
 	for (const section of REQUIRED_SECTIONS) {
 		if (!content.includes(section)) {
-			errors.push({
-				skill: skillName,
-				message: `Missing required section: ${section}`,
-			});
+			pushIssue(errors, skillName, `Missing required section: ${section}`);
 		}
 	}
 }
@@ -130,10 +118,11 @@ export function validateContentLength(
 	errors: SkillValidationIssue[],
 ): void {
 	if (content.length < MIN_CONTENT_LENGTH) {
-		errors.push({
-			skill: skillName,
-			message: `SKILL.md is too short (minimum ${MIN_CONTENT_LENGTH} characters)`,
-		});
+		pushIssue(
+			errors,
+			skillName,
+			`SKILL.md is too short (minimum ${MIN_CONTENT_LENGTH} characters)`,
+		);
 	}
 }
 
@@ -148,10 +137,11 @@ export function validateLineCount(
 	const lines = content.split(/\r?\n/);
 
 	if (lines.length > 500) {
-		errors.push({
-			skill: skillName,
-			message: `SKILL.md body is too long (${lines.length} lines, maximum 500 lines allowed)`,
-		});
+		pushIssue(
+			errors,
+			skillName,
+			`SKILL.md body is too long (${lines.length} lines, maximum 500 lines allowed)`,
+		);
 	}
 }
 
@@ -170,10 +160,11 @@ export function validateSupportedTasks(
 		.filter((line) => line.trim().startsWith('- '));
 
 	if (tasks.length < 8 || tasks.length > 12) {
-		errors.push({
-			skill: skillName,
-			message: `Supported tasks section has ${tasks.length} tasks (expected 8-12 tasks)`,
-		});
+		pushIssue(
+			errors,
+			skillName,
+			`Supported tasks section has ${tasks.length} tasks (expected 8-12 tasks)`,
+		);
 	}
 }
 
@@ -190,10 +181,11 @@ export function validateTips(
 	const tips = tipsBlock.split(/\r?\n/).filter((line) => line.trim().startsWith('- '));
 
 	if (tips.length < 4 || tips.length > 6) {
-		errors.push({
-			skill: skillName,
-			message: `Tips section has ${tips.length} tips (expected 4-6 tips)`,
-		});
+		pushIssue(
+			errors,
+			skillName,
+			`Tips section has ${tips.length} tips (expected 4-6 tips)`,
+		);
 	}
 }
 
@@ -226,10 +218,11 @@ export function validateBlankLines(
 				trimmedNextLine.startsWith('* ') ||
 				/^\d+\.\s/.test(trimmedNextLine)
 			) {
-				errors.push({
-					skill: skillName,
-					message: `Missing blank line after heading/label "${trimmedCurrentLine}" on line ${i + 1} before the list on line ${i + 2}`,
-				});
+				pushIssue(
+					errors,
+					skillName,
+					`Missing blank line after heading/label "${trimmedCurrentLine}" on line ${i + 1} before the list on line ${i + 2}`,
+				);
 			}
 		}
 	}
@@ -244,20 +237,18 @@ export function validateAuthor(
 	errors: SkillValidationIssue[],
 ): void {
 	if (!author?.trim()) {
-		errors.push({
-			skill: skillName,
-			message: 'Missing metadata.author',
-		});
+		pushIssue(errors, skillName, 'Missing metadata.author');
 		return;
 	}
 
 	const normalized = normalizeAuthorName(author);
 
 	if (author !== normalized) {
-		errors.push({
-			skill: skillName,
-			message: `metadata.author must use Title Case (expected "${normalized}", received "${author}")`,
-		});
+		pushIssue(
+			errors,
+			skillName,
+			`metadata.author must use Title Case (expected "${normalized}", received "${author}")`,
+		);
 	}
 }
 
@@ -280,10 +271,11 @@ export function validatePromptStructure(
 		.filter(Boolean);
 
 	if (subtopicBlocks.length < 3 || subtopicBlocks.length > 6) {
-		errors.push({
-			skill: skillName,
-			message: `Key prompts section has ${subtopicBlocks.length} subtopic(s) — expected 3-6`,
-		});
+		pushIssue(
+			errors,
+			skillName,
+			`Key prompts section has ${subtopicBlocks.length} subtopic(s) — expected 3-6`,
+		);
 	}
 
 	for (const block of subtopicBlocks) {
@@ -292,10 +284,11 @@ export function validatePromptStructure(
 		const prompts = [...block.matchAll(QUOTED_PROMPT_REGEX)];
 
 		if (prompts.length < 4 || prompts.length > 7) {
-			errors.push({
-				skill: skillName,
-				message: `Key prompts subtopic "${subtopicName}" has ${prompts.length} prompt(s) — expected 4-7`,
-			});
+			pushIssue(
+				errors,
+				skillName,
+				`Key prompts subtopic "${subtopicName}" has ${prompts.length} prompt(s) — expected 4-7`,
+			);
 		}
 	}
 }
@@ -319,11 +312,11 @@ export async function validateRouterConsistency(
 		const json = JSON.parse(raw) as { plugins?: Array<{ name?: string }> };
 		marketplaceNames = (json.plugins ?? []).map((p) => p.name ?? '').filter(Boolean);
 	} catch {
-		errors.push({
-			skill: '(consistency)',
-			message:
-				'Could not read .claude-plugin/marketplace.json for consistency check',
-		});
+		pushIssue(
+			errors,
+			'(consistency)',
+			'Could not read .claude-plugin/marketplace.json for consistency check',
+		);
 		return;
 	}
 
@@ -338,10 +331,11 @@ export async function validateRouterConsistency(
 			if (match[1]) routerNames.push(match[1]);
 		}
 	} catch {
-		errors.push({
-			skill: '(consistency)',
-			message: 'Could not read root SKILL.md for consistency check',
-		});
+		pushIssue(
+			errors,
+			'(consistency)',
+			'Could not read root SKILL.md for consistency check',
+		);
 		return;
 	}
 
@@ -352,40 +346,44 @@ export async function validateRouterConsistency(
 	// Filesystem → marketplace
 	for (const name of fsSet) {
 		if (!marketplaceSet.has(name)) {
-			errors.push({
-				skill: name,
-				message: `In skills/ directory but missing from marketplace.json — run "bun run sync"`,
-			});
+			pushIssue(
+				errors,
+				name,
+				`In skills/ directory but missing from marketplace.json — run "bun run sync"`,
+			);
 		}
 	}
 
 	// Marketplace → filesystem
 	for (const name of marketplaceSet) {
 		if (!fsSet.has(name)) {
-			errors.push({
-				skill: name,
-				message: `In marketplace.json but missing from skills/ directory`,
-			});
+			pushIssue(
+				errors,
+				name,
+				`In marketplace.json but missing from skills/ directory`,
+			);
 		}
 	}
 
 	// Filesystem → router
 	for (const name of fsSet) {
 		if (!routerSet.has(name)) {
-			errors.push({
-				skill: name,
-				message: `In skills/ directory but missing from root SKILL.md router — update the router`,
-			});
+			pushIssue(
+				errors,
+				name,
+				`In skills/ directory but missing from root SKILL.md router — update the router`,
+			);
 		}
 	}
 
 	// Router → filesystem
 	for (const name of routerSet) {
 		if (!fsSet.has(name)) {
-			errors.push({
-				skill: name,
-				message: `In root SKILL.md router but missing from skills/ directory — dead link in router`,
-			});
+			pushIssue(
+				errors,
+				name,
+				`In root SKILL.md router but missing from skills/ directory — dead link in router`,
+			);
 		}
 	}
 }
@@ -403,10 +401,11 @@ export async function validateSubdirectoryContents(
 		if (await dirExists(subPath)) {
 			const fileCount = await countFiles(subPath);
 			if (fileCount === 0) {
-				errors.push({
-					skill: skillName,
-					message: `Empty subdirectory "${subDir}/" is not allowed — must contain at least one .md file`,
-				});
+				pushIssue(
+					errors,
+					skillName,
+					`Empty subdirectory "${subDir}/" is not allowed — must contain at least one .md file`,
+				);
 			}
 		}
 	}


### PR DESCRIPTION
- Install .agents/skills/jscpd, .agents/skills/dry-refactoring (from kucherenko/jscpd) and .agents/skills/clack (for @clack/prompts), rewritten/grounded in actual repo usage and indexed in AGENTS.md / .agents/AGENTS.md. clack skill documents that this repo only uses intro/outro/spinner/note/log.* (no interactive prompts, no isCancel) since every CLI here is single-shot and scriptable.
- Extract validation/issue-helpers.ts (pushIssue, checkPatternList) to remove the errors.push({ skill, message }) and pattern-match-loop shapes duplicated ~10x across security.ts and validate.ts.
- Extract validation/skill-content-loading.ts (extractDescription, stripFrontmatter, dirExists, readAllMarkdown) to remove duplication between detect-duplicates.ts and semantic-validation.ts.
- Extract cli/cli-bootstrap.ts (runCli, printUsageAndExit) to remove the repeated main().catch(...) and usage-message-then-exit blocks across execute-plan.ts, generate-plan.ts, run-evaluation.ts, discover.ts, and recommend.ts.
- Fix corrupted bold markup (**word*- -> **word**) in .agents/skills/changeset/SKILL.md.
- Fix cli/skill-review.ts's generated PR-comment report: relative links (../docs/...) don't resolve in a GitHub PR comment body; added shared/constants.ts#GITHUB_BLOB_BASE_URL and switched to absolute GitHub blob URLs.
- Fix .github/skill-template.md and .claude/commands/new-skill.md: the description field used a YAML folded block scalar, contradicting docs/format.md's documented format and every one of the 146 real skills, all of which use a single double-quoted line.

jscpd (packages/, TypeScript, strict mode): 227 -> 218 clone pairs.

Verified: bun run typecheck, test (436/436), lint, lint:md, lint:links, validate (146/146), build all pass.