### PR TITLE
chore: remove repository Vercel configuration

### DIFF
--- a/apps/cv/vercel.json
+++ b/apps/cv/vercel.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"outputDirectory": null
-}

--- a/apps/jd/vercel.json
+++ b/apps/jd/vercel.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"outputDirectory": null
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"outputDirectory": null
-}


### PR DESCRIPTION
## Summary

Remove repository-level Vercel configuration so the Vercel project can be configured manually through the Vercel dashboard.

## Changes

- Remove the root `vercel.json`.
- Remove `apps/jd/vercel.json`.
- Remove `apps/cv/vercel.json`.

## Validation

- Commit hooks passed, including commitlint.
- The change is limited to Vercel configuration files.

## Follow-up

After this PR is merged, configure the Vercel project manually with the intended Root Directory, Framework Preset, Build Command, and deployment settings.
