### PR TITLE
refactor(shared): move SkillCategory type to shared/types.ts

### DIFF
--- a/packages/hr-skills-build/src/build/router.ts
+++ b/packages/hr-skills-build/src/build/router.ts
@@ -17,14 +17,11 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import {
-	CATEGORY_META,
-	classifySkill,
-	type SkillCategory,
-} from '../registry/classifier.js';
+import { CATEGORY_META, classifySkill } from '../registry/classifier.js';
 import { ROOT_DIR, SKILLS_DIR } from '../shared/constants.js';
 import { discoverSkills } from '../shared/helpers.js';
 import { parseSkillFrontmatter } from '../shared/parser.js';
+import type { SkillCategory } from '../shared/types.js';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/hr-skills-build/src/cli/discover.ts
+++ b/packages/hr-skills-build/src/cli/discover.ts
@@ -16,10 +16,9 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import * as p from '@clack/prompts';
 
-import type { SkillCategory } from '../registry/classifier.js';
 import { InvalidSearchQueryError, searchSkills } from '../search/search.js';
 import { ROOT_DIR } from '../shared/constants.js';
-import type { Registry, SkillSearchQuery } from '../shared/types.js';
+import type { Registry, SkillCategory, SkillSearchQuery } from '../shared/types.js';
 import { printUsageAndExit, runCli } from './cli-bootstrap.js';
 
 const REGISTRY_PATH = join(ROOT_DIR, 'registry', 'skills.json');

--- a/packages/hr-skills-build/src/registry/classifier.ts
+++ b/packages/hr-skills-build/src/registry/classifier.ts
@@ -24,20 +24,7 @@
  *  technical-hiring         — engineering/design/product specialist skills
  */
 
-export type SkillCategory =
-	| 'talent-acquisition'
-	| 'onboarding-offboarding'
-	| 'performance-talent'
-	| 'compensation-rewards'
-	| 'learning-development'
-	| 'org-design-change'
-	| 'workforce-analytics'
-	| 'hr-technology-ai'
-	| 'compliance-risk'
-	| 'culture-experience'
-	| 'global-project'
-	| 'technical-hiring'
-	| 'uncategorized';
+import type { SkillCategory } from '../shared/types.js';
 
 export interface SkillClassification {
 	category: SkillCategory;

--- a/packages/hr-skills-build/src/shared/schema.ts
+++ b/packages/hr-skills-build/src/shared/schema.ts
@@ -43,7 +43,7 @@ export type SkillFrontmatter = v.InferOutput<typeof SkillFrontmatterSchema>;
 
 /**
  * All valid domain category slugs for a skill entry.
- * Must stay in sync with `SkillCategory` in classifier.ts.
+ * Must stay in sync with `SkillCategory` in `shared/types.ts`.
  */
 const SKILL_CATEGORIES = [
 	'talent-acquisition',

--- a/packages/hr-skills-build/src/shared/types.ts
+++ b/packages/hr-skills-build/src/shared/types.ts
@@ -1,4 +1,30 @@
-import type { SkillCategory } from '../registry/classifier.js';
+// ---------------------------------------------------------------------------
+// Skill category (routing/classification)
+// ---------------------------------------------------------------------------
+
+/**
+ * The routing-table section a skill belongs to in the generated root
+ * `SKILL.md`. Assigned by `registry/classifier.ts#classifySkill()`.
+ *
+ * Lives here (not in `classifier.ts`) because it's a foundational domain
+ * type referenced by `SkillMetadata`/`Registry` below, `search/`, and
+ * `build/router.ts` — `classifier.ts` imports it back from here rather than
+ * the other way around, so `shared/` stays the dependency-free base layer.
+ */
+export type SkillCategory =
+	| 'talent-acquisition'
+	| 'onboarding-offboarding'
+	| 'performance-talent'
+	| 'compensation-rewards'
+	| 'learning-development'
+	| 'org-design-change'
+	| 'workforce-analytics'
+	| 'hr-technology-ai'
+	| 'compliance-risk'
+	| 'culture-experience'
+	| 'global-project'
+	| 'technical-hiring'
+	| 'uncategorized';
 
 // ---------------------------------------------------------------------------
 // Skill matrix types


### PR DESCRIPTION
SkillCategory was defined in registry/classifier.ts but imported back by shared/types.ts, discover.ts, and build/router.ts — an inverted dependency (shared/ should be the base layer that other modules import from, not the other way around).

Moved the type alone to shared/types.ts, where SkillMetadata/Registry already reference it. classifier.ts, discover.ts, and router.ts now import it from there. CategoryMeta/CATEGORY_META/EXPLICIT/KEYWORD_RULES stay in classifier.ts — they're classification business logic/data, not a shared type, so colocating them with classifySkill() is correct per this repo's domain-folder convention (not everything scattered outside shared/ needs to move there).

Also updated shared/schema.ts's stale cross-reference comment ('Must stay in sync with SkillCategory in classifier.ts' -> shared/types.ts).

Verified: typecheck, test (436/436), lint, validate (146/146), sync all pass.