### PR TITLE
fix(cv): configure Vercel output directory

### DIFF
--- a/apps/cv/vercel.json
+++ b/apps/cv/vercel.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"outputDirectory": null
+}


### PR DESCRIPTION
## Summary

Configure Vercel from the `apps/cv` project root so Nuxt Nitro deployments do not fall back to the default `dist` output directory.

## Why

The `hr-skills-cv` Vercel project uses `apps/cv` as its Root Directory. The repository-level `vercel.json` was not applied consistently from that project root, so Vercel completed the Nitro build and then failed while looking for a `dist` directory.

## Changes

- Add `apps/cv/vercel.json`.
- Set `outputDirectory` to `null` so Vercel uses the Nuxt Nitro deployment output.

## Validation

- Biome check passed for the new configuration file.
- `apps/cv` production build passed.
- Git diff check passed.

## Scope

This PR contains only the Vercel output configuration fix for `apps/cv`. The CV Builder implementation was already merged in PR #232.
