### PR TITLE
docs: full-repo comment/JSDoc and markdown consistency audit

### DIFF
--- a/.agents/skills/biome/SKILL.md
+++ b/.agents/skills/biome/SKILL.md
@@ -62,7 +62,8 @@ These conventions are enforced automatically by Biome.
 
 ## Linting
 
-The repository enables the recommended Biome rule set.
+The repository enables the recommended Biome rule set, with one override:
+`complexity/useLiteralKeys` is turned off (see `biome.jsonc`).
 
 Linting focuses on:
 

--- a/.agents/skills/changeset/SKILL.md
+++ b/.agents/skills/changeset/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changeset
-description: Use when determining whether a pull request requires a changeset, selecting the appropriate version bump (patch, minor, or major), or writing a `.changeset/*.md` entry for the hr-skills repository.
+description: "Use when determining whether a pull request requires a changeset, selecting the appropriate version bump (patch, minor, or major), or writing a `.changeset/*.md` entry for the hr-skills repository."
 compatibility: hr-skills monorepo
 ---
 

--- a/.agents/skills/github-awesome-copilot-git-commit/SKILL.md
+++ b/.agents/skills/github-awesome-copilot-git-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-awesome-copilot-git-commit
-description: Generate high-quality, atomic Conventional Commits by analyzing Git changes, recommending logical commit boundaries, validating commit messages, and assisting with PRs, changelogs, and releases.
+description: "Generate high-quality, atomic Conventional Commits by analyzing Git changes, recommending logical commit boundaries, validating commit messages, and assisting with PRs, changelogs, and releases."
 metadata:
   author: Tuan Duc Tran
   version: "2.0.0"

--- a/.agents/skills/humanizer/SKILL.md
+++ b/.agents/skills/humanizer/SKILL.md
@@ -24,7 +24,7 @@ metadata:
 ### Rewrite tasks
 
 - "Rewrite this SKILL.md description to sound natural and clear: [text]."
-- "Shorten and sharpen the description to 50-120 characters while keeping trigger phrases."
+- "Shorten and sharpen the description while keeping every trigger phrase and staying above the 50-character minimum — real descriptions in this repo run 250-700+ characters, so don't over-trim."
 - "Convert this list of prompts into a consistent style and tone."
 - "Generate three tone variants for the Tips section: formal, friendly, concise."
 

--- a/.agents/skills/markdown/SKILL.md
+++ b/.agents/skills/markdown/SKILL.md
@@ -86,6 +86,8 @@ Repository configuration includes:
 - maximum line length disabled
 - duplicate headings allowed in different sections
 - multiple H1 headings permitted
+- blank lines around lists not enforced by markdownlint itself (`MD032: false`)
+  — see "Blank line before lists" below for the separate rule that does cover this
 - fenced code blocks required
 - table column alignment not enforced
 

--- a/.agents/skills/skill-vetter/SKILL.md
+++ b/.agents/skills/skill-vetter/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 - Validate SKILL.md frontmatter and required sections
 - Check for dangerous shell commands or wide file write permissions
 - Detect suspicious external URLs and credential leaks in content
+- Detect hidden Unicode (zero-width characters, homoglyphs) used to hide
+  injected instructions or spoof visible text
 - Verify metadata.author and licensing sections
 - Summarize permission scopes (read/write/commands) and risk level
 - Produce remediation suggestions for failing checks
@@ -27,6 +29,7 @@ metadata:
 - "Scan for bash commands that write to sensitive paths and list risky lines."
 - "Check permission scope strings for overly broad write access: [permissions]."
 - "Extract URLs from the skill and flag external hosts not on allowlist."
+- "Scan this content for zero-width characters or homoglyphs that could hide instructions."
 
 ### Remediation
 

--- a/.agents/skills/turbo/SKILL.md
+++ b/.agents/skills/turbo/SKILL.md
@@ -261,7 +261,10 @@ bun run build
 
 Use Turborepo caching to avoid rebuilding unchanged packages.
 
-Tasks such as `validate`, `sync`, and `matrix` intentionally disable caching because they always operate on the latest repository state.
+Tasks such as `sync` and `matrix` intentionally disable caching because they
+always operate on the latest repository state and write files as a side
+effect. `validate` is cacheable (it only depends on `^build`) — a repeat run
+with no source changes replays cached results instead of re-validating.
 
 ## Tips
 

--- a/.agents/skills/valibot/SKILL.md
+++ b/.agents/skills/valibot/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: valibot
-description: >
-  Repository guidance for using Valibot as the schema validation library within
-  the hr-skills monorepo. Use when writing or modifying schemas in
-  packages/skills-ref/src/schema.ts or packages/hr-skills-build/src/shared/schema.ts,
-  when validating parsed YAML frontmatter, when handling safeParse results, or
-  when inferring types from schemas.
+description: "Repository guidance for using Valibot as the schema validation library within the hr-skills monorepo. Use when writing or modifying schemas in packages/skills-ref/src/schema.ts or packages/hr-skills-build/src/shared/schema.ts, when validating parsed YAML frontmatter, when handling safeParse results, or when inferring types from schemas."
 metadata:
   author: Tuan Duc Tran
   version: "1.0.0"
@@ -25,8 +20,10 @@ Two files define schemas; all other packages consume them:
 - `packages/skills-ref/src/schema.ts` — `SkillPropertiesSchema`, the generic
   Agent Skills shape used by `readProperties()` in `loader.ts`
 - `packages/hr-skills-build/src/shared/schema.ts` — `MarketplaceJsonSchema` (validates
-  `.claude-plugin/marketplace.json`) and `SkillFrontmatterSchema` (used by
-  `parseSkillFrontmatter()` in `parser.ts`)
+  `.claude-plugin/marketplace.json`), `SkillFrontmatterSchema` (used by
+  `parseSkillFrontmatter()` in `parser.ts`), and `RegistrySchema` (used by
+  `validateRegistryConsistency()` in `validate-registry.ts` to check
+  `registry/skills.json` against its schema)
 
 Import pattern used throughout the repo:
 
@@ -89,10 +86,15 @@ wildcard `* as v` is the established convention here.
 
 ## Tips
 
-- Always use `v.safeParse` in this repo, not `v.parse` — `parser.ts` returns an
-  empty object on failure, and `loader.ts` throws a typed `ValidationError` using
-  `v.summarize(result.issues)`. Throwing directly from `v.parse` bypasses that
-  error handling pattern.
+- Prefer `v.safeParse` for anything derived from user-authored content
+  (`parser.ts`'s `parseSkillFrontmatter`, `loader.ts`) — `parser.ts` returns an
+  empty object on failure, and `loader.ts` throws a typed `ValidationError`
+  using `v.summarize(result.issues)`. Throwing directly from `v.parse` bypasses
+  that error handling pattern.
+  One deliberate exception: `build/sync.ts#syncMarketplace()` uses `v.parse`
+  directly against `MarketplaceJsonSchema`, since `.claude-plugin/marketplace.json`
+  is a repo-committed file expected to always be valid — an unhandled throw
+  there is the intended fail-fast behavior, not a bug to fix.
 - Apply `v.pipe(v.string(), v.trim())` to every string field that comes from
   user-authored YAML — frontmatter values frequently have trailing whitespace or
   newlines that would silently fail downstream string comparisons.
@@ -112,9 +114,11 @@ wildcard `* as v` is the established convention here.
 
 - Using Zod-style chaining such as `v.string().trim().email()` — Valibot has no
   method chaining. Use `v.pipe(v.string(), v.trim(), v.email())` instead.
-- Calling `v.parse(Schema, data)` instead of `v.safeParse` — this throws a raw
-  `ValiError` that bypasses the typed error hierarchy in `errors.ts`. Use
-  `v.safeParse` and handle `result.success` explicitly.
+- Calling `v.parse(Schema, data)` on user-authored content (SKILL.md
+  frontmatter, etc.) instead of `v.safeParse` — this throws a raw `ValiError`
+  that bypasses the typed error hierarchy in `errors.ts`. Use `v.safeParse`
+  and handle `result.success` explicitly. (`sync.ts`'s `v.parse` against a
+  repo-committed marketplace.json is the one intentional exception — see Tips.)
 - Forgetting `v.trim()` in the pipeline for string fields parsed from YAML —
   without it, fields with trailing newlines or spaces will pass validation but
   cause subtle mismatch bugs in downstream string comparisons like author name

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,14 +4,11 @@ Briefly describe the changes introduced in this pull request.
 
 ## Content Type
 
-- [ ] Skill definition
-- [ ] Competency framework
-- [ ] Interview questions
-- [ ] Assessment criteria
-- [ ] Recruiting workflow
-- [ ] AI prompt
-- [ ] Documentation
-- [ ] Tooling / Configuration
+- [ ] New skill (`skills/hr-*/`)
+- [ ] Skill tier upgrade (Bare/Partial → Full)
+- [ ] Content fix (existing skill)
+- [ ] Documentation (`docs/`, `README.md`, `GOVERNANCE.md`, etc.)
+- [ ] Tooling / Configuration (`packages/*`, `.github/workflows/`)
 
 ## Why?
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -562,15 +562,17 @@ bun run validate
 
 ### Current Workflows
 
-| Workflow      | Purpose                        |
-| ------------- | ------------------------------ |
-| lint.yml      | Code and documentation quality |
-| test.yml      | Automated testing              |
-| typecheck.yml | Type validation                |
-| validate.yml  | Skill quality validation       |
-| knip.yml      | Dead code detection            |
-| matrix.yml    | Skill maturity generation      |
-| release.yml   | Changesets release automation  |
+| Workflow          | Purpose                        |
+| ----------------- | ------------------------------ |
+| lint.yml          | Code and documentation quality |
+| test.yml          | Automated testing              |
+| typecheck.yml     | Type validation                |
+| validate.yml      | Skill quality validation       |
+| knip.yml          | Dead code detection            |
+| matrix.yml        | Skill maturity generation      |
+| release.yml       | Changesets release automation  |
+| publish.yml       | Tag-triggered npm/dist publish |
+| skill-review.yml  | Automated PR skill review      |
 
 ---
 

--- a/docs/contributing/examples.md
+++ b/docs/contributing/examples.md
@@ -82,7 +82,7 @@ git push origin fix/hr-analytics-turnover-formula
 ```bash
 git checkout -b docs/clarify-skill-tiers
 
-# Edit docs/format.md (or docs/contributing/*.md once added)
+# Edit docs/format.md (or another file under docs/contributing/)
 
 bun run lint:md
 bun run lint:links
@@ -97,16 +97,15 @@ Applies to all of the above:
 1. Base branch: `dev` (never `main`).
 2. Fill in `.github/pull_request_template.md`:
    - **What changed** — one or two sentences
-   - **Content type** — check the box(es) that apply (skill definition, competency
-     framework, interview questions, assessment criteria, recruiting workflow, AI prompt,
-     documentation, tooling/configuration)
+   - **Content type** — check the box(es) that apply (new skill, skill tier
+     upgrade, content fix, documentation, tooling/configuration)
    - **Why** — the problem being solved or value added
    - **Related issue** — `Closes #NN` if applicable
    - **Validation** — confirm content reviewed, no duplicate information, links verified,
      formatting follows repository standards, CI checks pass
    - **Commit convention** — confirm commits follow Conventional Commits
 3. Wait for CI (`.github/workflows/`: `knip`, `lint`, `matrix`, `test`, `typecheck`,
-   `validate`) to pass.
+   `validate`, plus `skill-review` for PRs touching `skills/hr-*/**`) to pass.
 4. A maintainer reviews and merges.
 
 ## Best practices

--- a/docs/contributing/onboarding.md
+++ b/docs/contributing/onboarding.md
@@ -9,7 +9,7 @@ where things live and why" before writing any code or content.
 
 HR Skills **[Existing]** is a Bun + Turborepo monorepo. Three kinds of things live in it:
 
-1. **The product** — `skills/hr-*/`, 140+ domain-specific Agent Skill packages.
+1. **The product** — `skills/hr-*/`, 146 domain-specific Agent Skill packages.
 2. **The tooling** — `packages/hr-skills-build/` (validation, matrix/registry generation,
    planner, evaluation CLI) and `packages/skills-ref/` (TypeScript library for reading,
    validating, and generating prompts from skill files).
@@ -19,9 +19,10 @@ HR Skills **[Existing]** is a Bun + Turborepo monorepo. Three kinds of things li
    Claude Code is expected to follow when helping maintain the repo, and are a fast way to
    understand "how things are done here."
 
-`docs/` **[Existing]** holds two kinds of files: specifications you can read and are expected
-to follow (`docs/format.md`, `docs/evaluation.md`, `docs/planner.md`, `docs/runtime.md`,
-`docs/registry.md`), and **generated reports** you should never hand-edit
+`docs/` **[Existing]** holds 16 files: 15 hand-written specifications and reference docs
+(`docs/format.md`, `docs/registry.md`, `docs/evaluation.md`, `docs/planner.md`,
+`docs/runtime.md`, `docs/search.md`, and others covering each subsystem — see the directory
+listing for the full set), plus one **generated report** you should never hand-edit
 (`docs/skill-matrix.md`).
 
 ## Existing behavior — directory reference

--- a/docs/contributing/skill-authoring.md
+++ b/docs/contributing/skill-authoring.md
@@ -53,10 +53,11 @@ skills/hr-your-skill/
      ever activates the skill
    - `metadata.author`, `metadata.version` (start new skills at `"1.0.0"`)
 4. Write the required body sections:
-   - **Supported tasks** — a bullet list, recommended 8–12 items
-   - **Key prompts** — 3–6 subtopics, each with 4–7 numbered prompts using `[placeholders]`
-     for variable inputs
-   - **Tips** — 4–6 bullets of practical, professional guidance
+   - **Supported tasks** — a bullet list, **8–12 items required** (`bun run validate`
+     fails outside this range, it isn't just a suggestion)
+   - **Key prompts** — **3–6 subtopics required**, each with **4–7 numbered prompts
+     required**, using `[placeholders]` for variable inputs
+   - **Tips** — **4–6 bullets required** of practical, professional guidance
 5. (Recommended for Full tier) Add `content/*.md`, `prompts/*.md`, `examples/*.md`:
    - `content/*.md` — explains concepts in depth (Overview / Main topics / Practical guidance
      is a typical, not mandatory, shape)

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -73,8 +73,12 @@ here (`check`, `lint`, `format`, `knip`, `changeset`, `release`) are plain Bun s
 Turborepo task of their own; `.agents/skills/bun/SKILL.md` covers those.
 
 **[Existing]** CI (`.github/workflows/`) runs `knip.yml`, `lint.yml`, `matrix.yml`,
-`release.yml`, `test.yml`, `typecheck.yml`, and `validate.yml` as separate jobs.
-CONTRIBUTING.md's pre-submit checklist already matches this list (see below).
+`publish.yml`, `release.yml`, `skill-review.yml`, `test.yml`, `typecheck.yml`, and
+`validate.yml` as separate jobs.
+CONTRIBUTING.md's pre-submit checklist covers the local-command equivalents of these
+(`bun run typecheck`, `test`, `validate`, `lint:md`, `knip`); it doesn't enumerate every
+CI workflow filename, since `publish.yml`/`release.yml`/`skill-review.yml` run
+automatically on merge and aren't something a contributor triggers locally.
 
 ## Existing behavior — testing and validation
 

--- a/docs/duplicate-detection.md
+++ b/docs/duplicate-detection.md
@@ -86,7 +86,7 @@ composite ≥ 0.55   (default DUPLICATE_THRESHOLD)
 
 ## HR domain stop-words
 
-Approximately 70 common HR terms and English function words are filtered out before similarity is measured.  This prevents high vocabulary overlap caused by domain terminology alone from triggering false-positive warnings.
+Approximately 150 common HR terms and English function words are filtered out before similarity is measured.  This prevents high vocabulary overlap caused by domain terminology alone from triggering false-positive warnings.
 
 Examples of filtered terms:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ replace `SKILL.md` content, they orchestrate it.
 
 | Example | What it demonstrates |
 | --- | --- |
-| [`planner-runtime/from-intent-to-execution.md`](planner-runtime/from-intent-to-execution.md) | Turning one of the scenarios above into an `ExecutionPlan` with `bun src/generate-plan.ts`, then running it with `bun src/execute-plan.ts`, reading the resulting trace |
+| [`planner-runtime/from-intent-to-execution.md`](planner-runtime/from-intent-to-execution.md) | Turning one of the scenarios above into an `ExecutionPlan` with `bun run plan`, then running it with `bun run execute`, reading the resulting trace |
 
 ## Conventions used across these examples
 

--- a/examples/planner-runtime/from-intent-to-execution.md
+++ b/examples/planner-runtime/from-intent-to-execution.md
@@ -17,7 +17,7 @@ skills to load and *in what order*, rather than a person manually choosing
 ## Step 1 — Generate a plan from intent
 
 ```bash
-bun src/generate-plan.ts "hire a senior backend engineer: write the job description, run interviews, and prepare an offer"
+bun run plan "hire a senior backend engineer: write the job description, run interviews, and prepare an offer"
 ```
 
 The Planner (`packages/hr-skills-build/src/planner/planner.ts`) splits this intent
@@ -46,8 +46,8 @@ sort. The shape of the result — illustrating the documented
     {
       "skillId": "hr-recruiting",
       "order": 2,
-      "reason": "domain-expert",
-      "rationale": "Recruiting workflow expertise for sourcing and screening ahead of interviews",
+      "reason": "recommended-pairing",
+      "rationale": "Pulled in via hr-job-description's relatedSkills entry — sourcing and screening naturally follow writing the job description",
       "dependencies": []
     },
     {
@@ -78,7 +78,7 @@ dependency violations) before you act on it.
 ## Step 2 — Execute the plan
 
 ```bash
-bun src/execute-plan.ts "hire a senior backend engineer: write the job description, run interviews, and prepare an offer"
+bun run execute "hire a senior backend engineer: write the job description, run interviews, and prepare an offer"
 ```
 
 `execute-plan.ts` regenerates the same plan and runs it through
@@ -89,9 +89,9 @@ actually loads each skill's `SKILL.md`, builds a prompt from
 `context.toObject()` (the outputs of earlier steps), and calls a model:
 
 ```typescript
-import { executeWorkflow } from './runtime.js';
-import { generateExecutionPlan } from './planner.js';
-import { buildRegistry } from './registry.js';
+import { executeWorkflow } from './runtime/runtime.js';
+import { generateExecutionPlan } from './planner/planner.js';
+import { buildRegistry } from './registry/registry.js';
 
 const registry = await buildRegistry();
 const plan = generateExecutionPlan(

--- a/examples/prompt-to-output/README.md
+++ b/examples/prompt-to-output/README.md
@@ -4,7 +4,7 @@ Every skill ships its own `examples/` directory with realistic HR scenarios,
 sample prompts, and the output an agent should produce — see
 [`docs/format.md`](../../docs/format.md) for the authoring format. This page
 is a discoverability index into those, organized by workflow stage, so you
-don't have to browse 150+ skill folders to find a relevant one.
+don't have to browse 146 skill folders to find a relevant one.
 
 For examples that chain *multiple* skills together, see
 [`../end-to-end/`](../end-to-end) instead — this page is single-skill,

--- a/packages/hr-skills-build/src/build/generate-skill-matrix.ts
+++ b/packages/hr-skills-build/src/build/generate-skill-matrix.ts
@@ -1,7 +1,7 @@
 /**
  * Generates docs/skill-matrix.md — a snapshot of every skill's maturity tier,
- * content depth, and validation status. Run via `bun run matrix` or automatically
- * as a pre-release step in CI (matrix.yml workflow).
+ * content depth, and validation status. Run via `bun run matrix`, or
+ * automatically on every push to `main` (see .github/workflows/matrix.yml).
  */
 
 import { writeFile } from 'node:fs/promises';

--- a/packages/hr-skills-build/src/build/router.ts
+++ b/packages/hr-skills-build/src/build/router.ts
@@ -50,7 +50,10 @@ function extractUseWhen(description: string): string {
 	if (idx !== -1) {
 		// Everything after "Use when "
 		const raw = description.slice(idx).replace(USE_WHEN_RE, '').trim();
-		// Take up to the first period or 120 chars
+		// Take up to the first period (no length cap here — descriptions are
+		// expected to state the trigger in one sentence; the 120-char cap
+		// below only guards the fallback path, where we take an arbitrary
+		// first sentence that might run long).
 		const sentence = raw.split('.')[0] ?? raw;
 		return sentence.trim().replace(/\.$/, '');
 	}
@@ -110,9 +113,9 @@ function renderRoutingTables(
 
 	// Uncategorized — only rendered if non-empty (signals new skills need classifier entry)
 	if (uncategorized.length > 0) {
-		lines.push('### Uncategorized (add to classifier.ts)', '');
+		lines.push('### Uncategorized (add to registry/classifier.ts)', '');
 		lines.push(
-			'> ⚠️  These skills were not matched by the classifier. Add them to `src/classifier.ts`.',
+			'> ⚠️  These skills were not matched by the classifier. Add them to `src/registry/classifier.ts`.',
 			'',
 		);
 		lines.push('| Skill | Use when the task involves... |');

--- a/packages/hr-skills-build/src/cli/execute-plan.ts
+++ b/packages/hr-skills-build/src/cli/execute-plan.ts
@@ -21,21 +21,8 @@ import * as p from '@clack/prompts';
 import { generateExecutionPlan } from '../planner/planner.js';
 import { buildRegistry } from '../registry/registry.js';
 import { executeWorkflow } from '../runtime/runtime.js';
-import type { ExecutionStep, RuntimeContext } from '../shared/types.js';
+import { stubStepExecutor } from '../shared/helpers.js';
 import { printUsageAndExit, runCli } from './cli-bootstrap.js';
-
-/**
- * A stub step executor for CLI demonstration purposes. Real integrations
- * should replace this with logic that actually invokes the skill (for
- * example, loading its SKILL.md and prompting a model).
- */
-const stubStepExecutor = (step: ExecutionStep, context: RuntimeContext): unknown => {
-	return {
-		skillId: step.skillId,
-		note: `Stub output for ${step.skillId}`,
-		precedingSteps: Object.keys(context.toObject()),
-	};
-};
 
 async function main() {
 	const intent = process.argv[2];

--- a/packages/hr-skills-build/src/cli/generate-registry.ts
+++ b/packages/hr-skills-build/src/cli/generate-registry.ts
@@ -3,8 +3,9 @@
  * is the single source of truth for skill discovery, routing, capability
  * lookup, aliases, domains, and relationships at runtime.
  *
- * Run via `bun run registry`, or automatically as a pre-release step in CI
- * (matrix.yml workflow, alongside docs/skill-matrix.md).
+ * Run via `bun run registry`, or automatically on every push to `main`
+ * (matrix.yml workflow, alongside docs/skill-matrix.md — see
+ * .github/workflows/matrix.yml).
  *
  * See docs/registry.md for the full architecture writeup.
  */

--- a/packages/hr-skills-build/src/cli/run-evaluation.ts
+++ b/packages/hr-skills-build/src/cli/run-evaluation.ts
@@ -90,14 +90,18 @@ async function main() {
 	p.log.success(`Evaluation report saved to: ${outputPath}`);
 
 	const hasRegressions = reports.some((r) => r.regressedCaseIds.length > 0);
-	const hasInvalidPlans = reports.some((r) => r.failedCases > 0);
+	// failedCases counts every case that isn't a clean pass (regression and/or
+	// an invalid plan) — broader than "invalid plans" alone, so this check
+	// can catch failures hasRegressions alone would miss (e.g. an invalid
+	// plan with no golden fixture to regress against yet).
+	const hasFailedCases = reports.some((r) => r.failedCases > 0);
 
 	if (updateGolden) {
 		p.outro('Golden fixtures updated');
 		process.exit(0);
 	}
 
-	if (hasRegressions || hasInvalidPlans) {
+	if (hasRegressions || hasFailedCases) {
 		p.outro('Completed with regressions or failures');
 		process.exit(1);
 	}

--- a/packages/hr-skills-build/src/evaluation/evaluate.ts
+++ b/packages/hr-skills-build/src/evaluation/evaluate.ts
@@ -13,33 +13,18 @@
 
 import { generateExecutionPlan } from '../planner/planner.js';
 import { executeWorkflow } from '../runtime/runtime.js';
+import { stubStepExecutor } from '../shared/helpers.js';
 import type {
 	EvaluationCase,
 	EvaluationCaseResult,
 	EvaluationDataset,
 	EvaluationReport,
-	ExecutionStep,
 	GoldenCaseResult,
 	GoldenFixture,
 	QualityMetrics,
 	Registry,
-	RuntimeContext,
 } from '../shared/types.js';
 import { validateExecutionPlan } from '../validation/validate-planner.js';
-
-/**
- * The same stub step executor used by `execute-plan.ts`. Reused here (rather
- * than redefined) so that evaluation results characterize the Planner and
- * Runtime's sequencing/validation behavior, not a divergent stand-in.
- */
-const evaluationStepExecutor = (
-	step: ExecutionStep,
-	context: RuntimeContext,
-): unknown => ({
-	skillId: step.skillId,
-	note: `Stub output for ${step.skillId}`,
-	precedingSteps: Object.keys(context.toObject()),
-});
 
 /** Run a single evaluation case against the given registry, deterministically. */
 export async function runCase(
@@ -54,7 +39,7 @@ export async function runCase(
 	const workflow =
 		plan.steps.length === 0
 			? { status: 'completed' as const }
-			: await executeWorkflow(plan, evaluationStepExecutor);
+			: await executeWorkflow(plan, stubStepExecutor);
 
 	return {
 		caseId: evalCase.id,

--- a/packages/hr-skills-build/src/planner/planner.ts
+++ b/packages/hr-skills-build/src/planner/planner.ts
@@ -30,7 +30,7 @@ import type {
 // Execution Plan Model
 // ============================================================================
 
-// Planner types have been moved to src/types.ts to centralize shared
+// Planner types have been moved to src/shared/types.ts to centralize shared
 // interfaces and avoid duplication. See that file for the canonical
 // definitions used across planner, validator, and tests.
 

--- a/packages/hr-skills-build/src/registry/discovery.ts
+++ b/packages/hr-skills-build/src/registry/discovery.ts
@@ -11,6 +11,12 @@ import type { SkillDirectoryOptions } from '../shared/types.js';
  *  1. It starts with the configured `prefix` (default: `"hr-"`).
  *  2. It contains a `SKILL.md` file at its root (checked via `fs.access`).
  *
+ * Currently used only by `build/sync.ts`, which needs that `SKILL.md`
+ * guarantee before generating marketplace.json entries. Most other callers
+ * use the lighter `shared/helpers.ts#discoverSkills()` instead (no
+ * existence check, no options) since they read `SKILL.md` themselves right
+ * after and handle a missing file there.
+ *
  * @param options - Filtering and sorting options.
  * @param options.prefix - Directory-name prefix to filter by. Defaults to `"hr-"`.
  * @param options.sort - Whether to return names in lexicographic order. Defaults to `true`.

--- a/packages/hr-skills-build/src/search/recommendations.ts
+++ b/packages/hr-skills-build/src/search/recommendations.ts
@@ -2,14 +2,15 @@
  * Skill Recommendation Layer — Phase 6.1
  *
  * Exposes the `relatedSkills` graph that already lives in
- * `registry/skills.json` (computed by `rankRelatedSkills()` in registry.ts)
- * as a reusable, user-facing "skills you might also need" API — instead of
- * leaving it as internal Planner input only.
+ * `registry/skills.json` (computed by `rankRelatedSkills()`, then usually
+ * re-ranked with usage-informed signals by `reRankRelatedSkills()` — see
+ * registry.ts) as a reusable, user-facing "skills you might also need" API
+ * — instead of leaving it as internal Planner input only.
  *
  * This module is intentionally thin: it reads a `Registry` object and looks
  * up an already-ranked, already-capped list. It does not re-rank, re-score,
- * or introduce any new signal (no AI ranking, no embeddings, no heuristics).
- * The only source of truth is `RegistryEntry.relatedSkills`.
+ * or introduce any new signal (no AI ranking, no embeddings, no heuristics
+ * of its own). The only source of truth is `RegistryEntry.relatedSkills`.
  *
  * Consumes only `Registry` / `RegistryEntry` (as produced from
  * `registry/skills.json`) — never parses `SKILL.md` files directly.
@@ -36,10 +37,12 @@ export class UnknownSkillError extends Error {
  * Get the top related skills for a given skill ID.
  *
  * Ranking rule: preserves the order already computed for
- * `RegistryEntry.relatedSkills` (same-domain skills ranked by shared-tag
- * overlap, ties broken alphabetically — see `rankRelatedSkills()` in
- * registry.ts). This function does not alter that order; it only looks up,
- * caps, and formats it.
+ * `RegistryEntry.relatedSkills` — same-domain skills ranked by shared-tag
+ * overlap via `rankRelatedSkills()`, then (when a relevance signal table was
+ * available at registry-build time, which is the default `bun run registry`
+ * path) re-ranked by `reRankRelatedSkills()` to blend in observed
+ * co-selection evidence — see registry.ts. This function does not alter
+ * that order itself; it only looks up, caps, and formats it.
  *
  * Deterministic: for a fixed registry and skill ID, the same input always
  * produces the same output, in the same order.

--- a/packages/hr-skills-build/src/search/search.ts
+++ b/packages/hr-skills-build/src/search/search.ts
@@ -322,8 +322,9 @@ function buildExplanation(matches: SkillFieldMatch[]): string {
  *     stronger discoverability signal than one big match.
  *  3. A skill with at least one *exact* match gets a flat confidence bonus,
  *     so exact matches reliably outrank fuzzy-only matches.
- *  4. Ties are broken by skill ID, ascending — so identical registry
- *     content always produces identical ordering, run after run.
+ *  4. Ties are broken by number of distinct fields matched (more wins),
+ *     then by skill ID ascending — so identical registry content always
+ *     produces identical ordering, run after run.
  *
  * @param query - The search query. `query.text` is required unless
  *   `query.domain` is set (a domain-only browse is a valid query).

--- a/packages/hr-skills-build/src/shared/helpers.ts
+++ b/packages/hr-skills-build/src/shared/helpers.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path';
 import { HR_SKILL_PREFIX, SKILLS_DIR } from './constants.js';
 import { parseSkillFrontmatter } from './parser.js';
 import type { SkillFrontmatter } from './schema.js';
-import type { SkillValidationIssue, Tier } from './types.js';
+import type {
+	ExecutionStep,
+	RuntimeContext,
+	SkillValidationIssue,
+	Tier,
+} from './types.js';
 
 /**
  * Extract and trim the first capture group from a regex match against `content`.
@@ -23,6 +28,17 @@ export function extractMatch(regex: RegExp, content: string): string | null {
  * Only directories whose names start with `HR_SKILL_PREFIX` (`"hr-"`) are returned.
  *
  * @returns A promise that resolves to a sorted array of skill directory names.
+ */
+/**
+ * Discover all `hr-*` skill directory names under `skills/`, sorted.
+ *
+ * Does not verify `SKILL.md` exists in each directory — callers that need
+ * that guarantee (e.g. filtering out incomplete/in-progress skill folders)
+ * should use `registry/discovery.ts#getHrSkills()` instead, which checks
+ * for `SKILL.md` via `fs.access` and supports a configurable prefix. This
+ * function is the lighter-weight default used by most of `validation/`,
+ * `build/`, and `search/`, which read (and error-handle) `SKILL.md`
+ * themselves immediately after.
  */
 export async function discoverSkills(): Promise<string[]> {
 	const entries = await readdir(SKILLS_DIR, {
@@ -160,8 +176,8 @@ export async function countFiles(dirPath: string): Promise<number> {
  * - `'partial'` — one or two subdirectories are present.
  *
  * This is the single source of truth for tier classification — used by both
- * `generate-skill-matrix.ts` and `generate-registry.ts` so the matrix and the
- * registry can never disagree about a skill's tier.
+ * `build/generate-skill-matrix.ts` and `registry/registry.ts` so the matrix
+ * and the registry can never disagree about a skill's tier.
  *
  * @param hasContent - Whether the `content/` subdirectory exists and is non-empty.
  * @param hasPrompts - Whether the `prompts/` subdirectory exists and is non-empty.
@@ -243,4 +259,22 @@ export function makeKeyPromptsContent(subtopics: number, promptsEach: number): s
 		'',
 		'- Tip',
 	].join('\n');
+}
+
+/**
+ * A stub `StepExecutorFn` that returns a deterministic placeholder output
+ * instead of actually invoking a skill. Shared by `cli/execute-plan.ts` (CLI
+ * demonstration) and `evaluation/evaluate.ts` (so evaluation results
+ * characterize the Planner/Runtime's sequencing and validation behavior, not
+ * a divergent stand-in) — previously duplicated independently in both files.
+ *
+ * Real integrations should supply their own `StepExecutorFn` that actually
+ * invokes the skill (for example, loading its SKILL.md and prompting a model).
+ */
+export function stubStepExecutor(step: ExecutionStep, context: RuntimeContext): unknown {
+	return {
+		skillId: step.skillId,
+		note: `Stub output for ${step.skillId}`,
+		precedingSteps: Object.keys(context.toObject()),
+	};
 }

--- a/packages/hr-skills-build/src/shared/parser.ts
+++ b/packages/hr-skills-build/src/shared/parser.ts
@@ -16,7 +16,12 @@ import { SkillFrontmatterSchema } from './schema.js';
 import type { SkillMeta } from './types.js';
 
 /**
- * Parse YAML frontmatter from a markdown document.
+ * Parse and validate a markdown document's YAML frontmatter against
+ * {@link SkillFrontmatterSchema}.
+ *
+ * Never throws: missing frontmatter, invalid YAML, and schema validation
+ * failures all resolve to `{}` rather than raising an error, so callers can
+ * treat every field as optional.
  */
 export function parseSkillFrontmatter(content: string): SkillFrontmatter {
 	const frontmatter = extractMatch(FRONTMATTER_REGEX, content);
@@ -37,7 +42,12 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter {
 }
 
 /**
- * Parse skill metadata from a markdown document.
+ * Read a skill's `SKILL.md` and derive display metadata from it: the
+ * description split at "Use when" into `coverage`/`scopeSentence`, the
+ * `## Supported tasks` list, and up to 5 quoted example prompts from
+ * `## Key prompts` as `triggerPhrases`.
+ *
+ * @throws If `SKILL.md` cannot be read from the filesystem (see `readSkill`).
  */
 export async function parseSkillMeta(skillName: string): Promise<SkillMeta> {
 	const { content, frontmatter } = await readSkill(skillName);

--- a/packages/hr-skills-build/src/shared/types.ts
+++ b/packages/hr-skills-build/src/shared/types.ts
@@ -120,8 +120,12 @@ export interface RegistryEntry {
 	 */
 	dependencies: string[];
 	/**
-	 * Other skill IDs in the same domain, ranked by shared-tag overlap and
-	 * capped — a lightweight, fully deterministic recommendation graph.
+	 * Other skill IDs in the same domain, ranked by shared-tag overlap. When
+	 * `bun run registry` (the default path) finds a committed relevance
+	 * signal table, this static ranking is then blended with observed
+	 * co-selection rates via `reRankRelatedSkills` — which can also surface
+	 * cross-domain pairs the tag overlap alone missed. Still fully
+	 * deterministic (no randomness), just not purely tag-based in practice.
 	 */
 	relatedSkills: string[];
 }
@@ -264,12 +268,38 @@ export interface Registry {
 // Planner and validation types
 // ---------------------------------------------------------------------------
 
+/**
+ * Why a skill was included in an execution plan. Read together with
+ * `ExecutionStep.rationale` for a human-readable explanation.
+ *
+ * Note the two that are easy to conflate: `'related-skill'` is a *capability*
+ * match (the skill's declared capabilities partially/fuzzily overlap the
+ * requested one — see `matchCapabilityAgainstRegistry()` in planner.ts),
+ * while `'recommended-pairing'` comes from the *registry* `relatedSkills`
+ * graph (a different skill was already selected, and this one is commonly
+ * used alongside it). Despite the name, `'related-skill'` has nothing to do
+ * with `RegistryEntry.relatedSkills`.
+ */
 export type SelectionReason =
+	/** Exact substring match against one of the skill's declared capabilities. */
 	| 'direct-capability-match'
+	/**
+	 * Reserved — not currently assigned anywhere in `planner.ts`. Intended
+	 * for a future alias/alternate-name match, distinct from a capability
+	 * match, but no such matcher exists yet.
+	 */
 	| 'alias-match'
+	/**
+	 * Reserved — not currently assigned anywhere in `planner.ts`. Intended
+	 * for a future "best single skill for this whole domain" selection, but
+	 * no such matcher exists yet.
+	 */
 	| 'domain-expert'
+	/** Pulled in because a selected skill declares it as a dependency. */
 	| 'dependency-requirement'
+	/** Pulled in via `RegistryEntry.relatedSkills` of an already-selected skill. */
 	| 'recommended-pairing'
+	/** Partial/fuzzy capability-overlap match (see the note above). */
 	| 'related-skill';
 
 export interface ExecutionStep {

--- a/packages/hr-skills-build/src/validation/detect-duplicates.ts
+++ b/packages/hr-skills-build/src/validation/detect-duplicates.ts
@@ -32,7 +32,7 @@
  *
  * ## Stop-word / common-HR-term filtering
  *
- * A built-in list of ~70 HR domain stop-words ("employee", "manager",
+ * A built-in list of ~150 HR domain stop-words ("employee", "manager",
  * "process", "team", …) is subtracted before similarity is measured.  This
  * prevents high vocabulary overlap caused by domain terminology alone from
  * triggering false-positive warnings.

--- a/packages/hr-skills-build/src/validation/validate-planner.ts
+++ b/packages/hr-skills-build/src/validation/validate-planner.ts
@@ -2,11 +2,13 @@
  * Planner validation — checks execution plans for soundness.
  *
  * Validates:
- *  - No circular skill dependencies
- *  - No dangling skill references
- *  - Capability coverage (at least one match per requested capability)
- *  - Execution order respects dependencies
  *  - No duplicate steps
+ *  - No dangling skill references (including missing dependency references)
+ *  - Execution order respects dependencies
+ *  - No circular skill dependencies
+ *  - Capability coverage (at least one match per requested capability)
+ *  - Empty plan (warning — a plan with zero steps is not itself an error)
+ *  - Step `order` fields form a consistent 0..N-1 sequence
  *
  * All validations are deterministic and produce clear, actionable diagnostics.
  */

--- a/packages/skills-ref/src/helpers.ts
+++ b/packages/skills-ref/src/helpers.ts
@@ -95,6 +95,13 @@ export function createSkillBlock(skillDir: string): string {
  * Discover all HR skill directory names in the `skills/` folder, sorted
  * lexicographically. Only directories whose names begin with `"hr-"` are returned.
  *
+ * This is skills-ref's own copy of the same "discover hr-* directories"
+ * logic that also exists as `hr-skills-build`'s
+ * `shared/helpers.ts#discoverSkills()` and `registry/discovery.ts#getHrSkills()`.
+ * Kept separate deliberately — skills-ref must not depend on
+ * hr-skills-build (it's the lower-level package the other one builds on)
+ * — not an accidental duplication to merge.
+ *
  * @returns A sorted array of skill directory names (not full paths).
  */
 export function discoverSkillNames(): string[] {


### PR DESCRIPTION
Systematic review of every JSDoc comment and cross-file reference in packages/*/src/**/*.ts, plus every non-skill markdown file in the repo (config files, .github/workflows/*.yml comments, .agents/skills/ */SKILL.md, docs/, examples/), verifying each claim against the actual implementation rather than assuming accuracy.

Highlights (40+ individual fixes across TypeScript and Markdown):

- shared/types.ts: RegistryEntry.relatedSkills doc claimed pure tag-overlap ranking; the default bun run registry path actually blends in usage-informed signals via reRankRelatedSkills — same stale claim found and fixed in 3 separate files (types.ts, recommendations.ts x2).
- Stale/wrong file-path references: planner.ts pointed to a 'src/types.ts' that hasn't existed since the shared/ reorg; router.ts pointed to 'src/classifier.ts' (real: registry/ classifier.ts) in text shown in the generated root SKILL.md itself.
- evaluate.ts/execute-plan.ts: a doc claimed a stub executor was 'reused' between the two files when it was actually duplicated independently — extracted the real shared implementation to shared/helpers.ts#stubStepExecutor.
- detect-duplicates.ts + docs/duplicate-detection.md: '~70 HR stop-words' claim was stale; actual list has grown to 149 entries.
- skill-vetter/SKILL.md: undocumented a 5th security check (hidden-Unicode detection) that security.ts actually implements.
- validate-planner.ts: header listed 5 validations, code runs 7.
- search.ts: ranking-rule doc omitted an intermediate tiebreak (matches.length) that the real sort comparator uses.
- SelectionReason: added per-value docs; 'related-skill' is easily confused with 'recommended-pairing' despite having nothing to do with the relatedSkills registry field; 'alias-match'/'domain-expert' are declared but never assigned anywhere (documented as reserved).
- .github/pull_request_template.md: the 'Content Type' checklist was a stale recruiting-only list that didn't match what GOVERNANCE.md claims it maps to; docs/contributing/examples.md repeated the same stale list and was missing skill-review.yml from its CI wait-list.
- docs/ROADMAP.md and docs/contributing/workflow.md: both 'current workflows' lists were missing 2 of 9 real .github/workflows/*.yml files (publish.yml, skill-review.yml).
- valibot/SKILL.md: 'Always use v.safeParse, never v.parse' was false as an absolute — sync.ts intentionally uses v.parse as a deliberate fail-fast exception; qualified instead of contradicting real code. Also had the same stale 'description: >' YAML format already fixed elsewhere, and was missing a third schema (RegistrySchema) from its 'where Valibot is used' list.
- turbo/SKILL.md: 'validate intentionally disables caching' was false — only sync/matrix do; validate is genuinely cacheable, confirmed by an actual cache-hit/miss run.
- examples/README.md + planner-runtime/from-intent-to-execution.md: literal example commands (bun src/generate-plan.ts) used a path that doesn't exist (real: src/cli/generate-plan.ts) and would fail if run as written; also used reason: "domain-expert", a SelectionReason value confirmed never actually assigned by planner.ts.
- Several '140+'/'150+' skill-count approximations replaced with the exact, repeatedly-confirmed count of 146.

Cross-package near-duplication noted (not merged, deliberately kept separate): shared/helpers.ts#discoverSkills(), registry/discovery.ts #getHrSkills(), and skills-ref/helpers.ts#discoverSkillNames() are three independent 'discover hr-* directories' implementations with one real behavioral difference (SKILL.md existence check) and a real architectural reason for the cross-package split (skills-ref must not depend on hr-skills-build). Cross-referenced all three instead of merging into a shared god-file.

Verified after every fix: bun run typecheck, test (436/436), lint, lint:md, lint:links (0 broken links), build, validate (146/146), sync — all pass.