### PR TITLE
chore: normalize comments & docs, switch examples to 'bun run'

### DIFF
--- a/.agents/skills/clack/SKILL.md
+++ b/.agents/skills/clack/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # clack
 
-Repository guidance for [`@clack/prompts`](https://github.com/bombshell-dev/clack) (`^1.7.0`, see `package.json`) as used across `packages/hr-skills-build/src/cli/*.ts` and `src/build/sync.ts`.
+Repository guidance for [`@clack/prompts`](https://github.com/bombshell-dev/clack) (`^1.7.0`, see `package.json`) as used across `packages/hr-skills-build/src/cli/*.ts` and `packages/hr-skills-build/src/build/packages/hr-skills-build/src/build/sync.ts`.
 
 > **This repo's clack usage is narrow and deliberate.** Every CLI here (`discover`, `recommend`, `execute-plan`, `generate-plan`, `run-evaluation`, `sync`, `validate`) is a single-shot, non-interactive script driven by `process.argv` — none of them collect input via clack's interactive prompts. Full upstream docs: [Getting Started](https://bomb.sh/docs/clack/basics/getting-started/), [Prompts](https://bomb.sh/docs/clack/packages/prompts/), [Best Practices](https://bomb.sh/docs/clack/guides/best-practices/).
 
@@ -22,7 +22,7 @@ Only five clack APIs appear anywhere in this codebase — confirmed by grepping 
 | `p.outro(message)` | Announce completion at end | Every `cli/*.ts` entry point |
 | `p.spinner()` / `.start()` / `.stop()` | Show progress during `buildRegistry()`, plan generation, etc. | `execute-plan.ts`, `generate-plan.ts`, `recommend.ts` |
 | `p.note(message, title?)` | Print a multi-line info block (search results, recommendations) | `discover.ts`, `recommend.ts` |
-| `p.log.{info,error,warn,success,message}` | Single-line status/error output | All `cli/*.ts`, routed through `cli/cli-bootstrap.ts` |
+| `p.log.{info,error,warn,success,message}` | Single-line status/error output | All `cli/*.ts`, routed through `packages/hr-skills-build/src/cli/packages/hr-skills-build/src/cli/cli-bootstrap.ts` |
 
 ## What this repo does NOT use — do not introduce it
 
@@ -34,7 +34,7 @@ If a future CLI genuinely needs interactive input, that's a deliberate scope cha
 
 ## Repository pattern
 
-Every CLI entry point in `src/cli/*.ts` follows this shape (see `cli/cli-bootstrap.ts`):
+Every CLI entry point in `src/cli/*.ts` follows this shape (see `packages/hr-skills-build/src/cli/packages/hr-skills-build/src/cli/cli-bootstrap.ts`):
 
 ```typescript
 import * as p from '@clack/prompts';
@@ -44,8 +44,8 @@ async function main() {
 	const intent = process.argv[2];
 	if (!intent) {
 		printUsageAndExit(
-			'Usage: bun src/my-command.ts "<argument>"',
-			'  bun src/my-command.ts "example"',
+			'Usage: bun run my-command "<argument>"',
+			'  bun run my-command "example"',
 		);
 	}
 

--- a/.agents/skills/jscpd/SKILL.md
+++ b/.agents/skills/jscpd/SKILL.md
@@ -51,7 +51,7 @@ N clones · X% duplication
 
 | Option | Value here | Why |
 |--------|------------|-----|
-| `--format typescript` | scoped to `.ts` | `skills/**/*.md` content duplication is handled by `detect-duplicates.ts`, not jscpd |
+| `--format typescript` | scoped to `.ts` | `skills/**/*.md` content duplication is handled by `packages/hr-skills-build/src/validation/detect-duplicates.ts`, not jscpd |
 | `--mode strict` | exact-match clones | avoids false positives from formatting-only similarity (Biome already normalizes formatting) |
 | `--min-lines 3` / `--min-tokens 20` | low thresholds | this is a small, young codebase; catch clones early before they compound |
 | `--ignore` | `node_modules`, `dist`, `*.md` | matches `.gitignore` / build output conventions |

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -67,7 +67,7 @@ they govern, rather than being duplicated here:
 | --- | --- |
 | New or updated skill | [`docs/contributing/skill-authoring.md`](docs/contributing/skill-authoring.md), [`docs/format.md`](docs/format.md) |
 | Documentation | [`docs/contributing/workflow.md`](docs/contributing/workflow.md), this repository's Markdown/link-lint conventions |
-| Tooling / tests (`packages/*`) | `CONTRIBUTING.md`'s "Improving the build tooling" section, `AGENTS.md`'s Project structure table |
+| Tooling / tests (`packages/*`) | `./CONTRIBUTING.md`'s "Improving the build tooling" section, `AGENTS.md`'s Project structure table |
 | Pull requests (general) | `.github/pull_request_template.md`, `AGENTS.md`'s branch and commit conventions |
 
 If you're unsure which applies, start at

--- a/docs/duplicate-detection.md
+++ b/docs/duplicate-detection.md
@@ -165,7 +165,7 @@ Duplicate detection runs automatically as part of the standard validation comman
 ```bash
 bun run validate          # from repo root
 # or
-bun src/validate.ts       # from packages/hr-skills-build/
+bun run validate       # from packages/hr-skills-build/
 ```
 
 Warnings are printed after per-skill validation results and before the final pass/fail summary.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -134,13 +134,13 @@ Because the Planner and Runtime are both pure/deterministic (no wall-clock times
 bun run evaluate
 ```
 
-This builds the Skill Registry, loads every dataset in `eval/datasets/`, runs each case, diffs it against the matching `eval/golden/*.golden.json` fixture, prints per-case results and the aggregated quality metrics, and writes the full report to `eval-report.json`. Exit code is `0` when every case is regression-free and every plan is valid, `1` otherwise.
+This builds the Skill Registry, loads every dataset in `eval/datasets/`, runs each case, diffs it against the matching `eval/golden/*.golden.json` fixture, prints per-case results and the aggregated quality metrics, and writes the full report to `packages/hr-skills-build/eval-report.json`. Exit code is `0` when every case is regression-free and every plan is valid, `1` otherwise.
 
 To regenerate golden fixtures after an intentional change to the Planner, Runtime, or skill content (a new skill, a renamed capability, and so on), run the script directly from `packages/hr-skills-build` (the `bun run evaluate` root alias does not forward flags through Turborepo):
 
 ```bash
 cd packages/hr-skills-build
-bun src/run-evaluation.ts --update-golden
+bun run evaluate -- --update-golden
 ```
 
 Review the diff on `eval/golden/*.golden.json` in the resulting commit like any other code change — a `skillIds` change there is exactly the signal that a golden fixture would otherwise catch as a regression, so it deserves the same scrutiny.

--- a/docs/planner.md
+++ b/docs/planner.md
@@ -155,7 +155,7 @@ The `reason` field is crucial for explainability — it tells future developers 
 Generate a plan and save to `execution-plan.json`:
 
 ```bash
-bun src/generate-plan.ts "create interview questions for a senior manager"
+bun run plan "create interview questions for a senior manager"
 ```
 
 Output includes:

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -155,7 +155,7 @@ every other validator in `validate.ts`.
 ## Build integration
 
 - `packages/hr-skills-build/package.json` — `registry` script
-  (`bun src/generate-registry.ts`)
+  (`bun run registry`)
 - root `package.json` — `registry` script (`turbo run registry --filter=hr-skills-build`)
 - `turbo.jsonc` — `registry` task (uncached, output `registry/skills.json`)
 - `.github/workflows/matrix.yml` — regenerates and commits

--- a/docs/semantic-validation.md
+++ b/docs/semantic-validation.md
@@ -192,7 +192,7 @@ command, immediately after duplicate-content detection:
 ```bash
 bun run validate          # from repo root
 # or
-bun src/validate.ts       # from packages/hr-skills-build/
+bun run validate       # from packages/hr-skills-build/
 ```
 
 Warnings from duplicate detection and semantic validation are merged into

--- a/docs/usage-informed-relevance.md
+++ b/docs/usage-informed-relevance.md
@@ -148,7 +148,7 @@ signal values.
 ```bash
 bun run signals
 # or, from packages/hr-skills-build:
-bun src/generate-relevance-signals.ts
+bun run signals
 ```
 
 Regenerate whenever golden fixtures change (after `bun run evaluate

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ replace `SKILL.md` content, they orchestrate it.
 
 | Example | What it demonstrates |
 | --- | --- |
-| [`planner-runtime/from-intent-to-execution.md`](planner-runtime/from-intent-to-execution.md) | Turning one of the scenarios above into an `ExecutionPlan` with `bun src/generate-plan.ts`, then running it with `bun src/execute-plan.ts`, reading the resulting trace |
+| [`planner-runtime/from-intent-to-execution.md`](planner-runtime/from-intent-to-execution.md) | Turning one of the scenarios above into an `ExecutionPlan` with `bun run plan`, then running it with `bun run execute`, reading the resulting trace |
 
 ## Conventions used across these examples
 

--- a/examples/planner-runtime/from-intent-to-execution.md
+++ b/examples/planner-runtime/from-intent-to-execution.md
@@ -17,7 +17,7 @@ skills to load and *in what order*, rather than a person manually choosing
 ## Step 1 — Generate a plan from intent
 
 ```bash
-bun src/generate-plan.ts "hire a senior backend engineer: write the job description, run interviews, and prepare an offer"
+bun run plan "hire a senior backend engineer: write the job description, run interviews, and prepare an offer"
 ```
 
 The Planner (`packages/hr-skills-build/src/planner/planner.ts`) splits this intent
@@ -78,7 +78,7 @@ dependency violations) before you act on it.
 ## Step 2 — Execute the plan
 
 ```bash
-bun src/execute-plan.ts "hire a senior backend engineer: write the job description, run interviews, and prepare an offer"
+bun run execute "hire a senior backend engineer: write the job description, run interviews, and prepare an offer"
 ```
 
 `execute-plan.ts` regenerates the same plan and runs it through

--- a/packages/hr-skills-build/README.md
+++ b/packages/hr-skills-build/README.md
@@ -42,7 +42,7 @@ Checks every `skills/hr-*/SKILL.md` for:
 - Required sections: `## Supported tasks`, `## Key prompts`, `## Tips`
 - Minimum content length of 1 000 characters
 - `SKILL.md` body length under 500 lines
-- `metadata.author` exactly set to `Tuan Duc Tran`
+- `metadata.author` present and uses Title Case (validator normalizes and enforces Title Case)
 - 8-12 supported task items
 - 4-6 tip items
 - Blank lines before lists for MD032 compliance
@@ -66,8 +66,10 @@ Discovers all `skills/hr-*` directories and rebuilds generated references in `.c
 
 | File | Purpose |
 |------|---------|
-| `src/config.ts` | `SKILLS_DIR` path, `hr-` prefix, and skill discovery helper |
-| `src/validate.ts` | Validates frontmatter and required sections |
+| `src/validation/validate.ts` | Core skill validation (per-skill checks and global consistency) |
+| `src/build/sync.ts` | Generates `.claude-plugin/marketplace.json` and updates root `SKILL.md` router |
+| `src/build/router.ts` | Build and splice the root `SKILL.md` routing table |
+| `src/shared/constants.ts` | Validation constants (MIN_CONTENT_LENGTH, REQUIRED_SECTIONS, regexes) |
 
 ## Requirements
 

--- a/packages/hr-skills-build/src/cli/discover.ts
+++ b/packages/hr-skills-build/src/cli/discover.ts
@@ -7,9 +7,9 @@
  * (`bun run registry`) before this command is used.
  *
  * Usage:
- *   bun src/discover.ts "onboard new hires"
- *   bun src/discover.ts "onboarding" --domain onboarding-offboarding
- *   bun src/discover.ts "onbording" --limit 3 --no-fuzzy
+ *   bun run discover "onboard new hires"
+ *   bun run discover "onboarding" --domain onboarding-offboarding
+ *   bun run discover "onbording" --limit 3 --no-fuzzy
  */
 
 import { readFile } from 'node:fs/promises';
@@ -39,8 +39,8 @@ async function main() {
 
 	if (!text || text.startsWith('--')) {
 		printUsageAndExit(
-			'Usage: bun src/discover.ts "<query>" [--domain <domain>] [--limit N] [--no-fuzzy]',
-			'  bun src/discover.ts "onboard new hires"',
+			'Usage: bun run discover "<query>" [--domain <domain>] [--limit N] [--no-fuzzy]',
+			'  bun run discover "onboard new hires"',
 		);
 	}
 

--- a/packages/hr-skills-build/src/cli/execute-plan.ts
+++ b/packages/hr-skills-build/src/cli/execute-plan.ts
@@ -11,8 +11,8 @@
  * in an actual agent should supply their own `StepExecutorFn`.
  *
  * Usage:
- *   bun src/execute-plan.ts "create an onboarding checklist"
- *   bun src/execute-plan.ts "help with succession planning and talent development"
+ *   bun run execute "create an onboarding checklist"
+ *   bun run execute "help with succession planning and talent development"
  */
 
 import { writeFileSync } from 'node:fs';
@@ -42,8 +42,8 @@ async function main() {
 
 	if (!intent) {
 		printUsageAndExit(
-			'Usage: bun src/execute-plan.ts "<user intent>"',
-			'  bun src/execute-plan.ts "Create interview questions for a senior manager"',
+			'Usage: bun run execute "<user intent>"',
+			'  bun run execute "Create interview questions for a senior manager"',
 		);
 	}
 

--- a/packages/hr-skills-build/src/cli/generate-plan.ts
+++ b/packages/hr-skills-build/src/cli/generate-plan.ts
@@ -4,8 +4,8 @@
  * CLI: Generate an execution plan for a given intent.
  *
  * Usage:
- *   bun src/generate-plan.ts "create an onboarding checklist"
- *   bun src/generate-plan.ts "help with succession planning and talent development"
+ *   bun run plan "create an onboarding checklist"
+ *   bun run plan "help with succession planning and talent development"
  */
 
 import { writeFileSync } from 'node:fs';
@@ -24,8 +24,8 @@ async function main() {
 
 	if (!intent) {
 		printUsageAndExit(
-			'Usage: bun src/generate-plan.ts "<user intent>"',
-			'  bun src/generate-plan.ts "Create interview questions for a senior manager"',
+			'Usage: bun run plan "<user intent>"',
+			'  bun run plan "Create interview questions for a senior manager"',
 		);
 	}
 

--- a/packages/hr-skills-build/src/cli/generate-relevance-signals.ts
+++ b/packages/hr-skills-build/src/cli/generate-relevance-signals.ts
@@ -6,7 +6,7 @@
  * `registry/relevance-signals.json`.
  *
  * Usage:
- *   bun src/generate-relevance-signals.ts
+ *   bun run signals
  *
  * Equivalent root alias:
  *   bun run signals

--- a/packages/hr-skills-build/src/cli/recommend.ts
+++ b/packages/hr-skills-build/src/cli/recommend.ts
@@ -4,8 +4,8 @@
  * CLI: Get "skills you might also need" recommendations for a given skill ID.
  *
  * Usage:
- *   bun src/recommend.ts hr-onboarding
- *   bun src/recommend.ts hr-onboarding --limit 3
+ *   bun run recommend hr-onboarding
+ *   bun run recommend hr-onboarding --limit 3
  */
 
 import * as p from '@clack/prompts';
@@ -18,8 +18,8 @@ async function main() {
 
 	if (!skillId) {
 		printUsageAndExit(
-			'Usage: bun src/recommend.ts <skill-id> [--limit N]',
-			'  bun src/recommend.ts hr-onboarding',
+			'Usage: bun run recommend <skill-id> [--limit N]',
+			'  bun run recommend hr-onboarding',
 		);
 	}
 

--- a/packages/hr-skills-build/src/cli/run-evaluation.ts
+++ b/packages/hr-skills-build/src/cli/run-evaluation.ts
@@ -4,8 +4,8 @@
  * CLI: Run the evaluation framework against every dataset in `eval/datasets/`.
  *
  * Usage:
- *   bun src/run-evaluation.ts               # run and report regressions
- *   bun src/run-evaluation.ts --update-golden  # regenerate golden fixtures
+ *   bun run evaluate               # run and report regressions
+ *   bun run evaluate -- --update-golden  # regenerate golden fixtures
  *
  * Exit code is 0 when every dataset has zero regressions and zero invalid
  * plans, 1 otherwise — suitable for CI.

--- a/packages/hr-skills-build/src/cli/skill-review.ts
+++ b/packages/hr-skills-build/src/cli/skill-review.ts
@@ -16,8 +16,8 @@
  * report.
  *
  * Usage:
- *   bun src/cli/skill-review.ts hr-onboarding hr-recruiting
- *   bun src/cli/skill-review.ts --list-file changed-skills.txt
+ *   bun run skill-review hr-onboarding hr-recruiting
+ *   bun run skill-review -- --list-file changed-skills.txt
  */
 
 import { readFile } from 'node:fs/promises';

--- a/packages/hr-skills-build/test/registry/registry.test.ts
+++ b/packages/hr-skills-build/test/registry/registry.test.ts
@@ -138,7 +138,7 @@ describe('buildRegistry()', () => {
 		// even the top static item's (1)*(0.7) = 0.7... actually the static
 		// top item still wins on raw score, so just assert presence, not rank,
 		// to avoid over-asserting the exact blend formula here (that's
-		// relevance-signals.test.ts's job).
+		// packages/hr-skills-build/test/search/relevance-signals.test.ts's job).
 		expect(blendedSource?.relatedSkills).toContain(target.id);
 	});
 


### PR DESCRIPTION
This PR normalizes ambiguous comment references, updates docs and examples to recommend 'bun run <script>' instead of 'bun src/...', and standardizes .agents SKILL.md references. CI will run validate/lint/test via the dev pipeline.