### PR TITLE
fix(planner): eliminate polynomial ReDoS in analyzeIntent

### DIFF
--- a/packages/hr-skills-build/src/planner/planner.ts
+++ b/packages/hr-skills-build/src/planner/planner.ts
@@ -54,11 +54,15 @@ export function analyzeIntent(intent: string): string[] {
 		return [];
 	}
 
-	const normalized = intent.toLowerCase().trim();
+	const normalized = intent.toLowerCase().trim().replace(/\s+/g, ' ');
 
-	// Split on common delimiters
+	// Split on common delimiters. Whitespace was already collapsed to single
+	// spaces above, so the delimiters below use literal ' ' rather than '\s+'
+	// — a polynomial-time regex (CodeQL js/polynomial-redos) previously here
+	// let '\s+' before the and|or|then alternation backtrack over every
+	// possible split of a run of spaces before failing.
 	const parts = normalized
-		.split(/[,;]|(?:\s+(?:and|or|then)\s+)/i)
+		.split(/ ?[,;] ?| (?:and|or|then) /i)
 		.map((part) => part.trim())
 		.filter(Boolean);
 


### PR DESCRIPTION
Fixes CodeQL alert js/polynomial-redos (CWE-1333/400/730): https://github.com/tuanductran/hr-skills/security/code-scanning/16

analyzeIntent's delimiter split used /[,;]|(?:\s+(?:and|or|then)\s+)/i. The \s+ before the and|or|then alternation lets the regex engine backtrack over every possible split of a run of spaces before failing to match, giving polynomial-time behavior on input with many repeated spaces. intent is user-controlled (CLI plan/execute argv), so this was a real DoS surface.

Fix: collapse whitespace runs to a single space first, then match literal single spaces instead of the ambiguous \s+ quantifier, removing the backtracking ambiguity entirely.

Verified: split output unchanged for all existing test cases; 50,000 consecutive spaces now processes in ~2.5ms (previously polynomial blowup). typecheck, test (436/436), lint all pass.