### PR TITLE
refactor(build): rely on tsdown defaults

### DIFF
--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -64,7 +64,7 @@ test/
 tsconfig.json
 ```
 
-Packages may extend the shared repository configuration while adding package-specific files such as build configuration.
+Packages extend the shared repository TypeScript configuration while keeping package-specific configuration minimal.
 
 ## Code organization
 
@@ -140,6 +140,15 @@ bun run build
 - "Recommend a cleaner public API."
 - "Validate this package structure."
 
+## Configuration philosophy
+
+Repository configuration should remain as simple as possible.
+
+- Prefer tool defaults over explicit configuration.
+- Extend shared repository configuration instead of duplicating settings.
+- Add package-specific configuration only when the defaults are insufficient.
+- Keep build and compiler configuration easy to understand and maintain.
+
 ### Refactoring
 
 - "Simplify this TypeScript implementation."
@@ -162,17 +171,12 @@ Run repository type checking.
 bun run typecheck
 ```
 
-Package configuration — both `packages/hr-skills-build` and `packages/skills-ref` use this
-exact shape (both build with tsdown as of the tsdown migration).
+Package `tsconfig.json` files extend the shared repository configuration and include only the package sources.
 
 ```json
 {
   "extends": "../../tsconfig.json",
-  "include": [
-    "src",
-    "test",
-    "tsdown.config.ts"
-  ]
+  "include": ["src", "test"]
 }
 ```
 
@@ -183,7 +187,7 @@ exact shape (both build with tsdown as of the tsdown migration).
 - Keep implementations simpler than their type definitions.
 - Use `unknown` instead of `any` whenever possible.
 - Validate changes with `bun run typecheck`.
-- Keep package-specific configuration minimal.
+- Keep package-specific TypeScript configuration minimal and rely on shared defaults whenever possible.
 
 ## Common issues
 

--- a/changes.patch
+++ b/changes.patch
@@ -1,0 +1,104 @@
+diff --git a/.agents/skills/typescript/SKILL.md b/.agents/skills/typescript/SKILL.md
+index 475665f..83d5769 100644
+--- a/.agents/skills/typescript/SKILL.md
++++ b/.agents/skills/typescript/SKILL.md
+@@ -64,7 +64,7 @@ test/
+ tsconfig.json
+ ```
+ 
+-Packages may extend the shared repository configuration while adding package-specific files such as build configuration.
++Packages extend the shared repository TypeScript configuration while keeping package-specific configuration minimal.
+ 
+ ## Code organization
+ 
+@@ -140,6 +140,15 @@ bun run build
+ - "Recommend a cleaner public API."
+ - "Validate this package structure."
+ 
++## Configuration philosophy
++
++Repository configuration should remain as simple as possible.
++
++- Prefer tool defaults over explicit configuration.
++- Extend shared repository configuration instead of duplicating settings.
++- Add package-specific configuration only when the defaults are insufficient.
++- Keep build and compiler configuration easy to understand and maintain.
++
+ ### Refactoring
+ 
+ - "Simplify this TypeScript implementation."
+@@ -162,17 +171,12 @@ Run repository type checking.
+ bun run typecheck
+ ```
+ 
+-Package configuration — both `packages/hr-skills-build` and `packages/skills-ref` use this
+-exact shape (both build with tsdown as of the tsdown migration).
++Package `tsconfig.json` files extend the shared repository configuration and include only the package sources.
+ 
+ ```json
+ {
+   "extends": "../../tsconfig.json",
+-  "include": [
+-    "src",
+-    "test",
+-    "tsdown.config.ts"
+-  ]
++  "include": ["src", "test"]
+ }
+ ```
+ 
+@@ -183,7 +187,7 @@ exact shape (both build with tsdown as of the tsdown migration).
+ - Keep implementations simpler than their type definitions.
+ - Use `unknown` instead of `any` whenever possible.
+ - Validate changes with `bun run typecheck`.
+-- Keep package-specific configuration minimal.
++- Keep package-specific TypeScript configuration minimal and rely on shared defaults whenever possible.
+ 
+ ## Common issues
+ 
+diff --git a/packages/hr-skills-build/package.json b/packages/hr-skills-build/package.json
+index b493204..9d4e717 100644
+--- a/packages/hr-skills-build/package.json
++++ b/packages/hr-skills-build/package.json
+@@ -22,8 +22,10 @@
+ 	],
+ 	"main": "./dist/index.mjs",
+ 	"module": "./dist/index.mjs",
++	"types": "./dist/index.d.mts",
+ 	"exports": {
+ 		".": {
++			"types": "./dist/index.d.mts",
+ 			"default": "./dist/index.mjs"
+ 		}
+ 	},
+diff --git a/packages/hr-skills-build/tsconfig.json b/packages/hr-skills-build/tsconfig.json
+index 130e14b..a693f4b 100644
+--- a/packages/hr-skills-build/tsconfig.json
++++ b/packages/hr-skills-build/tsconfig.json
+@@ -1,4 +1,4 @@
+ {
+ 	"extends": "../../tsconfig.json",
+-	"include": ["src", "test", "tsdown.config.ts"]
++	"include": ["src", "test"]
+ }
+diff --git a/packages/skills-ref/tsconfig.json b/packages/skills-ref/tsconfig.json
+index 130e14b..188f705 100644
+--- a/packages/skills-ref/tsconfig.json
++++ b/packages/skills-ref/tsconfig.json
+@@ -1,4 +1,4 @@
+ {
+ 	"extends": "../../tsconfig.json",
+-	"include": ["src", "test", "tsdown.config.ts"]
++	"include": ["src", "tests"]
+ }
+diff --git a/packages/skills-ref/tsdown.config.ts b/packages/skills-ref/tsdown.config.ts
+deleted file mode 100644
+index 1a51afa..0000000
+--- a/packages/skills-ref/tsdown.config.ts
++++ /dev/null
+@@ -1,5 +0,0 @@
+-import { defineConfig } from 'tsdown';
+-
+-export default defineConfig({
+-	entry: ['./src/index.ts'],
+-});

--- a/packages/hr-skills-build/package.json
+++ b/packages/hr-skills-build/package.json
@@ -22,8 +22,10 @@
 	],
 	"main": "./dist/index.mjs",
 	"module": "./dist/index.mjs",
+	"types": "./dist/index.d.mts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.mts",
 			"default": "./dist/index.mjs"
 		}
 	},

--- a/packages/hr-skills-build/tsconfig.json
+++ b/packages/hr-skills-build/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "../../tsconfig.json",
-	"include": ["src", "test", "tsdown.config.ts"]
+	"include": ["src", "test"]
 }

--- a/packages/skills-ref/tsconfig.json
+++ b/packages/skills-ref/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "../../tsconfig.json",
-	"include": ["src", "test", "tsdown.config.ts"]
+	"include": ["src", "tests"]
 }

--- a/packages/skills-ref/tsconfig.json
+++ b/packages/skills-ref/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "../../tsconfig.json",
-	"include": ["src", "tests"]
+	"include": ["src", "test"]
 }

--- a/packages/skills-ref/tsdown.config.ts
+++ b/packages/skills-ref/tsdown.config.ts
@@ -1,5 +1,0 @@
-import { defineConfig } from 'tsdown';
-
-export default defineConfig({
-	entry: ['./src/index.ts'],
-});


### PR DESCRIPTION
Remove redundant tsdown configuration from workspace packages.

Update TypeScript configuration and repository documentation to reflect the shared-defaults configuration philosophy.

Also add type declaration metadata to hr-skills-build.