### PR TITLE
refactor(build): migrate hr-skills-build to tsdown

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,11 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "hr-skills",
   "description": "A collection of AI skills for HR managers covering recruiting, performance management, compensation, compliance, and all major HR domains. Built by Tuan Duc Tran for the Zalo HR/TA Job Onsite/Hybrid/Remote community.",
+  "owner": {
+    "name": "Tuan Duc Tran",
+    "email": "tuanductran.dev@gmail.com"
+  },
   "plugins": [
     {
       "name": "hr-accessibility-accommodation",

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -19,13 +19,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache turbo build setup
+      - name: Setup Bun cache
         uses: actions/cache@v6
         with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-turbo-
+            ${{ runner.os }}-bun-
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Cache turbo build setup
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
       - name: Install dependencies
         run: bun ci
 
@@ -51,24 +59,7 @@ jobs:
         run: bun run validate
 
       - name: Build distribution artifacts
-        # Root `bun run build` (`turbo run build --filter=!hr-skills`) builds
-        # every package except hr-skills — that's everything BUT what we
-        # want to target here, not a way to select hr-skills-build. It also
-        # runs skills-ref's build for no reason in this context.
-        # `bun run build -- --skill` is not valid syntax: bun forwards
-        # `--skill` to the root script (`turbo run build ...`), and turbo
-        # has no such flag — it fails with "unexpected argument '--skill'".
-        # The correct, filtered command targets hr-skills-build directly;
-        # its own "build" script already runs build-zip && build-skill, so
-        # one invocation produces both dist/hr-skills.zip and
-        # dist/hr-skills.skill.
-        # --force bypasses Turborepo's cache: the task's declared outputs
-        # (dist/**, resolved relative to the package) don't match where
-        # build-skills.ts actually writes (the repo-root dist/), so a cache
-        # hit replays the logged "OK" lines without restoring the real
-        # files — verified locally, a warm cache leaves dist/ empty even
-        # though the step reports success.
-        run: bunx turbo run build --filter=hr-skills-build --force
+        run: bun run build-skills
 
       - name: Extract changelog section for this version
         id: changelog

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,14 +44,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v6
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
       - name: Install dependencies
         run: bun ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,14 +32,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v6
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
       - name: Install dependencies
         run: bun ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Cache turbo build setup
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
       - name: Install dependencies
         run: bun ci
 

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -44,6 +44,22 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Setup Bun cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Cache turbo build setup
+        uses: actions/cache@v6
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
       - name: Install dependencies
         run: bun ci
 

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -44,14 +44,6 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Setup Bun cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
       - name: Cache turbo build setup
         uses: actions/cache@v6
         with:

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
       "dependencies": {
         "@clack/prompts": "catalog:",
         "skills-ref": "workspace:*",
+        "tsdown": "catalog:",
         "valibot": "catalog:",
         "yaml": "catalog:",
       },
@@ -35,6 +36,7 @@
       "version": "0.0.0",
       "dependencies": {
         "valibot": "catalog:",
+        "yaml": "catalog:",
       },
       "devDependencies": {
         "tsdown": "catalog:",
@@ -53,7 +55,7 @@
   },
   "catalogs": {
     "biome": {
-      "@biomejs/biome": "^2.5.6",
+      "@biomejs/biome": "^2.5.7",
     },
     "commit": {
       "@changesets/cli": "^2.31.1",
@@ -75,23 +77,23 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.6", "@biomejs/cli-darwin-x64": "2.5.6", "@biomejs/cli-linux-arm64": "2.5.6", "@biomejs/cli-linux-arm64-musl": "2.5.6", "@biomejs/cli-linux-x64": "2.5.6", "@biomejs/cli-linux-x64-musl": "2.5.6", "@biomejs/cli-win32-arm64": "2.5.6", "@biomejs/cli-win32-x64": "2.5.6" }, "bin": { "biome": "bin/biome" } }, "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.7", "@biomejs/cli-darwin-x64": "2.5.7", "@biomejs/cli-linux-arm64": "2.5.7", "@biomejs/cli-linux-arm64-musl": "2.5.7", "@biomejs/cli-linux-x64": "2.5.7", "@biomejs/cli-linux-x64-musl": "2.5.7", "@biomejs/cli-win32-arm64": "2.5.7", "@biomejs/cli-win32-x64": "2.5.7" }, "bin": { "biome": "bin/biome" } }, "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.7", "", { "os": "linux", "cpu": "x64" }, "sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.7", "", { "os": "win32", "cpu": "x64" }, "sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.1", "", { "dependencies": { "@changesets/config": "^3.1.4", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		},
 		"catalogs": {
 			"biome": {
-				"@biomejs/biome": "^2.5.6"
+				"@biomejs/biome": "^2.5.7"
 			},
 			"commit": {
 				"@changesets/cli": "^2.31.1",
@@ -62,6 +62,7 @@
 	},
 	"scripts": {
 		"build": "turbo run build --filter=!hr-skills",
+		"build-skills": "turbo run build-skills --filter=hr-skills-build",
 		"dev": "turbo run dev --filter=!hr-skills",
 		"test": "turbo run test --filter=!hr-skills",
 		"typecheck": "turbo run typecheck --filter=!hr-skills",

--- a/packages/hr-skills-build/package.json
+++ b/packages/hr-skills-build/package.json
@@ -20,10 +20,22 @@
 		"llm",
 		"agents"
 	],
+	"main": "./dist/index.mjs",
+	"module": "./dist/index.mjs",
+	"exports": {
+		".": {
+			"default": "./dist/index.mjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
 	"scripts": {
-		"build": "bun run build-zip && bun run build-skill",
-		"build-zip": "bun src/build/build-skills.ts",
-		"build-skill": "bun src/build/build-skills.ts --skill",
+		"build": "tsdown",
+		"build-skills": "bun src/build/build-skills.ts",
+		"dev": "tsdown --watch",
+		"test": "bun test",
+		"typecheck": "tsc --noEmit",
 		"validate": "bun src/validation/validate.ts",
 		"sync": "bun src/build/sync.ts",
 		"matrix": "bun src/build/generate-skill-matrix.ts",
@@ -34,15 +46,13 @@
 		"recommend": "bun src/cli/recommend.ts",
 		"execute": "bun src/cli/execute-plan.ts",
 		"evaluate": "bun src/cli/run-evaluation.ts",
-		"skill-review": "bun src/cli/skill-review.ts",
-		"test": "bun test",
-		"dev": "bun --watch src/validation/validate.ts",
-		"typecheck": "tsc --noEmit"
+		"skill-review": "bun src/cli/skill-review.ts"
 	},
 	"dependencies": {
 		"@clack/prompts": "catalog:",
 		"valibot": "catalog:",
 		"skills-ref": "workspace:*",
-		"yaml": "catalog:"
+		"yaml": "catalog:",
+		"tsdown": "catalog:"
 	}
 }

--- a/packages/hr-skills-build/src/build/build-skills.ts
+++ b/packages/hr-skills-build/src/build/build-skills.ts
@@ -3,13 +3,15 @@
  *
  * Flags
  * -----
- * default   Build dist/hr-skills.zip   (when no flag is given)
- * --skill   Build dist/hr-skills.skill
+ * default   Build both dist/hr-skills.zip and dist/hr-skills.skill
+ * --zip     Build dist/hr-skills.zip only
+ * --skill   Build dist/hr-skills.skill only
  *
  * Examples
  * --------
- * bun run build-skills                  # zip build
- * bun run build-skills -- --skill       # .skill build
+ * bun run build-skills
+ * bun run build-skills -- --zip
+ * bun run build-skills -- --skill
  *
  * Formats
  * -------
@@ -28,59 +30,95 @@
  * Ported from soulmap-ai/src/soulmap/devtools/packaging/build_skill.py
  */
 
-import { existsSync } from 'node:fs';
-import { mkdir, readdir, readFile, stat, unlink } from 'node:fs/promises';
+import { mkdir, readdir, readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
+import { parseArgs } from 'node:util';
 import { deflateRawSync } from 'node:zlib';
 
-import { ROOT_DIR } from '../shared/constants.js';
+import { ROOT_DIR } from 'skills-ref';
 
-// ---------------------------------------------------------------------------
-// Minimal ZIP writer — no external deps, uses Node built-in zlib
-// ---------------------------------------------------------------------------
-
+/**
+ * File entry to include in the generated ZIP archive.
+ */
 interface ZipEntry {
+	/** Archive-relative path using forward slashes. */
 	arcname: string;
+	/** Uncompressed file contents. */
 	data: Buffer;
+	/** Last modification time. */
 	mtime: Date;
 }
 
-/** CRC-32 table (polynomial 0xEDB88320, as required by the ZIP spec). */
-let _crc32Table: Uint32Array | null = null;
+/**
+ * MS-DOS timestamp fields stored in ZIP file headers.
+ *
+ * ZIP stores modification times as two 16-bit values:
+ * - `time`: hours, minutes, and seconds (2-second resolution)
+ * - `date`: year (relative to 1980), month, and day
+ */
+interface DosTimestamp {
+	/** Packed MS-DOS time field. */
+	time: number;
+	/** Packed MS-DOS date field. */
+	date: number;
+}
+
+/** CRC-32 lookup table (polynomial 0xEDB88320, per the ZIP specification). */
+let crc32Table: Uint32Array | undefined;
 
 function makeCrc32Table(): Uint32Array {
-	if (_crc32Table) return _crc32Table;
-	const table = new Uint32Array(256);
-	for (let i = 0; i < 256; i++) {
-		let c = i;
-		for (let j = 0; j < 8; j++) {
-			c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
-		}
-		table[i] = c;
+	if (crc32Table) {
+		return crc32Table;
 	}
-	_crc32Table = table;
+
+	const table = new Uint32Array(256);
+
+	for (let i = 0; i < 256; i++) {
+		let crc = i;
+
+		for (let j = 0; j < 8; j++) {
+			crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+		}
+
+		table[i] = crc;
+	}
+
+	crc32Table = table;
+
 	return table;
 }
 
-function crc32(buf: Buffer): number {
+/**
+ * Compute the CRC-32 checksum of a buffer.
+ */
+function crc32(buffer: Buffer): number {
 	const table = makeCrc32Table();
+
 	let crc = 0xffffffff;
-	for (let i = 0; i < buf.length; i++) {
-		crc = (crc >>> 8) ^ (table[(crc ^ (buf[i] ?? 0)) & 0xff] ?? 0);
+
+	for (let i = 0; i < buffer.length; i++) {
+		crc = (crc >>> 8) ^ (table[(crc ^ (buffer[i] ?? 0)) & 0xff] ?? 0);
 	}
+
 	return (crc ^ 0xffffffff) >>> 0;
 }
 
-function writeUInt16LE(buf: Buffer, value: number, offset: number): void {
-	buf[offset] = value & 0xff;
-	buf[offset + 1] = (value >>> 8) & 0xff;
+/**
+ * Write a 16-bit unsigned integer in little-endian byte order.
+ */
+function writeUInt16LE(buffer: Buffer, value: number, offset: number): void {
+	buffer[offset] = value & 0xff;
+	buffer[offset + 1] = (value >>> 8) & 0xff;
 }
 
-function writeUInt32LE(buf: Buffer, value: number, offset: number): void {
-	buf[offset] = value & 0xff;
-	buf[offset + 1] = (value >>> 8) & 0xff;
-	buf[offset + 2] = (value >>> 16) & 0xff;
-	buf[offset + 3] = (value >>> 24) & 0xff;
+/**
+ * Write a 32-bit unsigned integer in little-endian byte order.
+ */
+function writeUInt32LE(buffer: Buffer, value: number, offset: number): void {
+	buffer[offset] = value & 0xff;
+	buffer[offset + 1] = (value >>> 8) & 0xff;
+	buffer[offset + 2] = (value >>> 16) & 0xff;
+	buffer[offset + 3] = (value >>> 24) & 0xff;
 }
 
 /**
@@ -95,20 +133,27 @@ function writeUInt32LE(buf: Buffer, value: number, offset: number): void {
  * earliest representable value (1980-01-01 00:00:00) instead of wrapping
  * into another invalid bit pattern.
  */
-function dateToDos(date: Date): { time: number; date: number } {
+function dateToDos(date: Date): DosTimestamp {
 	const year = date.getFullYear();
 
 	if (year < 1980 || year > 2107) {
-		return { time: 0, date: 0x21 };
+		return {
+			time: 0,
+			date: 0x21,
+		};
 	}
 
 	const dosDate = ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate();
+
 	const dosTime =
 		(date.getHours() << 11) |
 		(date.getMinutes() << 5) |
 		Math.floor(date.getSeconds() / 2);
 
-	return { time: dosTime, date: dosDate };
+	return {
+		time: dosTime,
+		date: dosDate,
+	};
 }
 
 /**
@@ -119,7 +164,7 @@ function buildZipBuffer(entries: ZipEntry[]): Buffer {
 	const localParts: Buffer[] = [];
 	const centralDir: Buffer[] = [];
 	const offsets: number[] = [];
-	let currentOffset = 0;
+	const currentOffset = 0;
 
 	for (const entry of entries) {
 		const nameBytes = Buffer.from(entry.arcname, 'utf8');
@@ -127,6 +172,7 @@ function buildZipBuffer(entries: ZipEntry[]): Buffer {
 		const compressed = deflateRawSync(raw, { level: 6 });
 		const checksum = crc32(raw);
 		const { time: dosTime, date: dosDate } = dateToDos(entry.mtime);
+		const localHeaderOffset = currentOffset;
 
 		// Local file header: 30 bytes + filename
 		const local = Buffer.alloc(30 + nameBytes.length);
@@ -145,7 +191,6 @@ function buildZipBuffer(entries: ZipEntry[]): Buffer {
 
 		offsets.push(currentOffset);
 		localParts.push(local, compressed);
-		currentOffset += local.length + compressed.length;
 
 		// Central directory file header: 46 bytes + filename
 		const central = Buffer.alloc(46 + nameBytes.length);
@@ -165,7 +210,7 @@ function buildZipBuffer(entries: ZipEntry[]): Buffer {
 		writeUInt16LE(central, 0, 34); // disk number start
 		writeUInt16LE(central, 0, 36); // internal attributes
 		writeUInt32LE(central, 0, 38); // external attributes
-		writeUInt32LE(central, offsets[offsets.length - 1] ?? 0, 42); // local header offset
+		writeUInt32LE(central, localHeaderOffset, 42); // local header offset
 		nameBytes.copy(central, 46);
 
 		centralDir.push(central);
@@ -192,13 +237,18 @@ function buildZipBuffer(entries: ZipEntry[]): Buffer {
 // ---------------------------------------------------------------------------
 
 async function loadDistignore(repoRoot: string): Promise<string[]> {
-	const path = join(repoRoot, '.distignore');
-	if (!existsSync(path)) return [];
-	const text = await readFile(path, 'utf8');
+	const file = Bun.file(join(repoRoot, '.distignore'));
+
+	if (!(await file.exists())) {
+		return [];
+	}
+
+	const text = await file.text();
+
 	return text
 		.split('\n')
-		.map((l) => l.trim())
-		.filter((l) => l.length > 0 && !l.startsWith('#'));
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0 && !line.startsWith('#'));
 }
 
 function isIgnored(rel: string, patterns: string[]): boolean {
@@ -231,15 +281,26 @@ async function iterInputs(repoRoot: string): Promise<string[]> {
 
 	for (const name of ['LICENSE', 'SKILL.md']) {
 		const candidate = join(repoRoot, name);
-		if (existsSync(candidate)) paths.push(candidate);
+
+		if (await Bun.file(candidate).exists()) {
+			paths.push(candidate);
+		}
 	}
 
 	const usageGuide = join(repoRoot, 'docs', 'usage-guide.md');
-	if (existsSync(usageGuide)) paths.push(usageGuide);
+
+	if (await Bun.file(usageGuide).exists()) {
+		paths.push(usageGuide);
+	}
 
 	const skillsDir = join(repoRoot, 'skills');
-	if (existsSync(skillsDir)) {
-		paths.push(...(await walkFiles(skillsDir)));
+
+	try {
+		if ((await stat(skillsDir)).isDirectory()) {
+			paths.push(...(await walkFiles(skillsDir)));
+		}
+	} catch {
+		// skills/ does not exist
 	}
 
 	return [...new Set(paths)].sort();
@@ -252,9 +313,18 @@ async function iterInputs(repoRoot: string): Promise<string[]> {
  */
 async function iterClaudePluginInputs(repoRoot: string): Promise<string[]> {
 	const base = join(repoRoot, '.claude-plugin');
-	if (!existsSync(base)) return [];
+
+	try {
+		if (!(await stat(base)).isDirectory()) {
+			return [];
+		}
+	} catch {
+		return [];
+	}
+
 	const all = await walkFiles(base);
-	return all.filter((p) => p.endsWith('.json')).sort();
+
+	return all.filter((path) => path.endsWith('.json')).sort();
 }
 
 // ---------------------------------------------------------------------------
@@ -279,7 +349,11 @@ async function buildArchive(
 		inputs = [...new Set([...inputs, ...pluginFiles])].sort();
 	}
 
-	if (existsSync(outPath)) await unlink(outPath);
+	try {
+		await Bun.file(outPath).delete();
+	} catch {
+		// Output file does not exist.
+	}
 
 	const entries: ZipEntry[] = [];
 	for (const absPath of inputs) {
@@ -319,13 +393,36 @@ export async function buildSkill(repoRoot: string): Promise<string> {
 // CLI entrypoint
 // ---------------------------------------------------------------------------
 
-if (import.meta.main) {
-	const isSkill = process.argv.includes('--skill');
-	console.log(`Building HR Skills distribution (${isSkill ? '.skill' : 'zip'})...`);
+const {
+	values: { zip, skill },
+} = parseArgs({
+	args: Bun.argv,
+	options: {
+		zip: {
+			type: 'boolean',
+		},
+		skill: {
+			type: 'boolean',
+		},
+	},
+	strict: true,
+	allowPositionals: true,
+});
 
-	if (isSkill) {
+if (import.meta.main) {
+	if (zip && skill) {
+		throw new Error('Cannot specify both --zip and --skill.');
+	}
+
+	if (zip) {
+		console.log('Building HR Skills distribution (.zip)...');
+		await buildZip(ROOT_DIR);
+	} else if (skill) {
+		console.log('Building HR Skills distribution (.skill)...');
 		await buildSkill(ROOT_DIR);
 	} else {
-		await buildZip(ROOT_DIR);
+		console.log('Building HR Skills distribution (.zip + .skill)...');
+
+		await Promise.all([buildZip(ROOT_DIR), buildSkill(ROOT_DIR)]);
 	}
 }

--- a/packages/hr-skills-build/src/build/generate-skill-matrix.ts
+++ b/packages/hr-skills-build/src/build/generate-skill-matrix.ts
@@ -7,7 +7,7 @@
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { ROOT_DIR, SKILLS_DIR } from '../shared/constants.js';
+import { ROOT_DIR, SKILLS_DIR } from 'skills-ref';
 import {
 	computeTier,
 	countFiles,

--- a/packages/hr-skills-build/src/build/router.ts
+++ b/packages/hr-skills-build/src/build/router.ts
@@ -16,9 +16,8 @@
 
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-
+import { ROOT_DIR, SKILLS_DIR } from 'skills-ref';
 import { CATEGORY_META, classifySkill } from '../registry/classifier.js';
-import { ROOT_DIR, SKILLS_DIR } from '../shared/constants.js';
 import { discoverSkills } from '../shared/helpers.js';
 import { parseSkillFrontmatter } from '../shared/parser.js';
 import type { SkillCategory } from '../shared/types.js';

--- a/packages/hr-skills-build/src/build/sync.ts
+++ b/packages/hr-skills-build/src/build/sync.ts
@@ -1,10 +1,9 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import * as p from '@clack/prompts';
+import { ROOT_DIR } from 'skills-ref';
 import * as v from 'valibot';
-
 import { getHrSkills } from '../registry/discovery.js';
-import { ROOT_DIR } from '../shared/constants.js';
 import { parseSkillMeta } from '../shared/parser.js';
 import { MarketplaceJsonSchema } from '../shared/schema.js';
 import type { SkillMeta } from '../shared/types.js';

--- a/packages/hr-skills-build/src/cli/discover.ts
+++ b/packages/hr-skills-build/src/cli/discover.ts
@@ -15,9 +15,8 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import * as p from '@clack/prompts';
-
+import { ROOT_DIR } from 'skills-ref';
 import { InvalidSearchQueryError, searchSkills } from '../search/search.js';
-import { ROOT_DIR } from '../shared/constants.js';
 import type { Registry, SkillCategory, SkillSearchQuery } from '../shared/types.js';
 import { printUsageAndExit, runCli } from './cli-bootstrap.js';
 

--- a/packages/hr-skills-build/src/cli/generate-registry.ts
+++ b/packages/hr-skills-build/src/cli/generate-registry.ts
@@ -11,8 +11,8 @@
 
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { ROOT_DIR } from 'skills-ref';
 import { buildRegistry, loadRelevanceSignalTable } from '../registry/registry.js';
-import { ROOT_DIR } from '../shared/constants.js';
 
 async function generateRegistry(): Promise<void> {
 	const signalTable = await loadRelevanceSignalTable();

--- a/packages/hr-skills-build/src/registry/discovery.ts
+++ b/packages/hr-skills-build/src/registry/discovery.ts
@@ -1,8 +1,9 @@
 import { access, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { HR_SKILL_PREFIX, SKILLS_DIR } from '../shared/constants.js';
+import { HR_SKILL_PREFIX } from '../shared/constants.js';
 import type { SkillDirectoryOptions } from '../shared/types.js';
+import { SKILLS_DIR } from 'skills-ref';
 
 /**
  * Discover all HR skill directory names in `skills/` that satisfy the given options.

--- a/packages/hr-skills-build/src/registry/registry.ts
+++ b/packages/hr-skills-build/src/registry/registry.ts
@@ -18,7 +18,6 @@ import {
 	REGISTRY_SCHEMA_VERSION,
 	RELEVANCE_SIGNALS_PATH,
 	SKILL_LINK_REGEX,
-	SKILLS_DIR,
 } from '../shared/constants.js';
 import {
 	computeTier,
@@ -34,6 +33,7 @@ import {
 	reRankRelatedSkills,
 } from '../search/relevance-signals.js';
 import type { Registry, RegistryEntry, RelevanceSignalTable } from '../shared/types.js';
+import { SKILLS_DIR } from 'skills-ref';
 
 const HR_PREFIX_REGEX = /^hr-/;
 

--- a/packages/hr-skills-build/src/shared/constants.ts
+++ b/packages/hr-skills-build/src/shared/constants.ts
@@ -1,13 +1,5 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-/** Absolute path to the repository root (four levels up from `src/shared/`). */
-export const ROOT_DIR = join(__dirname, '../../../..');
-
-/** Absolute path to the `skills/` directory at the repo root. */
-export const SKILLS_DIR = join(ROOT_DIR, 'skills');
+import { join } from 'node:path';
+import { ROOT_DIR } from 'skills-ref';
 
 /**
  * Base URL for linking to a file in this repo on GitHub, e.g. for use in

--- a/packages/hr-skills-build/src/shared/helpers.ts
+++ b/packages/hr-skills-build/src/shared/helpers.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
-
-import { HR_SKILL_PREFIX, SKILLS_DIR } from './constants.js';
+import { SKILLS_DIR } from 'skills-ref';
+import { HR_SKILL_PREFIX } from './constants.js';
 import { parseSkillFrontmatter } from './parser.js';
 import type { SkillFrontmatter } from './schema.js';
 import type { SkillValidationIssue, Tier } from './types.js';

--- a/packages/hr-skills-build/src/shared/schema.ts
+++ b/packages/hr-skills-build/src/shared/schema.ts
@@ -1,51 +1,66 @@
 import * as v from 'valibot';
 
-/**
- * Valibot schema for `.claude-plugin/marketplace.json`.
- * Used by `sync.ts` to parse and validate the file before updating it.
- */
-export const MarketplaceJsonSchema = v.object({
-	name: v.string(),
-	description: v.string(),
-	plugins: v.array(
-		v.object({
-			name: v.string(),
-			source: v.string(),
-			description: v.string(),
-			skills: v.array(v.string()),
-		}),
-	),
+// ---------------------------------------------------------------------------
+// Common schemas
+// ---------------------------------------------------------------------------
+
+const TrimmedString = v.pipe(v.string(), v.trim());
+const NonEmptyString = v.pipe(TrimmedString, v.minLength(1));
+const EmailString = v.pipe(TrimmedString, v.email());
+
+// ---------------------------------------------------------------------------
+// Marketplace
+// ---------------------------------------------------------------------------
+
+const MarketplaceOwnerSchema = v.strictObject({
+	name: NonEmptyString,
+	email: EmailString,
+});
+
+const MarketplacePluginSchema = v.strictObject({
+	name: NonEmptyString,
+	source: v.literal('./'),
+	description: NonEmptyString,
+	skills: v.array(v.pipe(NonEmptyString, v.startsWith('./skills/'))),
 });
 
 /**
- * Valibot schema for the YAML frontmatter of a skill's `SKILL.md`.
- * All fields are optional — callers should treat a missing field as absent
- * rather than as an error at this layer (higher-level validation handles
- * required-field checks).
+ * Schema for `.claude-plugin/marketplace.json`.
  */
-export const SkillFrontmatterSchema = v.object({
-	name: v.optional(v.pipe(v.string(), v.trim())),
-	description: v.optional(v.pipe(v.string(), v.trim())),
-	metadata: v.optional(
-		v.object({
-			author: v.optional(v.pipe(v.string(), v.trim())),
-			version: v.optional(v.pipe(v.string(), v.trim())),
-		}),
-	),
+export const MarketplaceJsonSchema = v.strictObject({
+	$schema: v.literal('https://json.schemastore.org/claude-code-marketplace.json'),
+	name: NonEmptyString,
+	description: NonEmptyString,
+	owner: MarketplaceOwnerSchema,
+	plugins: v.array(MarketplacePluginSchema),
+});
+
+// ---------------------------------------------------------------------------
+// Skill frontmatter
+// ---------------------------------------------------------------------------
+
+const MetadataSchema = v.strictObject({
+	author: v.optional(NonEmptyString),
+	version: v.optional(NonEmptyString),
+});
+
+/**
+ * Schema for `SKILL.md` frontmatter.
+ */
+export const SkillFrontmatterSchema = v.strictObject({
+	name: v.optional(NonEmptyString),
+	description: v.optional(NonEmptyString),
+	metadata: v.optional(MetadataSchema),
 });
 
 /** TypeScript type inferred from {@link SkillFrontmatterSchema}. */
 export type SkillFrontmatter = v.InferOutput<typeof SkillFrontmatterSchema>;
 
 // ---------------------------------------------------------------------------
-// Skill registry schema
+// Registry
 // ---------------------------------------------------------------------------
 
-/**
- * All valid domain category slugs for a skill entry.
- * Must stay in sync with `SkillCategory` in `shared/types.ts`.
- */
-const SKILL_CATEGORIES = [
+const SkillCategories = [
 	'talent-acquisition',
 	'onboarding-offboarding',
 	'performance-talent',
@@ -61,38 +76,34 @@ const SKILL_CATEGORIES = [
 	'uncategorized',
 ] as const;
 
-/**
- * Valibot schema for a single entry in `registry/skills.json`.
- * Mirrors the `RegistryEntry` interface in types.ts.
- */
-const RegistryEntrySchema = v.object({
-	id: v.pipe(v.string(), v.minLength(1)),
-	name: v.pipe(v.string(), v.minLength(1)),
-	version: v.string(),
-	description: v.string(),
+const RegistryPathsSchema = v.strictObject({
+	content: v.boolean(),
+	prompts: v.boolean(),
+	examples: v.boolean(),
+});
+
+const RegistryEntrySchema = v.strictObject({
+	id: NonEmptyString,
+	name: NonEmptyString,
+	version: NonEmptyString,
+	description: NonEmptyString,
 	tier: v.picklist(['full', 'partial', 'bare']),
-	domain: v.picklist(SKILL_CATEGORIES),
-	tags: v.array(v.string()),
-	aliases: v.array(v.string()),
-	capabilities: v.array(v.string()),
-	triggerPhrases: v.array(v.string()),
-	paths: v.object({
-		content: v.boolean(),
-		prompts: v.boolean(),
-		examples: v.boolean(),
-	}),
-	dependencies: v.array(v.string()),
-	relatedSkills: v.array(v.string()),
+	domain: v.picklist(SkillCategories),
+	tags: v.array(NonEmptyString),
+	aliases: v.array(NonEmptyString),
+	capabilities: v.array(NonEmptyString),
+	triggerPhrases: v.array(NonEmptyString),
+	paths: RegistryPathsSchema,
+	dependencies: v.array(NonEmptyString),
+	relatedSkills: v.array(NonEmptyString),
 });
 
 /**
- * Valibot schema for the full `registry/skills.json` document.
- * Used by `validate-registry.ts` to confirm the committed file conforms to
- * the expected shape before checking staleness, duplicates, and graph integrity.
+ * Schema for `registry/skills.json`.
  */
-export const RegistrySchema = v.object({
-	schemaVersion: v.number(),
-	generatedAt: v.string(),
-	skillCount: v.number(),
+export const RegistrySchema = v.strictObject({
+	schemaVersion: v.pipe(v.number(), v.minValue(1)),
+	generatedAt: NonEmptyString,
+	skillCount: v.pipe(v.number(), v.minValue(0)),
 	skills: v.array(RegistryEntrySchema),
 });

--- a/packages/hr-skills-build/src/validation/detect-duplicates.ts
+++ b/packages/hr-skills-build/src/validation/detect-duplicates.ts
@@ -51,7 +51,7 @@
  */
 
 import { join } from 'node:path';
-import { SKILLS_DIR } from '../shared/constants.js';
+import { SKILLS_DIR } from 'skills-ref';
 import type { SkillValidationIssue } from '../shared/types.js';
 import {
 	extractDescription,

--- a/packages/hr-skills-build/src/validation/quality-scoring.ts
+++ b/packages/hr-skills-build/src/validation/quality-scoring.ts
@@ -38,13 +38,12 @@
 
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-
+import { SKILLS_DIR } from 'skills-ref';
 import {
 	KEY_PROMPTS_REGEX,
 	MIN_CONTENT_LENGTH,
 	MIN_DESCRIPTION_LENGTH,
 	QUOTED_PROMPT_REGEX,
-	SKILLS_DIR,
 	TASKS_REGEX,
 	TIPS_REGEX,
 	USE_WHEN_REGEX,

--- a/packages/hr-skills-build/src/validation/validate-registry.ts
+++ b/packages/hr-skills-build/src/validation/validate-registry.ts
@@ -1,9 +1,9 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { ROOT_DIR } from 'skills-ref';
 import * as v from 'valibot';
 import { buildRegistry, loadRelevanceSignalTable } from '../registry/registry.js';
 import type { RelevanceSignalTable } from '../search/relevance-signals.js';
-import { ROOT_DIR } from '../shared/constants.js';
 import { RegistrySchema } from '../shared/schema.js';
 import type { RegistryEntry, SkillValidationIssue } from '../shared/types.js';
 

--- a/packages/hr-skills-build/src/validation/validate.ts
+++ b/packages/hr-skills-build/src/validation/validate.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import process from 'node:process';
 import * as p from '@clack/prompts';
-import { validate as validateRef } from 'skills-ref';
+import { ROOT_DIR, SKILLS_DIR, validate as validateRef } from 'skills-ref';
 import { buildRegistry, loadRelevanceSignalTable } from '../registry/registry.js';
 import {
 	HR_SKILL_PREFIX,
@@ -11,9 +11,7 @@ import {
 	MIN_DESCRIPTION_LENGTH,
 	QUOTED_PROMPT_REGEX,
 	REQUIRED_SECTIONS,
-	ROOT_DIR,
 	SKILL_LINK_REGEX,
-	SKILLS_DIR,
 	TASKS_REGEX,
 	TIPS_REGEX,
 } from '../shared/constants.js';

--- a/packages/hr-skills-build/test/build/sync.test.ts
+++ b/packages/hr-skills-build/test/build/sync.test.ts
@@ -18,8 +18,13 @@ describe('syncMarketplace()', () => {
 		tempMarketplacePath = join(tempDir, 'marketplace.json');
 
 		const initialJson = {
+			$schema: 'https://json.schemastore.org/claude-code-marketplace.json',
 			name: 'Test Plugin',
 			description: 'A test plugin.',
+			owner: {
+				name: 'Test Owner',
+				email: 'test@example.com',
+			},
 			plugins: [],
 		};
 
@@ -52,6 +57,15 @@ describe('syncMarketplace()', () => {
 		const updatedContent = await readFile(tempMarketplacePath, 'utf8');
 
 		const updatedJson = JSON.parse(updatedContent);
+
+		expect(updatedJson.$schema).toBe(
+			'https://json.schemastore.org/claude-code-marketplace.json',
+		);
+
+		expect(updatedJson.owner).toEqual({
+			name: 'Test Owner',
+			email: 'test@example.com',
+		});
 
 		expect(updatedJson.plugins).toHaveLength(1);
 
@@ -86,6 +100,10 @@ describe('syncMarketplace()', () => {
 		const invalidJson = {
 			name: 'Test Plugin',
 			description: 'A test plugin.',
+			owner: {
+				name: 'Test Owner',
+				email: 'not-an-email',
+			},
 			plugins: 'invalid',
 		};
 
@@ -102,5 +120,21 @@ describe('syncMarketplace()', () => {
 		const metas: SkillMeta[] = [];
 
 		expect(syncMarketplace(metas, tempMarketplacePath)).rejects.toThrow();
+	});
+
+	it('preserves marketplace metadata', async () => {
+		await syncMarketplace([], tempMarketplacePath);
+
+		const json = JSON.parse(await readFile(tempMarketplacePath, 'utf8'));
+
+		expect(json).toMatchObject({
+			$schema: 'https://json.schemastore.org/claude-code-marketplace.json',
+			name: 'Test Plugin',
+			description: 'A test plugin.',
+			owner: {
+				name: 'Test Owner',
+				email: 'test@example.com',
+			},
+		});
 	});
 });

--- a/packages/hr-skills-build/test/registry/discovery.test.ts
+++ b/packages/hr-skills-build/test/registry/discovery.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'bun:test';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { getHrSkills } from '../../src/registry/discovery.js';
-import { HR_SKILL_PREFIX, SKILLS_DIR } from '../../src/shared/constants.js';
+import { HR_SKILL_PREFIX } from '../../src/shared/constants.js';
+import { SKILLS_DIR } from 'skills-ref'
 
 describe('getHrSkills()', () => {
 	it('returns at least one skill', async () => {

--- a/packages/hr-skills-build/tsconfig.json
+++ b/packages/hr-skills-build/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "../../tsconfig.json",
-	"include": ["src", "test"]
+	"include": ["src", "test", "tsdown.config.ts"]
 }

--- a/packages/hr-skills-build/tsdown.config.ts
+++ b/packages/hr-skills-build/tsdown.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+	entry: ['./src/index.ts'],
+});

--- a/packages/skills-ref/package.json
+++ b/packages/skills-ref/package.json
@@ -44,7 +44,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"valibot": "catalog:"
+		"valibot": "catalog:",
+		"yaml": "catalog:"
 	},
 	"devDependencies": {
 		"tsdown": "catalog:"

--- a/packages/skills-ref/src/constants.ts
+++ b/packages/skills-ref/src/constants.ts
@@ -1,8 +1,7 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT_DIR = join(__dirname, '../../..');
+/** Absolute path to the repository root. */
+export const ROOT_DIR = join(import.meta.dirname, '../../..');
 
 /** Absolute path to the `skills/` directory at the repository root. */
 export const SKILLS_DIR = join(ROOT_DIR, 'skills');
@@ -12,12 +11,6 @@ export const SKILLS_DIR = join(ROOT_DIR, 'skills');
  * Maps to the `allowedTools` property in {@link SkillProperties}.
  */
 export const ALLOWED_TOOLS_KEY = 'allowed-tools';
-
-/**
- * Matches any non-whitespace character.
- * Used when scanning YAML lines for their indentation level.
- */
-export const NON_WHITESPACE_REGEX = /\S/u;
 
 /** The delimiter string that opens and closes a YAML frontmatter block in `SKILL.md`. */
 export const FRONTMATTER_DELIMITER = '---';

--- a/packages/skills-ref/src/errors.ts
+++ b/packages/skills-ref/src/errors.ts
@@ -1,28 +1,32 @@
+import type { BaseIssue } from 'valibot';
+
 /**
- * Base error for all skill-related failures.
+ * Base class for all skill-related errors.
  */
 export class SkillError extends Error {
 	constructor(message: string, options?: ErrorOptions) {
 		super(message, options);
+
 		this.name = new.target.name;
 	}
 }
 
 /**
- * Error thrown when a skill cannot be parsed.
+ * Thrown when a skill cannot be parsed.
  */
 export class ParseError extends SkillError {}
 
 /**
- * Error thrown when a skill fails validation.
+ * Thrown when skill validation fails.
  */
 export class ValidationError extends SkillError {
 	constructor(
 		message: string,
-		public readonly errors: readonly string[] = [message],
+		readonly issues: readonly BaseIssue<unknown>[],
 		options?: ErrorOptions,
 	) {
 		super(message, options);
-		Object.freeze(this.errors);
+
+		Object.freeze(this.issues);
 	}
 }

--- a/packages/skills-ref/src/helpers.ts
+++ b/packages/skills-ref/src/helpers.ts
@@ -13,33 +13,13 @@ import { findSkillMd, readProperties } from './loader.js';
  * @returns `true` if `value` is a plain object, `false` otherwise.
  */
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
-	return (
-		value != null &&
-		typeof value === 'object' &&
-		Object.getPrototypeOf(value) === Object.prototype
-	);
-}
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
 
-/**
- * Strip surrounding single or double quotes from a string.
- * If the string is not quoted, it is returned unchanged.
- *
- * @param value - The string to unquote.
- * @returns The string with surrounding matching quotes removed, or the original string.
- *
- * @example
- * unquote('"hello"')  // => 'hello'
- * unquote("'world'")  // => 'world'
- * unquote('no-quotes') // => 'no-quotes'
- */
-export function unquote(value: string): string {
-	if (
-		(value.startsWith('"') && value.endsWith('"')) ||
-		(value.startsWith("'") && value.endsWith("'"))
-	)
-		return value.slice(1, -1);
+	const prototype = Object.getPrototypeOf(value);
 
-	return value;
+	return prototype === Object.prototype || prototype === null;
 }
 
 /**
@@ -118,4 +98,37 @@ export function makeTempSkill(content: string): string {
 	const tmp = mkdtempSync(join(tmpdir(), 'skill-test-'));
 	writeFileSync(join(tmp, 'SKILL.md'), content, 'utf8');
 	return tmp;
+}
+
+/**
+ * Recursively removes keys that could be used for prototype pollution from a
+ * parsed YAML value.
+ *
+ * Object keys named `__proto__`, `constructor`, and `prototype` are discarded.
+ * Arrays are sanitized recursively, while primitive values are returned
+ * unchanged.
+ *
+ * @param value - Parsed YAML value.
+ * @returns A sanitized copy of the input value.
+ */
+export function sanitizeYamlValue(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(sanitizeYamlValue);
+	}
+
+	if (value && typeof value === 'object') {
+		const output = Object.create(null) as Record<string, unknown>;
+
+		for (const [key, child] of Object.entries(value)) {
+			if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+				continue;
+			}
+
+			output[key] = sanitizeYamlValue(child);
+		}
+
+		return output;
+	}
+
+	return value;
 }

--- a/packages/skills-ref/src/index.ts
+++ b/packages/skills-ref/src/index.ts
@@ -1,11 +1,4 @@
-/**
- * Public API for the `skills-ref` package.
- *
- * Re-exports the three main entry points:
- *  - {@link readProperties} — read and validate skill frontmatter from disk.
- *  - {@link toPrompt}       — render skill directories as an XML system-prompt block.
- *  - {@link validate}       — validate a skill directory against all core rules.
- */
+export { ROOT_DIR, SKILLS_DIR } from './constants.js';
 export { readProperties } from './loader.js';
 export { toPrompt } from './prompt.js';
 export { validate } from './validator.js';

--- a/packages/skills-ref/src/loader.ts
+++ b/packages/skills-ref/src/loader.ts
@@ -66,17 +66,26 @@ export function readProperties(skillDir: string): SkillProperties {
 	const content = readFileSync(skillMd, 'utf8');
 	const [frontmatter] = parseFrontmatter(content);
 
+	const {
+		name,
+		description,
+		license,
+		compatibility,
+		metadata,
+		['allowed-tools']: allowedTools,
+	} = frontmatter;
+
 	const result = v.safeParse(SkillPropertiesSchema, {
-		name: frontmatter['name'],
-		description: frontmatter['description'],
-		license: toStringOrUndefined(frontmatter['license']),
-		compatibility: toStringOrUndefined(frontmatter['compatibility']),
-		allowedTools: toStringOrUndefined(frontmatter['allowed-tools']),
-		metadata: toStringRecord(frontmatter['metadata']),
+		name,
+		description,
+		license: toStringOrUndefined(license),
+		compatibility: toStringOrUndefined(compatibility),
+		allowedTools: toStringOrUndefined(allowedTools),
+		metadata: toStringRecord(metadata),
 	});
 
 	if (!result.success) {
-		throw new ValidationError(v.summarize(result.issues));
+		throw new ValidationError(v.summarize(result.issues), result.issues);
 	}
 
 	return result.output;

--- a/packages/skills-ref/src/models.ts
+++ b/packages/skills-ref/src/models.ts
@@ -2,16 +2,8 @@ import { ALLOWED_TOOLS_KEY } from './constants.js';
 import type { SkillProperties } from './schema.js';
 
 /**
- * Convert a skill's {@link SkillProperties} to a plain dictionary suitable for
- * serialization (e.g. JSON output or YAML round-tripping).
- *
- * Only fields with defined, non-null values are included in the result —
- * optional properties are omitted rather than serialized as `null`.
- * The `allowedTools` field is keyed as `"allowed-tools"` to match the raw
- * frontmatter field name expected by the Claude plugin format.
- *
- * @param props - The validated skill properties to convert.
- * @returns A `Record<string, unknown>` containing only the present fields.
+ * Converts validated skill properties to a plain object suitable for
+ * serialization.
  */
 export function toDict(props: SkillProperties): Record<string, unknown> {
 	const result: Record<string, unknown> = {
@@ -19,14 +11,21 @@ export function toDict(props: SkillProperties): Record<string, unknown> {
 		description: props.description,
 	};
 
-	if (props.license != null) result['license'] = props.license;
+	if (props.license != null) {
+		result['license'] = props.license;
+	}
 
-	if (props.compatibility != null) result['compatibility'] = props.compatibility;
+	if (props.compatibility != null) {
+		result['compatibility'] = props.compatibility;
+	}
 
-	if (props.allowedTools != null) result[ALLOWED_TOOLS_KEY] = props.allowedTools;
+	if (props.allowedTools != null) {
+		result[ALLOWED_TOOLS_KEY] = props.allowedTools;
+	}
 
-	if (props.metadata && Object.keys(props.metadata).length > 0)
+	if (props.metadata && Object.keys(props.metadata).length > 0) {
 		result['metadata'] = { ...props.metadata };
+	}
 
 	return result;
 }

--- a/packages/skills-ref/src/parser.ts
+++ b/packages/skills-ref/src/parser.ts
@@ -1,180 +1,68 @@
-import { FRONTMATTER_DELIMITER, NON_WHITESPACE_REGEX } from './constants.js';
+import { parseDocument } from 'yaml';
+
+import { FRONTMATTER_DELIMITER } from './constants.js';
 import { ParseError } from './errors.js';
-import { unquote } from './helpers.js';
+import { sanitizeYamlValue } from './helpers.js';
 
 /**
  * Parse the YAML frontmatter block from a `SKILL.md` file.
  *
  * Expects the content to begin with a `---` delimiter, followed by YAML,
  * followed by a closing `---` delimiter. Everything after the closing
- * delimiter is the body.
+ * delimiter is returned as the markdown body.
  *
- * @param content - The full UTF-8 content of a `SKILL.md` file.
- * @returns A tuple of `[frontmatter, body]` where `frontmatter` is the
- *   parsed key-value map and `body` is the trimmed markdown content
- *   that follows the closing `---`.
- * @throws {ParseError} If the content does not start with `---` or the
- *   frontmatter block is not properly closed.
+ * @param content - Full contents of a `SKILL.md` file.
+ * @returns A tuple containing the parsed frontmatter and markdown body.
+ * @throws {ParseError} If the frontmatter is missing, malformed, or contains invalid YAML.
  */
 export function parseFrontmatter(content: string): [Record<string, unknown>, string] {
-	if (!content.startsWith(FRONTMATTER_DELIMITER))
+	if (!content.startsWith(FRONTMATTER_DELIMITER)) {
 		throw new ParseError('SKILL.md must start with YAML frontmatter (---)');
+	}
 
-	const parts = content.split(FRONTMATTER_DELIMITER);
+	const start = content.indexOf('\n') + 1;
 
-	if (parts.length < 3)
+	const end = content.search(/\r?\n---(?:\r?\n|$)/);
+
+	if (start === 0 || end === -1 || end <= start) {
 		throw new ParseError('SKILL.md frontmatter not properly closed with ---');
+	}
 
-	const frontmatter = parts[1];
+	const frontmatter = content.slice(start, end);
 
-	if (frontmatter === undefined)
-		throw new ParseError('SKILL.md frontmatter not properly closed with ---');
+	const body = content
+		.slice(end)
+		.replace(/^\r?\n---\r?\n?/, '')
+		.trim();
 
-	const body = parts.slice(2).join(FRONTMATTER_DELIMITER).trim();
-
-	return [parseSimpleYaml(frontmatter), body];
+	return [parseYamlFrontmatter(frontmatter), body];
 }
 
 /**
- * Parse a restricted subset of YAML sufficient for `SKILL.md` frontmatter.
+ * Parse the YAML frontmatter section.
  *
- * Supports:
- * - Scalar string values (quoted or unquoted).
- * - Nested objects (one level deep, indented with any consistent whitespace).
- * - Block scalars (`|` literal and `>` folded).
- * - Comment lines (lines beginning with `#`).
- *
- * Does **not** support: arrays, anchors, aliases, multi-document streams,
- * or more than one level of nesting.
- *
- * Prototype-pollution keys (`__proto__`, `constructor`, `prototype`) are
- * silently ignored.
- *
- * @param yaml - The raw YAML string extracted between the `---` delimiters.
- * @returns A `Record<string, unknown>` of parsed top-level key-value pairs.
+ * @param yaml - Raw YAML between the `---` delimiters.
+ * @returns Parsed frontmatter object.
+ * @throws {ParseError} If the YAML contains syntax errors.
  */
-function parseSimpleYaml(yaml: string): Record<string, unknown> {
-	const result: Record<string, unknown> = {};
-	const lines = yaml.split('\n');
-	let index = 0;
+function parseYamlFrontmatter(yaml: string): Record<string, unknown> {
+	const document = parseDocument(yaml);
 
-	while (index < lines.length) {
-		const line = lines[index];
+	const [error] = document.errors;
 
-		if (line === undefined) break;
-
-		const trimmedLine = line.trimEnd();
-
-		if (trimmedLine.length === 0 || trimmedLine.startsWith('#')) {
-			index++;
-			continue;
-		}
-
-		const colonIndex = trimmedLine.indexOf(':');
-
-		if (colonIndex === -1) {
-			index++;
-			continue;
-		}
-
-		const key = trimmedLine.slice(0, colonIndex).trim();
-
-		// Prevent Prototype Pollution
-		if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-			index++;
-			continue;
-		}
-
-		const value = trimmedLine.slice(colonIndex + 1).trim();
-		const indent = line.search(NON_WHITESPACE_REGEX);
-
-		// Block scalar multiline string
-		if (value === '|' || value === '>') {
-			let scalarContent = '';
-			const isFolded = value === '>';
-			index++;
-
-			while (index < lines.length) {
-				const childLine = lines[index];
-
-				if (childLine === undefined) break;
-
-				const childTrimmed = childLine.trimEnd();
-
-				if (childTrimmed.length === 0) {
-					scalarContent += '\n';
-					index++;
-					continue;
-				}
-
-				const childIndent = childLine.search(NON_WHITESPACE_REGEX);
-
-				if (childIndent <= indent) break;
-
-				const contentLine = childLine.slice(childIndent);
-
-				if (scalarContent.length > 0 && !scalarContent.endsWith('\n') && isFolded)
-					scalarContent += ` ${contentLine.trim()}`;
-				else
-					scalarContent +=
-						(scalarContent.length > 0 && !scalarContent.endsWith('\n')
-							? '\n'
-							: '') + contentLine;
-
-				index++;
-			}
-
-			result[key] = scalarContent.trimEnd();
-			continue;
-		}
-
-		// Nested object (value is empty, children follow on indented lines)
-		if (value === '') {
-			const nested: Record<string, string> = {};
-			index++;
-
-			while (index < lines.length) {
-				const childLine = lines[index];
-
-				if (childLine === undefined) break;
-
-				const childTrimmed = childLine.trimEnd();
-
-				if (childTrimmed.length === 0) {
-					index++;
-					continue;
-				}
-
-				const childIndent = childLine.search(NON_WHITESPACE_REGEX);
-
-				if (childIndent <= indent) break;
-
-				const childColonIndex = childTrimmed.indexOf(':');
-
-				if (childColonIndex !== -1) {
-					const childKey = childTrimmed.slice(0, childColonIndex).trim();
-
-					// Prevent Prototype Pollution
-					if (
-						childKey !== '__proto__' &&
-						childKey !== 'constructor' &&
-						childKey !== 'prototype'
-					) {
-						const childValue = childTrimmed.slice(childColonIndex + 1).trim();
-						nested[childKey] = unquote(childValue);
-					}
-				}
-
-				index++;
-			}
-
-			result[key] = nested;
-			continue;
-		}
-
-		result[key] = unquote(value);
-		index++;
+	if (error) {
+		throw new ParseError(error.message, {
+			cause: error,
+		});
 	}
 
-	return result;
+	const value = document.toJS({
+		mapAsMap: false,
+	});
+
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return Object.create(null);
+	}
+
+	return sanitizeYamlValue(value) as Record<string, unknown>;
 }

--- a/packages/skills-ref/src/schema.ts
+++ b/packages/skills-ref/src/schema.ts
@@ -1,25 +1,22 @@
 import * as v from 'valibot';
 
+const TrimmedString = v.pipe(v.string(), v.trim());
+const OptionalTrimmedString = v.optional(TrimmedString);
+const MetadataSchema = v.record(v.string(), TrimmedString);
+
 /**
- * Valibot schema for the properties read from a skill's `SKILL.md` frontmatter.
- *
- * Only `name` and `description` are required; all other fields are optional.
- * String values are trimmed of leading and trailing whitespace during parsing.
+ * Schema for the properties read from a skill's `SKILL.md` frontmatter.
  */
-export const SkillPropertiesSchema = v.object({
-	/** Skill identifier (required). Must match the containing directory name. */
-	name: v.pipe(v.string(), v.trim()),
-	/** Short description of what the skill does (required). */
-	description: v.pipe(v.string(), v.trim()),
-	/** SPDX license identifier for the skill content (optional). */
-	license: v.optional(v.pipe(v.string(), v.trim())),
-	/** Compatibility notes for the skill, e.g. supported Claude versions (optional). */
-	compatibility: v.optional(v.pipe(v.string(), v.trim())),
-	/** Comma-separated list of Claude tools this skill is permitted to use (optional). */
-	allowedTools: v.optional(v.pipe(v.string(), v.trim())),
-	/** Arbitrary key-value metadata pairs from the `metadata:` block (optional). */
-	metadata: v.optional(v.record(v.string(), v.pipe(v.string(), v.trim()))),
+export const SkillPropertiesSchema = v.strictObject({
+	name: TrimmedString,
+	description: TrimmedString,
+	license: OptionalTrimmedString,
+	compatibility: OptionalTrimmedString,
+	allowedTools: OptionalTrimmedString,
+	metadata: v.optional(MetadataSchema),
 });
 
-/** TypeScript type inferred from {@link SkillPropertiesSchema}. */
+/**
+ * Parsed properties extracted from a skill's `SKILL.md` frontmatter.
+ */
 export type SkillProperties = v.InferOutput<typeof SkillPropertiesSchema>;

--- a/packages/skills-ref/src/validator.ts
+++ b/packages/skills-ref/src/validator.ts
@@ -123,9 +123,11 @@ export function validate(skillDir: string): string[] {
 	try {
 		[metadata] = parseFrontmatter(content);
 	} catch (error) {
-		if (error instanceof ParseError) return [error.message];
+		if (error instanceof ParseError) {
+			return [error.message];
+		}
 
-		return [`Failed to parse SKILL.md: ${String(error)}`];
+		throw error;
 	}
 
 	const errors: string[] = [];

--- a/packages/skills-ref/test/errors.test.ts
+++ b/packages/skills-ref/test/errors.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'bun:test';
+import type { BaseIssue } from 'valibot';
+
 import { ParseError, SkillError, ValidationError } from '../src/errors.js';
 
 describe('SkillError', () => {
@@ -11,8 +13,15 @@ describe('SkillError', () => {
 		expect(err.name).toBe('SkillError');
 		expect(err.message).toBe('msg');
 
-		// correct prototype chain check
 		expect(Object.getPrototypeOf(err)).toBe(SkillError.prototype);
+	});
+
+	it('supports ErrorOptions.cause', () => {
+		const cause = new Error('root cause');
+
+		const err = new SkillError('msg', { cause });
+
+		expect(err.cause).toBe(cause);
 	});
 });
 
@@ -27,38 +36,56 @@ describe('ParseError', () => {
 		expect(err.name).toBe('ParseError');
 		expect(err.message).toBe('parse fail');
 
-		// correct prototype chain check
 		expect(Object.getPrototypeOf(err)).toBe(ParseError.prototype);
+	});
+
+	it('supports ErrorOptions.cause', () => {
+		const cause = new Error('yaml error');
+
+		const err = new ParseError('parse fail', { cause });
+
+		expect(err.cause).toBe(cause);
 	});
 });
 
 describe('ValidationError', () => {
-	it('defaults errors to [message]', () => {
-		const err = new ValidationError('invalid');
+	it('stores validation issues', () => {
+		const issues = [
+			{
+				kind: 'schema',
+				type: 'string',
+				input: 123,
+				expected: 'string',
+				message: 'Expected string',
+			},
+		] as unknown as readonly BaseIssue<unknown>[];
+
+		const err = new ValidationError('validation failed', issues);
 
 		expect(err).toBeInstanceOf(Error);
 		expect(err).toBeInstanceOf(SkillError);
 		expect(err).toBeInstanceOf(ValidationError);
 
 		expect(err.name).toBe('ValidationError');
-		expect(err.message).toBe('invalid');
+		expect(err.message).toBe('validation failed');
 
-		expect(err.errors).toEqual(['invalid']);
+		expect(err.issues).toBe(issues);
 	});
 
-	it('accepts explicit errors list', () => {
-		const err = new ValidationError('many errors', ['err1', 'err2']);
+	it('freezes the issues array', () => {
+		const issues = [] as unknown as readonly BaseIssue<unknown>[];
 
-		expect(err.errors).toEqual(['err1', 'err2']);
-		expect(err.message).toBe('many errors');
+		const err = new ValidationError('validation failed', issues);
+
+		expect(Array.isArray(err.issues)).toBe(true);
+		expect(Object.isFrozen(err.issues)).toBe(true);
 	});
 
-	it('always exposes readonly errors array', () => {
-		const err = new ValidationError('x');
+	it('supports ErrorOptions.cause', () => {
+		const cause = new Error('validation cause');
 
-		expect(Array.isArray(err.errors)).toBe(true);
+		const err = new ValidationError('validation failed', [], { cause });
 
-		// ensure immutability
-		expect(Object.isFrozen(err.errors)).toBe(true);
+		expect(err.cause).toBe(cause);
 	});
 });

--- a/packages/skills-ref/test/models.test.ts
+++ b/packages/skills-ref/test/models.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { ALLOWED_TOOLS_KEY } from '../src/constants.js';
 import { toDict } from '../src/models.js';
 
 describe('toDict', () => {
@@ -29,7 +30,7 @@ describe('toDict', () => {
 
 		expect(result['license']).toBe('MIT');
 		expect(result['compatibility']).toBe('claude-3');
-		expect(result['allowed-tools']).toBe('bash');
+		expect(result[ALLOWED_TOOLS_KEY]).toBe('bash');
 		expect(result['metadata']).toEqual({
 			author: 'Alice',
 			version: '1.0',
@@ -44,7 +45,7 @@ describe('toDict', () => {
 
 		expect(result['license']).toBeUndefined();
 		expect(result['compatibility']).toBeUndefined();
-		expect(result['allowed-tools']).toBeUndefined();
+		expect(result[ALLOWED_TOOLS_KEY]).toBeUndefined();
 		expect(result['metadata']).toBeUndefined();
 	});
 

--- a/packages/skills-ref/test/parser.test.ts
+++ b/packages/skills-ref/test/parser.test.ts
@@ -134,6 +134,16 @@ metadata:
 
 		try {
 			expect(() => readProperties(tmp)).toThrow(ValidationError);
+
+			try {
+				readProperties(tmp);
+			} catch (error) {
+				expect(error).toBeInstanceOf(ValidationError);
+
+				if (error instanceof ValidationError) {
+					expect(error.issues.length).toBeGreaterThan(0);
+				}
+			}
 		} finally {
 			rmSync(tmp, {
 				recursive: true,
@@ -149,6 +159,16 @@ metadata:
 
 		try {
 			expect(() => readProperties(tmp)).toThrow(ValidationError);
+
+			try {
+				readProperties(tmp);
+			} catch (error) {
+				expect(error).toBeInstanceOf(ValidationError);
+
+				if (error instanceof ValidationError) {
+					expect(error.issues.length).toBeGreaterThan(0);
+				}
+			}
 		} finally {
 			rmSync(tmp, {
 				recursive: true,
@@ -173,6 +193,16 @@ description:
 
 		try {
 			expect(() => readProperties(tmp)).toThrow(ValidationError);
+
+			try {
+				readProperties(tmp);
+			} catch (error) {
+				expect(error).toBeInstanceOf(ValidationError);
+
+				if (error instanceof ValidationError) {
+					expect(error.issues.length).toBeGreaterThan(0);
+				}
+			}
 		} finally {
 			rmSync(tmp, {
 				recursive: true,

--- a/packages/skills-ref/test/validator.test.ts
+++ b/packages/skills-ref/test/validator.test.ts
@@ -104,4 +104,24 @@ description: desc
 			rmSync(tmp, { recursive: true, force: true });
 		}
 	});
+
+	it('returns parse errors for invalid frontmatter', () => {
+		const tmp = makeTempSkill(`---
+		name:
+  -
+		---`);
+
+		try {
+			const errors = validate(tmp);
+
+			expect(errors).toHaveLength(1);
+			expect(typeof errors[0]).toBe('string');
+			expect(errors[0]).not.toBe('');
+		} finally {
+			rmSync(tmp, {
+				recursive: true,
+				force: true,
+			});
+		}
+	});
 });

--- a/registry/relevance-signals.json
+++ b/registry/relevance-signals.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
-	"generatedAt": "2026-08-01",
+	"generatedAt": "2026-08-04",
 	"sourceDatasets": [
 		"planning-scenarios"
 	],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://json.schemastore.org/tsconfig",
 	"compilerOptions": {
 		"target": "ESNext",
 		"lib": ["ESNext"],

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -6,9 +6,8 @@
 			"dependsOn": ["^build"],
 			"outputs": ["dist/**"]
 		},
-		"hr-skills-build#build": {
-			"dependsOn": ["^build"],
-			"outputs": []
+		"build-skills": {
+			"cache": false
 		},
 		"dev": {
 			"persistent": true,


### PR DESCRIPTION
Migrate hr-skills-build to tsdown and modernize the build pipeline.

Separate library builds from skill artifact generation and introduce a dedicated build-skills Turbo task.

Update package scripts, exports, and JSON schema metadata while refactoring build, registry, validation, and shared modules to align with the new architecture.

Refresh GitHub Actions to use the new build pipeline and improve Bun and Turbo cache configuration.

Validation:
- bun run build
- bun run validate
- bun run typecheck
- bun test
- bun knip