### PR TITLE
Sync license to MIT and refactor SkillCategory type location

### DIFF
--- a/packages/hr-skills-build/src/build/router.ts
+++ b/packages/hr-skills-build/src/build/router.ts
@@ -17,14 +17,11 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import {
-	CATEGORY_META,
-	classifySkill,
-	type SkillCategory,
-} from '../registry/classifier.js';
+import { CATEGORY_META, classifySkill } from '../registry/classifier.js';
 import { ROOT_DIR, SKILLS_DIR } from '../shared/constants.js';
 import { discoverSkills } from '../shared/helpers.js';
 import { parseSkillFrontmatter } from '../shared/parser.js';
+import type { SkillCategory } from '../shared/types.js';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/hr-skills-build/src/cli/discover.ts
+++ b/packages/hr-skills-build/src/cli/discover.ts
@@ -16,10 +16,9 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import * as p from '@clack/prompts';
 
-import type { SkillCategory } from '../registry/classifier.js';
 import { InvalidSearchQueryError, searchSkills } from '../search/search.js';
 import { ROOT_DIR } from '../shared/constants.js';
-import type { Registry, SkillSearchQuery } from '../shared/types.js';
+import type { Registry, SkillCategory, SkillSearchQuery } from '../shared/types.js';
 import { printUsageAndExit, runCli } from './cli-bootstrap.js';
 
 const REGISTRY_PATH = join(ROOT_DIR, 'registry', 'skills.json');

--- a/packages/hr-skills-build/src/registry/classifier.ts
+++ b/packages/hr-skills-build/src/registry/classifier.ts
@@ -24,20 +24,7 @@
  *  technical-hiring         — engineering/design/product specialist skills
  */
 
-export type SkillCategory =
-	| 'talent-acquisition'
-	| 'onboarding-offboarding'
-	| 'performance-talent'
-	| 'compensation-rewards'
-	| 'learning-development'
-	| 'org-design-change'
-	| 'workforce-analytics'
-	| 'hr-technology-ai'
-	| 'compliance-risk'
-	| 'culture-experience'
-	| 'global-project'
-	| 'technical-hiring'
-	| 'uncategorized';
+import type { SkillCategory } from '../shared/types.js';
 
 export interface SkillClassification {
 	category: SkillCategory;

--- a/packages/hr-skills-build/src/shared/schema.ts
+++ b/packages/hr-skills-build/src/shared/schema.ts
@@ -43,7 +43,7 @@ export type SkillFrontmatter = v.InferOutput<typeof SkillFrontmatterSchema>;
 
 /**
  * All valid domain category slugs for a skill entry.
- * Must stay in sync with `SkillCategory` in classifier.ts.
+ * Must stay in sync with `SkillCategory` in `shared/types.ts`.
  */
 const SKILL_CATEGORIES = [
 	'talent-acquisition',

--- a/packages/hr-skills-build/src/shared/types.ts
+++ b/packages/hr-skills-build/src/shared/types.ts
@@ -1,4 +1,30 @@
-import type { SkillCategory } from '../registry/classifier.js';
+// ---------------------------------------------------------------------------
+// Skill category (routing/classification)
+// ---------------------------------------------------------------------------
+
+/**
+ * The routing-table section a skill belongs to in the generated root
+ * `SKILL.md`. Assigned by `registry/classifier.ts#classifySkill()`.
+ *
+ * Lives here (not in `classifier.ts`) because it's a foundational domain
+ * type referenced by `SkillMetadata`/`Registry` below, `search/`, and
+ * `build/router.ts` — `classifier.ts` imports it back from here rather than
+ * the other way around, so `shared/` stays the dependency-free base layer.
+ */
+export type SkillCategory =
+	| 'talent-acquisition'
+	| 'onboarding-offboarding'
+	| 'performance-talent'
+	| 'compensation-rewards'
+	| 'learning-development'
+	| 'org-design-change'
+	| 'workforce-analytics'
+	| 'hr-technology-ai'
+	| 'compliance-risk'
+	| 'culture-experience'
+	| 'global-project'
+	| 'technical-hiring'
+	| 'uncategorized';
 
 // ---------------------------------------------------------------------------
 // Skill matrix types

--- a/packages/skills-ref/package.json
+++ b/packages/skills-ref/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"description": "Reference library for Agent Skills — validate, read, and generate prompts from SKILL.md files",
 	"type": "module",
-	"license": "Apache-2.0",
+	"license": "MIT",
 	"author": "Tuan Duc Tran",
 	"homepage": "https://github.com/tuanductran/hr-skills/tree/main/packages/skills-ref#readme",
 	"repository": {


### PR DESCRIPTION
# What changed?

Briefly describe the changes introduced in this pull request.

## Content Type

- [ ] Skill definition
- [ ] Competency framework
- [ ] Interview questions
- [ ] Assessment criteria
- [ ] Recruiting workflow
- [ ] AI prompt
- [ ] Documentation
- [x] Tooling / Configuration

## Why?

- Keep the skills-ref license consistent with the MIT license.
- Centralize the `SkillCategory` type in a shared location to improve maintainability, reduce duplication, and simplify reuse across the codebase.

## Related Issue

Closes #

## Validation

- [x] Content reviewed for accuracy
- [x] No duplicate information exists
- [x] Links and references verified
- [x] Formatting follows repository standards
- [x] CI checks pass

## Commit Convention

- [x] Commits follow Conventional Commits
