### PR TITLE
fix(cli): add --help, surface spinner errors, repair zip offsets

### DIFF
--- a/.agents/skills/clack/SKILL.md
+++ b/.agents/skills/clack/SKILL.md
@@ -18,11 +18,13 @@ Only five clack APIs appear anywhere in this codebase — confirmed by grepping 
 
 | API | Purpose | Used in |
 |---|---|---|
-| `p.intro(title)` | Announce the CLI at start | Every `cli/*.ts` entry point |
-| `p.outro(message)` | Announce completion at end | Every `cli/*.ts` entry point |
-| `p.spinner()` / `.start()` / `.stop()` | Show progress during `buildRegistry()`, plan generation, etc. | `execute-plan.ts`, `generate-plan.ts`, `recommend.ts` |
-| `p.note(message, title?)` | Print a multi-line info block (search results, recommendations) | `discover.ts`, `recommend.ts` |
+| `p.intro(title)` | Announce the CLI at start | Every `cli/*.ts` entry point, plus `build/sync.ts` and `validation/validate.ts` |
+| `p.outro(message)` | Announce completion at end — **including every failure path**, or the box is left unterminated | Same as `p.intro` |
+| `p.spinner()` / `.start()` / `.stop()` | Show progress during `buildRegistry()`, validation, plan generation, etc. | Created via `cliSpinner()` in `discover.ts`, `execute-plan.ts`, `generate-plan.ts`, `recommend.ts`, `run-evaluation.ts`, `validation/validate.ts` |
+| `p.note(message, title?)` | Print a multi-line info block (search results, recommendations, usage) | `discover.ts`, `recommend.ts`, `execute-plan.ts`, `generate-plan.ts`, `run-evaluation.ts`, `cli-bootstrap.ts` |
 | `p.log.{info,error,warn,success,message}` | Single-line status/error output | All `cli/*.ts`, routed through `cli/cli-bootstrap.ts` |
+
+`p.note` titles are SCREAMING CASE at every call site (`RESULTS FOR …`, `EXECUTION PLAN`, `USAGE`). Keep it that way.
 
 ## What this repo does NOT use — do not introduce it
 
@@ -38,20 +40,25 @@ Every CLI entry point in `src/cli/*.ts` follows this shape (see `cli/cli-bootstr
 
 ```typescript
 import * as p from '@clack/prompts';
-import { printUsageAndExit, runCli } from './cli-bootstrap.js';
+import { type CliUsage, cliSpinner, printUsageAndExit, runCli } from './cli-bootstrap.js';
+
+const USAGE: CliUsage = {
+	title: 'My Command',
+	usage: 'bun run my-command "<argument>"',
+	example: 'bun run my-command "example"',
+};
 
 async function main() {
 	const intent = process.argv[2];
-	if (!intent) {
-		printUsageAndExit(
-			'Usage: bun run my-command "<argument>"',
-			'  bun run my-command "example"',
-		);
+
+	// Reject a bare flag in the positional slot too, not just an empty one.
+	if (!intent || intent.startsWith('--')) {
+		printUsageAndExit(USAGE);
 	}
 
-	p.intro('My Command');
+	p.intro(USAGE.title);
 
-	const spinner = p.spinner();
+	const spinner = cliSpinner();
 	spinner.start('Building Skill Registry...');
 	const registry = await buildRegistry();
 	spinner.stop(`Registry ready (${registry.skillCount} skills)`);
@@ -61,12 +68,17 @@ async function main() {
 	p.outro('Done');
 }
 
-runCli(main);
+runCli(main, USAGE);
 ```
 
-- `printUsageAndExit` / `runCli` (from `cli/cli-bootstrap.ts`) standardize the "missing arg" and "uncaught error" paths — see [`cli-bootstrap`](../../../packages/hr-skills-build/src/cli/cli-bootstrap.ts). Don't hand-roll `p.log.error(...); process.exit(1);` again; that duplication is exactly what `cli-bootstrap.ts` was extracted to remove (see [`dry-refactoring`](../dry-refactoring/SKILL.md)).
-- `p.intro`/`p.outro` bookend the whole run — call each exactly once.
+- One `CliUsage` per command, shared by `printUsageAndExit`, `runCli`, and `p.intro(USAGE.title)`, so the `--help` screen and the bad-invocation error can't drift apart.
+- **Pass `USAGE` to `runCli`.** That is what implements `--help`/`-h`: it prints usage and exits 0 *before* `main()` runs. Omit it and the command treats `--help` as a positional argument — which is how `bun run evaluate --help` once ran the whole evaluation suite and `bun run plan --help` generated a plan for the literal intent `"--help"`.
+- **Use `cliSpinner()`, never `p.spinner()` directly.** A running spinner repaints every 80ms by erasing the lines beneath it, and clack's exit handler then stamps "Canceled" over the area — so an error thrown mid-spin is invisible. `cliSpinner()` registers the spinner so `runCli` can stop it with the real message.
+- `printUsageAndExit` / `runCli` standardize the bad-invocation and uncaught-error paths — see [`cli-bootstrap`](../../../packages/hr-skills-build/src/cli/cli-bootstrap.ts). Don't hand-roll `p.log.error(...); process.exit(1);` again; that duplication is exactly what `cli-bootstrap.ts` was extracted to remove (see [`dry-refactoring`](../dry-refactoring/SKILL.md)). Prefer letting a typed error propagate to `runCli` over catching it locally.
+- `p.intro`/`p.outro` bookend the whole run — call each exactly once, **on success and failure alike**. `p.log.*` output renders with clack's `│` gutter but no `┌` above and no `└` below, so an `exit(1)` with no outro leaves a visibly broken box.
+- Validate flag *values*, not just presence: `--limit 0` and `--limit abc` used to reach the search layer as `0`/`NaN` and produce "no results", blaming the query for a bad flag. Reject unknown flags too, rather than ignoring them.
 - `spinner.stop(message)` should report a concrete result (count, duration), not just "Done" — matches the existing `Registry ready (${registry.skillCount} skills)` style.
+- A CLI module that anything else imports (`validation/validate.ts` is imported by its own test) keeps its `if (import.meta.main)` guard around `runCli`, and parses `process.argv` *inside* it — otherwise a plain `import` runs the command or parses the host process's flags.
 
 ## Key prompts
 

--- a/.changeset/cli-help-and-zip-offsets.md
+++ b/.changeset/cli-help-and-zip-offsets.md
@@ -1,0 +1,15 @@
+---
+"hr-skills": patch
+---
+
+Fixed `dist/hr-skills.zip` and `dist/hr-skills.skill` being written as structurally invalid archives. `buildZipBuffer` declared its running byte position as `const currentOffset = 0`, so every central-directory entry and the end-of-central-directory record recorded offset `0`. Readers still listed the entries (they self-heal the central-directory offset), but extracting anything past the first file failed with "Bad magic number for file header" — and `build-skills` reported `OK (zip)` regardless. Both archives now round-trip all 823+ entries.
+
+Added `--help` / `-h` to every CLI, handled in `runCli` before any work runs. `--help` previously fell through as a positional argument: `bun run evaluate --help` ran the entire evaluation suite, `bun run plan --help` and `bun run execute --help` built the registry and generated a plan for the literal intent `"--help"`, and `bun run recommend --help` built all 146 skills before failing with `Unknown skill ID: "--help"`. Help now exits 0 without doing any work.
+
+Fixed errors thrown while a spinner was running being erased from the terminal. A live `@clack/prompts` spinner repaints by erasing the lines beneath it and its exit handler stamps "Canceled" over the area, so the real message never appeared — a missing `registry/skills.json` reported only "Canceled". CLI spinners are now created through `cliSpinner()`, which lets `runCli` stop the spinner with the actual error.
+
+Fixed `bun run evaluate --update-golden` exiting 0 even when cases failed, which silently baselined those failures into the golden fixtures. It now exits 1 and reports the failing count. Unknown flags are rejected instead of ignored, so a typo'd `--update-goldens` no longer performs a plain reporting pass.
+
+Fixed `bun run recommend <skill> --limit 0` (and a non-numeric `--limit`) reporting "No recommendations available" — blaming the skill for a bad flag. `--limit` is now validated as a positive integer, and a flag in the positional slot prints usage instead of spending a full registry build to report `Unknown skill ID: "--limit"`.
+
+Improved `bun run validate` output: it now shows progress for the two slowest phases instead of running silently, reports each failing skill once with its message rather than twice (the first time as a bare name), sorts issues so repeat runs over an unchanged tree emit identical logs, uses an error glyph rather than a warning for the fatal "no skills found" case, and closes the output box on failure paths instead of leaving it unterminated.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,10 @@ jobs:
 
       - name: Run tests
         run: bun run test
+
+      # The playground apps are bundler smoke tests: they only fail when
+      # `hr-skills-build/client` stops being browser-safe. They have no `test`
+      # script, so `bun run test` never builds them — this step is what makes
+      # them assert anything in CI.
+      - name: Build (playground client-bundle smoke tests)
+        run: bun run build

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -4,3 +4,4 @@ dist
 .turbo
 CHANGELOG.md
 docs/engineering/skill-matrix.md
+CLAUDE.md

--- a/packages/hr-skills-build/src/build/build-skills.ts
+++ b/packages/hr-skills-build/src/build/build-skills.ts
@@ -160,11 +160,14 @@ function dateToDos(date: Date): DosTimestamp {
  * Assemble a ZIP archive from entries and return it as a Buffer.
  * Uses DEFLATE compression (method 8), matching Python's ZIP_DEFLATED.
  */
-function buildZipBuffer(entries: ZipEntry[]): Buffer {
+export function buildZipBuffer(entries: ZipEntry[]): Buffer {
 	const localParts: Buffer[] = [];
 	const centralDir: Buffer[] = [];
-	const offsets: number[] = [];
-	const currentOffset = 0;
+	// Running byte offset into the concatenated local-header section. Every
+	// central-directory entry stores the offset of its own local header here,
+	// and the EOCD stores the offset where the central directory itself begins,
+	// so this must advance by each entry's on-disk size as we go.
+	let currentOffset = 0;
 
 	for (const entry of entries) {
 		const nameBytes = Buffer.from(entry.arcname, 'utf8');
@@ -189,8 +192,8 @@ function buildZipBuffer(entries: ZipEntry[]): Buffer {
 		writeUInt16LE(local, 0, 28); // extra field length
 		nameBytes.copy(local, 30);
 
-		offsets.push(currentOffset);
 		localParts.push(local, compressed);
+		currentOffset += local.length + compressed.length;
 
 		// Central directory file header: 46 bytes + filename
 		const central = Buffer.alloc(46 + nameBytes.length);
@@ -407,23 +410,26 @@ export async function buildSkill(repoRoot: string): Promise<string> {
 // CLI entrypoint
 // ---------------------------------------------------------------------------
 
-const {
-	values: { zip, skill },
-} = parseArgs({
-	args: Bun.argv,
-	options: {
-		zip: {
-			type: 'boolean',
-		},
-		skill: {
-			type: 'boolean',
-		},
-	},
-	strict: true,
-	allowPositionals: true,
-});
-
 if (import.meta.main) {
+	// Kept inside the `import.meta.main` guard: `strict: true` over `Bun.argv`
+	// means running this at module scope makes a plain `import` of this file
+	// parse the *host* process's flags and throw on any it doesn't know.
+	const {
+		values: { zip, skill },
+	} = parseArgs({
+		args: Bun.argv,
+		options: {
+			zip: {
+				type: 'boolean',
+			},
+			skill: {
+				type: 'boolean',
+			},
+		},
+		strict: true,
+		allowPositionals: true,
+	});
+
 	if (zip && skill) {
 		throw new Error('Cannot specify both --zip and --skill.');
 	}

--- a/packages/hr-skills-build/src/cli/cli-bootstrap.ts
+++ b/packages/hr-skills-build/src/cli/cli-bootstrap.ts
@@ -7,38 +7,135 @@
  * several also repeated the same "print usage, print an example, exit 1"
  * shape when a required argument was missing (jscpd flagged multiple pairs
  * across these files). Both now live here once.
+ *
+ * Three CLI-wide behaviours are enforced here rather than per command:
+ *
+ * 1. `--help` / `-h` prints usage and exits 0 without doing any work. Every
+ *    command used to treat it as a positional argument, so `bun run evaluate
+ *    --help` ran the whole evaluation suite and `bun run plan --help`
+ *    generated a plan for the literal intent `"--help"`.
+ * 2. Usage and error output is bookended by `p.intro`/`p.outro`. Without an
+ *    intro, `@clack/prompts` renders its `│` gutter with no `┌` above it and
+ *    no `└` below, so the output box is visibly unterminated.
+ * 3. A live spinner is stopped with the error before exiting — see
+ *    {@link cliSpinner}.
  */
 
 import * as p from '@clack/prompts';
 
 /**
- * Run a CLI `main()` function, logging uncaught errors through `@clack/prompts`
- * and exiting with status 1. Every `cli/*.ts` entry point should end with
- * `runCli(main);` instead of hand-rolling its own `.catch(...)`.
+ * Usage text for one CLI, shared by its `--help` screen and its
+ * "missing required argument" error so the two can't drift apart.
+ */
+export interface CliUsage {
+	/** The command's `p.intro()` title, so `--help` shows the same header as a real run. */
+	title: string;
+	/** One-line invocation summary, e.g. ``bun run plan "<user intent>"``. */
+	usage: string;
+	/** One concrete example invocation. */
+	example: string;
+}
+
+const HELP_FLAGS = new Set(['--help', '-h']);
+
+/**
+ * The spinner most recently created by {@link cliSpinner} and not yet stopped.
+ *
+ * `@clack/prompts` repaints a running spinner every 80ms by moving the cursor
+ * up and erasing downward, which wipes out anything written beneath it — and
+ * its `process.on('exit')` handler then stamps "Canceled" over the area. So an
+ * error logged while a spinner is live is invisible: the user sees only
+ * "Canceled" with no reason. {@link runCli} therefore routes the message
+ * through the spinner itself whenever one is running.
+ */
+let activeSpinner: p.SpinnerResult | undefined;
+
+/**
+ * Create a `@clack/prompts` spinner that {@link runCli} can stop if the
+ * command throws. Use this instead of calling `p.spinner()` directly in
+ * `src/cli/*.ts`, otherwise a failure mid-spin loses its error message.
+ *
+ * Registration is tied to `start`/`stop` rather than to creation, because
+ * these CLIs reuse a single spinner across several phases — registering once at
+ * creation would leave every phase after the first unprotected.
+ *
+ * @returns A spinner that registers itself while running.
+ */
+export function cliSpinner(): p.SpinnerResult {
+	const instance = p.spinner();
+	const start = instance.start.bind(instance);
+	const stop = instance.stop.bind(instance);
+
+	instance.start = (msg?: string) => {
+		activeSpinner = instance;
+		start(msg);
+	};
+
+	instance.stop = (msg?: string) => {
+		activeSpinner = undefined;
+		stop(msg);
+	};
+
+	return instance;
+}
+
+/**
+ * Print a command's usage block inside an opened `@clack/prompts` box. Leaves
+ * the box open for the caller to close with `p.outro`.
+ *
+ * @param usage - The command's title, usage line, and example.
+ */
+function printUsage(usage: CliUsage): void {
+	p.intro(usage.title);
+	p.note(`${usage.usage}\n\nExample:\n  ${usage.example}`, 'USAGE');
+}
+
+/**
+ * Run a CLI `main()` function. Handles `--help`/`-h` before any work happens,
+ * logs uncaught errors through `@clack/prompts`, and exits with status 1.
+ * Every `cli/*.ts` entry point should end with `runCli(main, USAGE);` instead
+ * of hand-rolling its own `.catch(...)`.
  *
  * @param main - The CLI's entry point.
+ * @param usage - Usage text for `--help`. Omit only for a command that takes
+ *   no arguments at all.
  */
-export function runCli(main: () => Promise<void>): void {
+export function runCli(main: () => Promise<void>, usage?: CliUsage): void {
+	if (usage && process.argv.slice(2).some((arg) => HELP_FLAGS.has(arg))) {
+		printUsage(usage);
+		p.outro('Asked for help — nothing was run.');
+		process.exit(0);
+	}
+
 	main().catch((err: unknown) => {
 		const message = err instanceof Error ? err.message : String(err);
-		p.log.error(`Error: ${message}`);
+		const spinner = activeSpinner;
+		activeSpinner = undefined;
+
+		if (spinner) {
+			spinner.error(`Error: ${message}`);
+		} else {
+			p.log.error(`Error: ${message}`);
+		}
+
+		p.outro('Failed');
 		process.exit(1);
 	});
 }
 
 /**
- * Print a "missing required argument" usage message (usage line + one
- * example invocation) and exit with status 1. Call this when `value` is
- * falsy; callers keep control of the exact wording since each CLI's usage
- * differs, only the three-line shape is shared.
+ * Print a usage message for a bad invocation and exit with status 1. Call this
+ * when a required argument is missing — or is a flag, since a bare flag in the
+ * positional slot means the argument was never supplied — and also for an
+ * out-of-range flag value or an unrecognized flag, overriding
+ * {@link CliUsage.usage} with the specific complaint.
  *
- * @param usageLine - One-line usage summary, e.g. `Usage: bun run plan <intent>`.
- * @param exampleLine - One example invocation shown under "Example:".
+ * @param usage - The same {@link CliUsage} passed to {@link runCli}, so the
+ *   error and the `--help` screen stay identical.
  * @returns Never returns — always exits the process.
  */
-export function printUsageAndExit(usageLine: string, exampleLine: string): never {
-	p.log.error(usageLine);
-	p.log.info('Example:');
-	p.log.message(exampleLine);
+export function printUsageAndExit(usage: CliUsage): never {
+	printUsage(usage);
+	p.outro('Invalid arguments');
 	process.exit(1);
 }

--- a/packages/hr-skills-build/src/cli/discover.ts
+++ b/packages/hr-skills-build/src/cli/discover.ts
@@ -16,11 +16,17 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import * as p from '@clack/prompts';
 import { ROOT_DIR } from 'skills-ref';
-import { InvalidSearchQueryError, searchSkills } from '../search/search.js';
+import { searchSkills } from '../search/search.js';
 import type { Registry, SkillCategory, SkillSearchQuery } from '../shared/types.js';
-import { printUsageAndExit, runCli } from './cli-bootstrap.js';
+import { type CliUsage, cliSpinner, printUsageAndExit, runCli } from './cli-bootstrap.js';
 
 const REGISTRY_PATH = join(ROOT_DIR, 'registry', 'skills.json');
+
+const USAGE: CliUsage = {
+	title: 'Skill Search',
+	usage: 'bun run discover "<query>" [--domain <domain>] [--limit N] [--no-fuzzy]',
+	example: 'bun run discover "onboard new hires"',
+};
 
 function parseFlag(name: string): string | undefined {
 	const index = process.argv.indexOf(`--${name}`);
@@ -36,10 +42,7 @@ async function main() {
 	const text = process.argv[2];
 
 	if (!text || text.startsWith('--')) {
-		printUsageAndExit(
-			'Usage: bun run discover "<query>" [--domain <domain>] [--limit N] [--no-fuzzy]',
-			'  bun run discover "onboard new hires"',
-		);
+		printUsageAndExit(USAGE);
 	}
 
 	const domain = parseFlag('domain') as SkillCategory | undefined;
@@ -47,9 +50,9 @@ async function main() {
 	const limit = limitFlag ? Number(limitFlag) : undefined;
 	const fuzzy = !hasFlag('no-fuzzy');
 
-	p.intro('Skill Search');
+	p.intro(USAGE.title);
 
-	const spinner = p.spinner();
+	const spinner = cliSpinner();
 	spinner.start('Loading Skill Registry...');
 	const raw = await readFile(REGISTRY_PATH, 'utf8');
 	const registry = JSON.parse(raw) as Registry;
@@ -62,31 +65,26 @@ async function main() {
 		...(limit && { limit }),
 	};
 
-	try {
-		const response = searchSkills(query, registry);
+	// An InvalidSearchQueryError propagates to runCli, which reports it and
+	// closes the clack box — the local catch that used to live here logged the
+	// message and exited without an outro, leaving the box unterminated.
+	const response = searchSkills(query, registry);
 
-		if (response.results.length === 0) {
-			p.log.warn(`No skills matched "${text}"`);
-		} else {
-			p.note(
-				response.results
-					.map(
-						(r) =>
-							`${r.skillId} — score ${r.score} (${r.domain})\n   ${r.explanation}`,
-					)
-					.join('\n\n'),
-				`RESULTS FOR "${response.query}" (${response.resultCount})`,
-			);
-		}
-
-		p.outro('Done');
-	} catch (error) {
-		if (error instanceof InvalidSearchQueryError) {
-			p.log.error(error.message);
-			process.exit(1);
-		}
-		throw error;
+	if (response.results.length === 0) {
+		p.log.warn(`No skills matched "${text}"`);
+	} else {
+		p.note(
+			response.results
+				.map(
+					(r) =>
+						`${r.skillId} — score ${r.score} (${r.domain})\n   ${r.explanation}`,
+				)
+				.join('\n\n'),
+			`RESULTS FOR "${response.query}" (${response.resultCount})`,
+		);
 	}
+
+	p.outro('Done');
 }
 
-runCli(main);
+runCli(main, USAGE);

--- a/packages/hr-skills-build/src/cli/execute-plan.ts
+++ b/packages/hr-skills-build/src/cli/execute-plan.ts
@@ -22,21 +22,27 @@ import { generateExecutionPlan } from '../planner/planner.js';
 import { buildRegistry } from '../registry/registry.js';
 import { executeWorkflow } from '../runtime/runtime.js';
 import { stubStepExecutor } from '../shared/helpers.js';
-import { printUsageAndExit, runCli } from './cli-bootstrap.js';
+import { type CliUsage, cliSpinner, printUsageAndExit, runCli } from './cli-bootstrap.js';
+
+const USAGE: CliUsage = {
+	title: 'Workflow Runtime',
+	usage: 'bun run execute "<user intent>"',
+	example: 'bun run execute "Create interview questions for a senior manager"',
+};
 
 async function main() {
 	const intent = process.argv[2];
 
-	if (!intent) {
-		printUsageAndExit(
-			'Usage: bun run execute "<user intent>"',
-			'  bun run execute "Create interview questions for a senior manager"',
-		);
+	// `startsWith('--')` matters as much as the empty check: without it,
+	// `bun run execute --help` built the registry and ran the runtime against
+	// the literal intent "--help".
+	if (!intent || intent.startsWith('--')) {
+		printUsageAndExit(USAGE);
 	}
 
-	p.intro('Workflow Runtime');
+	p.intro(USAGE.title);
 
-	const spinner = p.spinner();
+	const spinner = cliSpinner();
 
 	spinner.start('Building Skill Registry...');
 	const registry = await buildRegistry();
@@ -92,4 +98,4 @@ async function main() {
 	process.exit(result.status === 'completed' ? 0 : 1);
 }
 
-runCli(main);
+runCli(main, USAGE);

--- a/packages/hr-skills-build/src/cli/generate-plan.ts
+++ b/packages/hr-skills-build/src/cli/generate-plan.ts
@@ -17,21 +17,27 @@ import {
 	suggestPlanImprovements,
 	validateExecutionPlan,
 } from '../validation/validate-planner.js';
-import { printUsageAndExit, runCli } from './cli-bootstrap.js';
+import { type CliUsage, cliSpinner, printUsageAndExit, runCli } from './cli-bootstrap.js';
+
+const USAGE: CliUsage = {
+	title: 'Execution Plan Generator',
+	usage: 'bun run plan "<user intent>"',
+	example: 'bun run plan "Create interview questions for a senior manager"',
+};
 
 async function main() {
 	const intent = process.argv[2];
 
-	if (!intent) {
-		printUsageAndExit(
-			'Usage: bun run plan "<user intent>"',
-			'  bun run plan "Create interview questions for a senior manager"',
-		);
+	// `startsWith('--')` matters as much as the empty check: without it,
+	// `bun run plan --help` built the registry and generated a plan for the
+	// literal intent "--help".
+	if (!intent || intent.startsWith('--')) {
+		printUsageAndExit(USAGE);
 	}
 
-	p.intro('Execution Plan Generator');
+	p.intro(USAGE.title);
 
-	const spinner = p.spinner();
+	const spinner = cliSpinner();
 
 	spinner.start('Building Skill Registry...');
 	const registry = await buildRegistry();
@@ -127,4 +133,4 @@ ${plan.notes && plan.notes.length > 0 ? `Notes:\n${plan.notes.map((note) => `  â
 	process.exit(validation.isValid ? 0 : 1);
 }
 
-runCli(main);
+runCli(main, USAGE);

--- a/packages/hr-skills-build/src/cli/recommend.ts
+++ b/packages/hr-skills-build/src/cli/recommend.ts
@@ -10,26 +10,42 @@
 
 import * as p from '@clack/prompts';
 import { buildRegistry, loadRelevanceSignalTable } from '../registry/registry.js';
-import { getRecommendations, UnknownSkillError } from '../search/recommendations.js';
-import { printUsageAndExit, runCli } from './cli-bootstrap.js';
+import { getRecommendations } from '../search/recommendations.js';
+import { type CliUsage, cliSpinner, printUsageAndExit, runCli } from './cli-bootstrap.js';
+
+const USAGE: CliUsage = {
+	title: 'Skill Recommendations',
+	usage: 'bun run recommend <skill-id> [--limit N]',
+	example: 'bun run recommend hr-onboarding',
+};
 
 async function main() {
 	const skillId = process.argv[2];
 
-	if (!skillId) {
-		printUsageAndExit(
-			'Usage: bun run recommend <skill-id> [--limit N]',
-			'  bun run recommend hr-onboarding',
-		);
+	// `startsWith('--')` matters as much as the empty check: without it,
+	// `bun run recommend --limit 3` spent a full registry build before failing
+	// with `Unknown skill ID: "--limit"`.
+	if (!skillId || skillId.startsWith('--')) {
+		printUsageAndExit(USAGE);
 	}
 
 	const limitFlagIndex = process.argv.indexOf('--limit');
 	const limit =
 		limitFlagIndex !== -1 ? Number(process.argv[limitFlagIndex + 1]) : undefined;
 
-	p.intro('Skill Recommendations');
+	// `--limit 0` and `--limit abc` used to reach getRecommendations() as 0/NaN,
+	// where `slice(0, limit)` returned nothing and the CLI reported "No
+	// recommendations available for <skill>" — blaming the skill for a bad flag.
+	if (limit !== undefined && (!Number.isInteger(limit) || limit <= 0)) {
+		printUsageAndExit({
+			...USAGE,
+			usage: '--limit must be a positive integer',
+		});
+	}
 
-	const spinner = p.spinner();
+	p.intro(USAGE.title);
+
+	const spinner = cliSpinner();
 	spinner.start('Building Skill Registry...');
 	// Load the same usage-informed relevance signal table generate-registry.ts
 	// uses (Phase 6.1-B/C), so ad-hoc recommendations here match what's
@@ -43,31 +59,26 @@ async function main() {
 			: `Registry ready (${registry.skillCount} skills)`,
 	);
 
-	try {
-		const result = getRecommendations(skillId, registry, limit);
+	// An UnknownSkillError propagates to runCli, which reports it and closes the
+	// clack box — the local catch that used to live here logged the message and
+	// exited without an outro, leaving the box unterminated.
+	const result = getRecommendations(skillId, registry, limit);
 
-		if (result.recommendations.length === 0) {
-			p.log.warn(`No recommendations available for "${skillId}"`);
-		} else {
-			p.note(
-				result.recommendations
-					.map(
-						(rec) =>
-							`${rec.rank}. ${rec.id} (${rec.domain})\n   ${rec.description}`,
-					)
-					.join('\n\n'),
-				`RECOMMENDATIONS FOR ${result.skillId}`,
-			);
-		}
-
-		p.outro('Done');
-	} catch (error) {
-		if (error instanceof UnknownSkillError) {
-			p.log.error(error.message);
-			process.exit(1);
-		}
-		throw error;
+	if (result.recommendations.length === 0) {
+		p.log.warn(`No recommendations available for "${skillId}"`);
+	} else {
+		p.note(
+			result.recommendations
+				.map(
+					(rec) =>
+						`${rec.rank}. ${rec.id} (${rec.domain})\n   ${rec.description}`,
+				)
+				.join('\n\n'),
+			`RECOMMENDATIONS FOR ${result.skillId}`,
+		);
 	}
+
+	p.outro('Done');
 }
 
-runCli(main);
+runCli(main, USAGE);

--- a/packages/hr-skills-build/src/cli/run-evaluation.ts
+++ b/packages/hr-skills-build/src/cli/run-evaluation.ts
@@ -22,14 +22,36 @@ import {
 } from '../evaluation/evaluation-datasets.js';
 import { buildRegistry } from '../registry/registry.js';
 import type { EvaluationReport } from '../shared/types.js';
-import { runCli } from './cli-bootstrap.js';
+import { type CliUsage, cliSpinner, printUsageAndExit, runCli } from './cli-bootstrap.js';
+
+const USAGE: CliUsage = {
+	title: 'Evaluation Framework',
+	usage: 'bun run evaluate [--update-golden]',
+	example: 'bun run evaluate',
+};
+
+const KNOWN_FLAGS = new Set(['--update-golden']);
 
 async function main() {
+	// Without this, a typo'd `--update-goldens` was silently ignored: the run did
+	// a plain reporting pass and exited 1, which reads as a test failure rather
+	// than a bad flag.
+	const unknownFlags = process.argv
+		.slice(2)
+		.filter((arg) => arg.startsWith('--') && !KNOWN_FLAGS.has(arg));
+
+	if (unknownFlags.length > 0) {
+		printUsageAndExit({
+			...USAGE,
+			usage: `Unknown flag(s): ${unknownFlags.join(', ')}`,
+		});
+	}
+
 	const updateGolden = process.argv.includes('--update-golden');
 
-	p.intro('Evaluation Framework');
+	p.intro(USAGE.title);
 
-	const spinner = p.spinner();
+	const spinner = cliSpinner();
 
 	spinner.start('Building Skill Registry...');
 	const registry = await buildRegistry();
@@ -97,6 +119,15 @@ async function main() {
 	const hasFailedCases = reports.some((r) => r.failedCases > 0);
 
 	if (updateGolden) {
+		// Re-baselining clears regressions by definition, but an invalid plan is
+		// still broken after the fixture is rewritten. Exiting 0 here froze those
+		// failures into the fixtures and reported success.
+		if (hasFailedCases) {
+			const failed = reports.reduce((sum, r) => sum + r.failedCases, 0);
+			p.outro(`Golden fixtures updated — ${failed} case(s) still failing`);
+			process.exit(1);
+		}
+
 		p.outro('Golden fixtures updated');
 		process.exit(0);
 	}
@@ -110,4 +141,4 @@ async function main() {
 	process.exit(0);
 }
 
-runCli(main);
+runCli(main, USAGE);

--- a/packages/hr-skills-build/src/validation/validate.ts
+++ b/packages/hr-skills-build/src/validation/validate.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import process from 'node:process';
 import * as p from '@clack/prompts';
 import { ROOT_DIR, SKILLS_DIR, validate as validateRef } from 'skills-ref';
+import { type CliUsage, cliSpinner, runCli } from '../cli/cli-bootstrap.js';
 import { buildRegistry, loadRelevanceSignalTable } from '../registry/registry.js';
 import {
 	HR_SKILL_PREFIX,
@@ -471,6 +472,12 @@ async function validateSkill(skillName: string): Promise<SkillValidationIssue[]>
 	return errors;
 }
 
+const USAGE: CliUsage = {
+	title: 'Validate HR Skills',
+	usage: 'bun run validate',
+	example: 'bun run validate',
+};
+
 /**
  * Validate all HR skills.
  *
@@ -480,12 +487,14 @@ async function validateSkill(skillName: string): Promise<SkillValidationIssue[]>
  * run in parallel with the per-skill phase via a second `Promise.all`.
  */
 async function validate(): Promise<void> {
-	p.intro('Validating HR skills...');
+	p.intro(USAGE.title);
 
 	const skillNames = await discoverSkills();
 
 	if (skillNames.length === 0) {
-		p.log.warn(`No skills found with prefix "${HR_SKILL_PREFIX}"`);
+		// Fatal, so an error glyph — this used to warn in yellow and then exit 1.
+		p.log.error(`No skills found with prefix "${HR_SKILL_PREFIX}"`);
+		p.outro('Validation failed');
 		process.exit(1);
 	}
 
@@ -494,7 +503,10 @@ async function validate(): Promise<void> {
 	const allErrors: SkillValidationIssue[] = [];
 	const allWarnings: SkillValidationIssue[] = [];
 
+	const spinner = cliSpinner();
+
 	// Run per-skill validation and global consistency checks concurrently.
+	spinner.start(`Validating ${skillNames.length} skills...`);
 	const [perSkillResults] = await Promise.all([
 		// Per-skill: all 146 skills validated in parallel
 		Promise.all(skillNames.map((name) => validateSkill(name))),
@@ -503,19 +515,20 @@ async function validate(): Promise<void> {
 		validateRegistryConsistency(allErrors),
 	]);
 
-	// Collect per-skill errors and log any failing skill names
-	for (let i = 0; i < perSkillResults.length; i++) {
-		const errors = perSkillResults[i];
-		if (!errors || errors.length === 0) continue;
-		allErrors.push(...errors);
-		const skillName = skillNames[i];
-		if (skillName) p.log.error(skillName);
+	// Collect per-skill errors. Each one is reported with its message further
+	// down; this loop used to also log the bare failing skill name, so every
+	// failure appeared twice and the first copy carried no explanation.
+	for (const errors of perSkillResults) {
+		if (errors && errors.length > 0) allErrors.push(...errors);
 	}
+
+	spinner.stop(`${skillNames.length} skills checked — ${allErrors.length} error(s)`);
 
 	// Phase 6.1-B — warn when a high-evidence usage signal isn't reflected
 	// in relatedSkills, and Phase 6.2 — duplicate-content detection and
 	// semantic validation. All three run concurrently since none depends
 	// on another's output.
+	spinner.start('Checking duplicates, signals, and semantic consistency...');
 	const signalTable = await loadRelevanceSignalTable();
 	await Promise.all([
 		buildRegistry(signalTable).then((registry) =>
@@ -524,6 +537,16 @@ async function validate(): Promise<void> {
 		detectDuplicates(skillNames, allWarnings),
 		validateSemanticConsistency(SKILLS_DIR, skillNames, allWarnings),
 	]);
+	spinner.stop(`Quality checks complete — ${allWarnings.length} warning(s)`);
+
+	// Both phases above fill allErrors/allWarnings from concurrent tasks, so
+	// insertion order tracks I/O timing rather than the tree. Sort so two runs
+	// over an unchanged repo emit byte-identical logs and CI diffs stay usable.
+	const bySkillThenMessage = (a: SkillValidationIssue, b: SkillValidationIssue) =>
+		a.skill.localeCompare(b.skill) || a.message.localeCompare(b.message);
+
+	allErrors.sort(bySkillThenMessage);
+	allWarnings.sort(bySkillThenMessage);
 
 	// Report warnings (informational — do not affect exit code)
 	if (allWarnings.length > 0) {
@@ -536,16 +559,17 @@ async function validate(): Promise<void> {
 
 	// Report errors (fatal)
 	if (allErrors.length > 0) {
-		p.log.error('Validation failed');
-
 		for (const error of allErrors) p.log.error(`${error.skill}: ${error.message}`);
 
+		// Closes the clack box, which an outro-less exit(1) left unterminated.
+		p.outro(`Validation failed — ${allErrors.length} error(s)`);
 		process.exit(1);
 	}
 
-	p.log.success(`All ${skillNames.length} HR skills are valid`);
-	if (allWarnings.length === 0) p.log.info('No quality warnings.');
-	p.outro('Done');
+	if (allWarnings.length === 0) p.log.info('No quality warnings');
+	p.outro(`All ${skillNames.length} HR skills are valid`);
 }
 
-if (import.meta.main) await validate();
+// The guard stays: test/validation/validate.test.ts imports this module, and
+// without it a plain import would kick off a full 146-skill validation run.
+if (import.meta.main) runCli(validate, USAGE);

--- a/packages/hr-skills-build/test/build/build-skills.test.ts
+++ b/packages/hr-skills-build/test/build/build-skills.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test';
+import { inflateRawSync } from 'node:zlib';
+
+import { buildZipBuffer } from '../../src/build/build-skills.js';
+
+const LOCAL_HEADER_SIG = 0x04034b50;
+const CENTRAL_HEADER_SIG = 0x02014b50;
+const EOCD_SIG = 0x06054b50;
+const EOCD_SIZE = 22;
+
+function entry(arcname: string, body: string) {
+	return {
+		arcname,
+		data: Buffer.from(body, 'utf8'),
+		mtime: new Date('2026-01-02T03:04:05Z'),
+	};
+}
+
+describe('buildZipBuffer()', () => {
+	// Regression guard: `currentOffset` used to be `const currentOffset = 0`, so
+	// every central-directory entry and the EOCD recorded offset 0. `namelist()`
+	// still worked (readers self-heal the central-directory offset), which is why
+	// this shipped unnoticed — but any entry past the first failed to extract
+	// with "Bad magic number for file header".
+	it('points every central-directory entry at its own local header', () => {
+		const files = [
+			entry('LICENSE', 'MIT'.repeat(40)),
+			entry('SKILL.md', '# heading\n'.repeat(40)),
+			entry('skills/hr-onboarding/SKILL.md', 'onboarding'.repeat(40)),
+		];
+		const buf = buildZipBuffer(files);
+
+		// No archive comment is ever written, so the EOCD is the final 22 bytes.
+		const eocd = buf.length - EOCD_SIZE;
+		expect(buf.readUInt32LE(eocd)).toBe(EOCD_SIG);
+
+		const totalEntries = buf.readUInt16LE(eocd + 10);
+		const centralSize = buf.readUInt32LE(eocd + 12);
+		const centralStart = buf.readUInt32LE(eocd + 16);
+
+		expect(totalEntries).toBe(files.length);
+		// The central directory has to begin where the EOCD claims it does.
+		expect(centralStart).toBe(eocd - centralSize);
+		expect(buf.readUInt32LE(centralStart)).toBe(CENTRAL_HEADER_SIG);
+
+		const localOffsets: number[] = [];
+		let cursor = centralStart;
+
+		for (const expected of files) {
+			expect(buf.readUInt32LE(cursor)).toBe(CENTRAL_HEADER_SIG);
+
+			const nameLength = buf.readUInt16LE(cursor + 28);
+			const name = buf.toString('utf8', cursor + 46, cursor + 46 + nameLength);
+			const localOffset = buf.readUInt32LE(cursor + 42);
+
+			expect(name).toBe(expected.arcname);
+
+			// The stored offset must land on this entry's local header...
+			expect(buf.readUInt32LE(localOffset)).toBe(LOCAL_HEADER_SIG);
+			const localNameLength = buf.readUInt16LE(localOffset + 26);
+			expect(
+				buf.toString(
+					'utf8',
+					localOffset + 30,
+					localOffset + 30 + localNameLength,
+				),
+			).toBe(expected.arcname);
+
+			// ...and the bytes there must inflate back to the original content.
+			const compressedSize = buf.readUInt32LE(localOffset + 18);
+			const dataStart = localOffset + 30 + localNameLength;
+			const inflated = inflateRawSync(
+				buf.subarray(dataStart, dataStart + compressedSize),
+			);
+			expect(inflated.toString('utf8')).toBe(expected.data.toString('utf8'));
+
+			localOffsets.push(localOffset);
+			cursor += 46 + nameLength;
+		}
+
+		// Strictly increasing: the all-zero offsets of the original bug fail here.
+		expect(localOffsets[0]).toBe(0);
+		for (let i = 1; i < localOffsets.length; i++) {
+			expect(localOffsets[i]).toBeGreaterThan(localOffsets[i - 1] as number);
+		}
+	});
+});

--- a/playground/next-app/app/layout.tsx
+++ b/playground/next-app/app/layout.tsx
@@ -1,3 +1,17 @@
+import type { Metadata, Viewport } from 'next';
+
+export const metadata: Metadata = {
+	title: 'hr-skills-build playground (Next.js)',
+	description:
+		'Browser smoke test proving hr-skills-build/client bundles without node: builtins.',
+};
+
+// `colorScheme` lets the UA supply a dark background and readable text in dark
+// mode without this playground shipping a stylesheet.
+export const viewport: Viewport = {
+	colorScheme: 'light dark',
+};
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<html lang='en'>

--- a/playground/next-app/app/page.tsx
+++ b/playground/next-app/app/page.tsx
@@ -5,7 +5,9 @@ import { ClientWidget } from './client-widget';
 // issue: `skills-ref` computes `ROOT_DIR` via `import.meta.dirname` at
 // module load time, which Next's webpack server bundling does not evaluate
 // correctly for an externalized workspace package symlinked outside
-// `next-app/` (see `next.config.ts`). That's a Next.js/ESM interop wrinkle
+// `next-app/`. Nothing here works around it — there is deliberately no
+// `next.config.ts`, because the server path is out of scope for this
+// playground. That's a Next.js/ESM interop wrinkle
 // in `skills-ref`, not something the client/server split changed — the fs
 // path is already covered by `bun test` / `bun run validate` in
 // `packages/hr-skills-build`. What this playground exists to prove is the

--- a/playground/vite-app/index.html
+++ b/playground/vite-app/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<!-- Lets the UA supply a dark background and readable text in dark mode
+		     without this playground shipping a stylesheet. -->
+		<meta name="color-scheme" content="light dark" />
 		<title>hr-skills-build/client playground</title>
 	</head>
 	<body>

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -10,6 +10,10 @@
 			"cache": false
 		},
 		"dev": {
+			// The playground dev servers resolve `hr-skills-build/client` to
+			// `dist/index.client.mjs`, which does not exist on a clean clone until
+			// tsdown emits it — without this they race the watcher and fail.
+			"dependsOn": ["^build"],
 			"persistent": true,
 			"cache": false
 		},


### PR DESCRIPTION
## Summary

Three independent defects, all found while getting the repo installed and running end to end. Each is verified empirically, not just by reading.

### 1. `dist/hr-skills.zip` and `dist/hr-skills.skill` were structurally invalid

`buildZipBuffer` declared its running byte position as `const currentOffset = 0` — a `const` that can never increment. Every central-directory entry's `localHeaderOffset` and the end-of-central-directory offset were written as `0`. The `offsets` array was populated and never read.

Readers still list the entries, because they self-heal the central-directory offset — which is why this shipped unnoticed. Extraction is what breaks:

```
before: 823 entries, testzip -> LICENSE, BadZipFile: Bad magic number for file header
after:  823 entries, testzip -> None,    all entries read OK, 3798893 bytes
```

`build-skills` printed `OK (zip)` either way, and `publish.yml` ships this artifact — so only the first file in every published archive was extractable.

Guarded by a new test that walks the central directory, checks each stored offset lands on its own local header, and inflates each entry back to its input.

### 2. No CLI implemented `--help`

`--help` fell through as a positional argument. Measured before:

| Command | `--help` did | exit |
|---|---|---|
| `bun run evaluate --help` | ran the **entire evaluation suite** | 0 |
| `bun run plan --help` | built the registry, generated a plan for the literal intent `"--help"` | 0 |
| `bun run execute --help` | built the registry, ran the runtime | 0 |
| `bun run recommend --help` | built all 146 skills, then `Unknown skill ID: "--help"` | 1 |
| `bun run discover --help` | printed usage in red as an error, box never opened | 1 |

`runCli` now handles `--help`/`-h` before `main()` runs and exits 0. All five verified.

### 3. Errors thrown during a spinner were erased from the terminal

A running `@clack/prompts` spinner repaints every 80ms by moving the cursor up and erasing downward, wiping anything logged beneath it — then its `process.on('exit')` handler stamps "Canceled" over the area. Reproduced: a thrown error inside a live spinner rendered as `■ Canceled` with the message gone. A missing `registry/skills.json` reported no reason at all.

Spinners now come from `cliSpinner()`, which registers the instance on `start` and clears it on `stop`, so `runCli` can stop it with the real message. Registration is tied to `start`/`stop` rather than creation because these CLIs reuse one spinner across several phases.

## Also fixed

- `evaluate --update-golden` exited 0 even when cases failed, silently baselining those failures into the golden fixtures. Now exits 1 with the failing count. Unknown flags are rejected rather than ignored, so a typo'd `--update-goldens` no longer performs a plain reporting pass and exits 1 looking like a test failure.
- `recommend <skill> --limit 0` (and a non-numeric `--limit`) reached `slice(0, 0)`/`slice(0, NaN)` and reported "No recommendations available for &lt;skill&gt;" — blaming the skill for a bad flag. `--limit` is validated as a positive integer, and a flag in the positional slot prints usage instead of spending a full registry build to report `Unknown skill ID: "--limit"`.
- `validate` ran its two slowest phases in complete silence, printed every failing skill twice (the first time as a bare name with no message), emitted issues in I/O-timing order so two runs on an unchanged tree produced different logs, used a warning glyph for the fatal "no skills found" exit, and left the clack box unterminated on both failure paths.
- Usage and error output is now bookended by `intro`/`outro`. Without an intro, clack renders its `│` gutter with no `┌` above and no `└` below — a visibly broken box, which was every usage and error path in the repo.
- The local `try`/`catch` blocks in `discover.ts` and `recommend.ts` that hand-rolled `p.log.error(...); process.exit(1)` are deleted; the typed errors propagate to `runCli`. That duplication is what `cli-bootstrap.ts` was extracted to remove.
- `parseArgs` in `build-skills.ts` ran at module scope with `strict: true` over `Bun.argv`, so a plain `import` of that module parsed the host process's flags and could throw. Moved inside the `import.meta.main` guard.

## Repo plumbing

- **The playground apps never built in CI**, so the client-bundle smoke tests they exist to be asserted nothing. `turbo run test`/`typecheck` report `<NONEXISTENT>` for both (no such scripts), and no workflow ran the root `bun run build`. Added that step to `test.yml`.
- `turbo.jsonc`'s `dev` task lacked `dependsOn: ["^build"]`, unlike every other task. On a clean clone both dev servers resolve `hr-skills-build/client` to a `dist/` file that does not exist until tsdown's first emit.
- `page.tsx` pointed at a `next.config.ts` that has never existed. Comment corrected rather than inventing the config.
- `vite-app` had no viewport meta tag (Vite injects none, so mobile rendered at a 980px virtual viewport); `next-app` had no `<title>`. Both now declare `color-scheme: light dark`, which gets dark mode from the UA without either app shipping a stylesheet.
- `CLAUDE.md` is a one-line `AGENTS.md` alias that can never satisfy MD041, so `lint:md:fix` in the `pre-commit` hook rejected **every** commit. Added to `.markdownlintignore`.
- `.agents/skills/clack/SKILL.md` updated: its API inventory was stale in both directions (8 of 12 `p.note` call sites unlisted, `validate.ts` excluded from scope entirely), and its template no longer matched the bootstrap.

## Verification

| Check | Result |
|---|---|
| `bun run validate` | 146 skills, 0 errors |
| `bun run test` | 476 pass, 0 fail (+1 new) |
| `bun run typecheck` | clean |
| `bun run check` | clean, 114 files |
| `bun run build` | both playground apps compile |
| `bun run lint:md` | clean |
| archive round-trip | `testzip() -> None`, 823/824 entries readable |

`bun run knip` could not be run locally: `oxc-parser@0.142.0` fails to allocate its raw-transfer `ArrayBuffer` on the first parse under Node 24 on Windows, regardless of workspace scope. Confirmed identical on a clean tree with the changes stashed, so it is environmental and pre-existing. The one new export (`buildZipBuffer`) matches an existing accepted precedent — `src/build/sync.ts` exports `syncMarketplace`, consumed only by its test and likewise excluded from the `src/index.ts` barrel.

## Not addressed

The CLI audit surfaced more than this PR fixes. Left for follow-ups: `generate-registry`, `generate-relevance-signals`, `skill-review`, `generate-skill-matrix`, and `build-skills` use `console.log` with no clack at all, violating this repo's own convention doc; nine competing status-glyph vocabularies, traceable to `SkillValidationIssue` having no severity field; `matrix` renders `NaN%` on an empty repo and has no `--check` mode unlike its `api-docs` sibling; `plan`/`execute`/`evaluate` write artifacts to `process.cwd()`, which under turbo is the package directory rather than the repo root; and a typo'd skill name is reported to PRs as a **security finding**, because `readSkillContent` pushes "SKILL.md file not found" into the same array the security checks fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
