### PR TITLE
feat(skills): enrich AI adoption and governance with AIHR evidence

### DIFF
--- a/registry/skills.json
+++ b/registry/skills.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-14",
+  "generatedAt": "2026-08-21",
   "skillCount": 146,
   "skills": [
     {
@@ -153,7 +153,7 @@
     {
       "id": "hr-ai-adoption",
       "name": "hr-ai-adoption",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Help HR leaders drive practical, sustained adoption of AI tools among HR teams and the broader employee population, beyond initial rollout. Use when asked to drive AI adoption in HR, get our team to actually use this AI tool, build an AI adoption strategy for employees, measure AI tool usage and impact, or overcome resistance to AI tools in HR.",
       "tier": "full",
       "domain": "hr-technology-ai",
@@ -174,8 +174,8 @@
         "Addressing job security and role-change concerns tied to AI adoption",
         "Designing feedback loops to improve AI tools based on real usage",
         "Building manager enablement to support their teams through AI adoption",
-        "Comparing adoption approaches for different AI tool types (chatbot, analytics, copilot)",
-        "Sustaining adoption momentum after the initial rollout period fades"
+        "Connecting AI adoption to internal mobility, skills visibility, and employee experience",
+        "Building a use-case canvas and staged pilot with explicit expand, pause, or redesign criteria"
       ],
       "triggerPhrases": [
         "Design an AI adoption strategy for [HR team / broader employee population] rolling out [AI tool].",
@@ -345,7 +345,7 @@
     {
       "id": "hr-ai-governance",
       "name": "hr-ai-governance",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Help HR and compliance teams govern the responsible use of AI in HR processes, including hiring algorithms, monitoring tools, and policy design. Use when asked to design an AI governance policy for HR, assess bias risk in a hiring algorithm, write an AI use policy for HR, audit an HR AI tool, or similar HR AI governance tasks.",
       "tier": "full",
       "domain": "hr-technology-ai",
@@ -364,10 +364,10 @@
         "Designing human-in-the-loop review requirements for AI-assisted decisions",
         "Building an AI vendor due-diligence checklist for HR tools",
         "Drafting data privacy guidance for AI tools processing employee data",
-        "Creating training for HR staff on responsible AI use",
         "Auditing existing HR AI tools against governance standards",
         "Designing escalation processes for AI-related employee complaints",
-        "Drafting documentation standards for AI-assisted employment decisions"
+        "Classifying HR AI use cases by decision impact and required oversight",
+        "Designing data-flow, retention, correction, and appeal controls for HR AI systems"
       ],
       "triggerPhrases": [
         "Draft an AI use policy governing how HR may use AI tools in hiring and performance decisions.",

--- a/skills/hr-ai-adoption/SKILL.md
+++ b/skills/hr-ai-adoption/SKILL.md
@@ -3,7 +3,7 @@ name: hr-ai-adoption
 description: "Help HR leaders drive practical, sustained adoption of AI tools among HR teams and the broader employee population, beyond initial rollout. Use when asked to drive AI adoption in HR, get our team to actually use this AI tool, build an AI adoption strategy for employees, measure AI tool usage and impact, or overcome resistance to AI tools in HR."
 metadata:
   author: Tuan Duc Tran
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 # AI adoption in HR
@@ -22,8 +22,8 @@ Drive practical, sustained adoption of AI tools — among HR teams and the broad
 - Addressing job security and role-change concerns tied to AI adoption
 - Designing feedback loops to improve AI tools based on real usage
 - Building manager enablement to support their teams through AI adoption
-- Comparing adoption approaches for different AI tool types (chatbot, analytics, copilot)
-- Sustaining adoption momentum after the initial rollout period fades
+- Connecting AI adoption to internal mobility, skills visibility, and employee experience
+- Building a use-case canvas and staged pilot with explicit expand, pause, or redesign criteria
 
 ## Key prompts
 
@@ -48,6 +48,13 @@ Drive practical, sustained adoption of AI tools — among HR teams and the broad
 3. "How do we respond to skepticism from experienced HR practitioners who don't see the value of [AI tool] in their workflow?"
 4. "What should we do when a vocal team member actively discourages peers from adopting [AI tool]?"
 
+### Use-case and rollout design
+
+1. "Map the current [HR workflow] and identify the smallest AI use case that could improve [outcome] without removing human accountability."
+2. "Design a staged pilot for [AI tool] with baseline measures, representative users, support, feedback, stop conditions, and expansion criteria."
+3. "Create a use-case canvas for [AI initiative] covering user problem, data readiness, prohibited uses, owner, reviewer, and evidence of value."
+4. "Connect [AI adoption initiative] to internal mobility, skills visibility, and employee experience without overstating what the tool can infer."
+
 ### Measuring and sustaining
 
 1. "Design a way to measure actual usage and productivity impact of [AI tool], not just initial adoption numbers."
@@ -62,3 +69,4 @@ Drive practical, sustained adoption of AI tools — among HR teams and the broad
 - Use early wins and visible champions to build peer credibility — adoption spreads faster through trusted colleagues than top-down mandates.
 - Measure usage and outcomes, not just initial training attendance; adoption that fades after a launch event isn't real adoption.
 - Keep collecting feedback after rollout; tools that don't improve based on real usage patterns lose credibility and get quietly abandoned.
+- Measure repeated use, rework, quality, confidence, and safe-use adherence rather than treating account activation or training attendance as adoption.

--- a/skills/hr-ai-adoption/content/aihr-adoption-operating-model.md
+++ b/skills/hr-ai-adoption/content/aihr-adoption-operating-model.md
@@ -1,0 +1,40 @@
+# AIHR evidence: an operating model for AI adoption in HR
+
+AIHR’s public articles describe AI adoption as a workflow and capability change, not simply a software launch. Relevant examples include [AI for internal mobility](https://www.aihr.com/blog/ai-for-internal-mobility/), [AI in HR](https://www.aihr.com/blog/ai-in-hr/), and [AI HR assistant](https://www.aihr.com/blog/ai-hr-assistant/). The practical implication is to connect each AI use case to a user problem, a safe operating boundary, enablement, and evidence of changed work.
+
+## Start from work, not features
+
+Map the current HR workflow before choosing the adoption intervention. Identify the repetitive step, decision bottleneck, quality problem, or employee experience gap the tool is meant to improve. Define what a good outcome looks like in the existing process, then select a small use case where users can see value without changing every process at once.
+
+For internal mobility, for example, adoption should be framed around making skills, opportunities, and development conversations more visible. A tool that recommends opportunities still needs trusted skills data, manager participation, employee agency, and a clear route to challenge or correct a recommendation.
+
+## Sequence the rollout
+
+Use a staged rollout: prepare the operating boundary, pilot with representative users, measure the workflow outcome, improve the experience, and then expand. Select pilot groups for learning value rather than enthusiasm alone. Include skeptical users and the contexts in which the process is difficult, while avoiding an initial scope so broad that the team cannot distinguish product problems from change-management problems.
+
+A pilot should define baseline performance, training and support, feedback channels, prohibited uses, and a stop condition. The next stage should depend on evidence of useful and safe behavior, not merely the number of accounts provisioned or people who attended training.
+
+## Enablement and trust
+
+AIHR’s AI-in-HR framing supports role-specific enablement. HR practitioners need practice with representative cases, guidance on verification and confidential data, examples of acceptable and unacceptable use, and a way to ask for help. Managers need language for role changes and job-security concerns. Employees need to understand where AI supports a service and where a human remains accountable.
+
+Peer champions can translate general training into local workflows, but they should not become informal policy owners. Give champions a bounded remit, escalation route, reusable examples, and a feedback mechanism. Publish improvements made from feedback so users can see that adoption is a two-way process.
+
+## Measure sustained adoption
+
+Measure a funnel rather than a single usage number: awareness, first successful use, repeated use in a target workflow, quality and time outcome, user confidence, and safe-use adherence. Segment results by role, team, use case, and level of support. A falling usage rate may indicate weak relevance, poor data, unclear policy, or lack of manager reinforcement; it should trigger investigation rather than an automatic mandate.
+
+Pair quantitative signals with workflow observation and user interviews. Track rework, escalation, correction, and abandonment, because high activity can coexist with low value. For a people-facing use case, include employee experience and fairness signals alongside productivity measures.
+
+## Adoption review questions
+
+| Review area | Questions |
+| --- | --- |
+| Relevance | Which specific HR task becomes easier, safer, faster, or more useful? |
+| Readiness | Do users have the data, skills, permissions, and time required to use the tool well? |
+| Trust | Can users verify, correct, and escalate an output? |
+| Enablement | Are examples and support tailored to the role and workflow? |
+| Outcomes | What changed in quality, cycle time, employee experience, or capability? |
+| Sustainability | What will maintain good use after launch support is reduced? |
+
+This document synthesizes the linked public AIHR material. It is operational guidance, not a promise that any specific AI product will produce a particular result.

--- a/skills/hr-ai-adoption/examples/aihr-assistant-rollout.md
+++ b/skills/hr-ai-adoption/examples/aihr-assistant-rollout.md
@@ -1,0 +1,25 @@
+# Staged rollout for an HR assistant
+
+## Scenario
+
+An HR operations team wants to introduce an AI assistant for policy search and first-draft employee responses. The objective is to reduce repetitive lookup work while preserving human accountability for sensitive cases.
+
+## Prepare
+
+The team maps the current workflow and chooses two low-risk tasks: finding approved policy passages and drafting a response that a named HR specialist must review. It defines prohibited uses, approved sources, confidential-data rules, baseline response time, quality criteria, and a route for employees to request human assistance.
+
+## Pilot
+
+The pilot includes HR operations, one HR business partner, and a skeptical representative from a high-volume service team. Each participant practices with realistic redacted cases. A champion collects friction and examples, but cannot approve policy changes or expand the use case. The product owner reviews errors weekly and pauses the pilot if the assistant invents policy, exposes restricted information, or is used to decide an employment outcome.
+
+## Measure
+
+The team tracks first successful use, repeated use in the target workflow, reviewer correction rate, rework, response time, escalation, confidence, and safe-use adherence. Interviews explain why users abandon the tool or bypass review. Adoption is considered healthy only when the workflow outcome improves without a rise in unsupported answers or hidden policy decisions.
+
+## Expand or redesign
+
+After 30 days, the team compares results with the baseline and publishes improvements made from feedback. Expansion requires stable quality, a workable review load, clear employee communication, and an owner for ongoing monitoring. If usage is low because the approved knowledge base is incomplete, the team improves the source and enablement before mandating use.
+
+## Expected output
+
+The final package contains a use-case canvas, pilot charter, role-based practice set, manager and employee communications, champion remit, dashboard definition, weekly review log, and an expand/pause/redesign decision record. The workflow is informed by [AIHR’s AI HR assistant article](https://www.aihr.com/blog/ai-hr-assistant/) and [AI in HR overview](https://www.aihr.com/blog/ai-in-hr/).

--- a/skills/hr-ai-adoption/prompts/aihr-adoption-planning.md
+++ b/skills/hr-ai-adoption/prompts/aihr-adoption-planning.md
@@ -1,0 +1,22 @@
+# AI adoption planning prompts
+
+## Use-case and rollout design
+
+- "Map the current [HR workflow] and identify the smallest AI use case that could improve [quality, cycle time, employee experience, or capability] without hiding the accountable human."
+- "Design a staged rollout for [AI tool] across [population]. Define pilot selection, baseline measures, enablement, support, feedback, stop conditions, and expansion criteria."
+- "Compare the adoption risks of introducing [chatbot, copilot, analytics, or internal-mobility tool] in [HR process] and recommend controls for each stage."
+- "Create a use-case canvas for [AI initiative] covering user problem, desired outcome, data readiness, prohibited uses, reviewer, escalation, and evidence of value."
+
+## Enablement and trust
+
+- "Create role-specific practice exercises for [HR role] using [AI tool], including verification steps, confidential-data boundaries, acceptable-use examples, and escalation."
+- "Draft manager talking points for [AI rollout] that address job changes honestly, explain accountability, and avoid promising that automation will have no workforce impact."
+- "Design a peer-champion program for [population] with a bounded remit, support materials, feedback route, and handoff to the accountable product or HR owner."
+- "Write an employee FAQ for [AI-supported HR service] explaining purpose, human involvement, data boundaries, correction, and how to request human help."
+
+## Measurement and sustainment
+
+- "Build an adoption funnel for [AI use case] from awareness to repeated safe use and measurable workflow outcome. Define leading and lagging indicators."
+- "Design a baseline and pilot evaluation for [HR process] that measures quality, rework, cycle time, confidence, fairness, and safe-use adherence."
+- "Analyze these usage and outcome signals for [AI tool]. Distinguish low relevance, poor enablement, data issues, policy friction, and manager reinforcement problems."
+- "Create a 30/60/90-day sustainment plan for [AI rollout], including feedback reviews, product improvements, champion support, and a decision to expand, pause, or redesign."

--- a/skills/hr-ai-governance/SKILL.md
+++ b/skills/hr-ai-governance/SKILL.md
@@ -3,7 +3,7 @@ name: hr-ai-governance
 description: "Help HR and compliance teams govern the responsible use of AI in HR processes, including hiring algorithms, monitoring tools, and policy design. Use when asked to design an AI governance policy for HR, assess bias risk in a hiring algorithm, write an AI use policy for HR, audit an HR AI tool, or similar HR AI governance tasks."
 metadata:
   author: Tuan Duc Tran
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 # HR AI governance
@@ -20,10 +20,10 @@ Helps HR and compliance teams govern the responsible, compliant use of AI tools 
 - Designing human-in-the-loop review requirements for AI-assisted decisions
 - Building an AI vendor due-diligence checklist for HR tools
 - Drafting data privacy guidance for AI tools processing employee data
-- Creating training for HR staff on responsible AI use
 - Auditing existing HR AI tools against governance standards
 - Designing escalation processes for AI-related employee complaints
-- Drafting documentation standards for AI-assisted employment decisions
+- Classifying HR AI use cases by decision impact and required oversight
+- Designing data-flow, retention, correction, and appeal controls for HR AI systems
 
 ## Key prompts
 
@@ -43,6 +43,13 @@ Helps HR and compliance teams govern the responsible, compliant use of AI tools 
 4. "Draft questions to ask an AI hiring tool vendor about training data and validation testing."
 5. "Assess data privacy risks of an AI tool that analyzes employee communications."
 
+### Use-case triage and operational controls
+
+1. "Classify [HR AI use case] as administrative assistance, decision support, or automated decision-making and define the required controls."
+2. "Map the data flow, retention, access, and deletion controls for [AI tool] processing [employee or candidate data]."
+3. "Design a monitoring and appeal process for [AI-assisted HR decision] that records overrides, incidents, and correction requests."
+4. "Create a pre-pilot, launch, and post-launch review checklist for [HR AI use case]."
+
 ### Disclosure and training
 
 1. "Write an employee-facing disclosure explaining how AI is used in the hiring process."
@@ -57,6 +64,8 @@ Helps HR and compliance teams govern the responsible, compliant use of AI tools 
 - Document what data trains and validates any AI hiring tool before adoption, not after a complaint.
 - Disclose AI use to candidates and employees clearly, in plain language, ahead of the decision being made.
 - Reassess AI tools periodically for bias, since model behavior and underlying data can drift over time.
+- Treat prompts, uploads, outputs, and vendor logs as potential employee-data surfaces; define their controls before launch.
+- Classify the use case before evaluating the vendor so governance effort follows employment impact, not product novelty.
 
 ## Common mistakes
 

--- a/skills/hr-ai-governance/content/aihr-evidence-and-governance.md
+++ b/skills/hr-ai-governance/content/aihr-evidence-and-governance.md
@@ -1,0 +1,39 @@
+# AIHR evidence: governance for AI in HR
+
+AIHR’s public material treats AI in HR as a portfolio of use cases rather than a single deployment. The governance question is therefore not only whether a tool is accurate, but also whether the use case is proportionate, explainable, secure, and reviewable throughout the employee lifecycle. See [AI in HR](https://www.aihr.com/blog/ai-in-hr/) and [Data Privacy and Ethics in AI for HR](https://www.aihr.com/blog/data-privacy-and-ethics-in-ai-for-hr/).
+
+## Use-case classification
+
+Start by classifying the proposed use case before selecting a vendor or model. Separate administrative assistance, decision support, and automated decision-making. The closer a system is to hiring, promotion, performance, compensation, termination, or access to sensitive employee information, the stronger the evidence, approval, monitoring, and human-review requirements should be.
+
+Document the intended decision, affected people, data inputs, model output, responsible owner, human reviewer, escalation route, retention period, and fallback process. Do not allow a model output to become a hidden policy simply because it is convenient to consume.
+
+## Privacy and data minimization
+
+AIHR’s privacy-and-ethics framing supports a data-minimization approach: use only the attributes needed for the stated HR purpose, remove direct identifiers where they are not necessary, restrict access by role, and define retention before collecting data. Treat prompts, uploaded documents, generated outputs, logs, and vendor telemetry as potential employee-data surfaces.
+
+A governance review should ask whether the organization has a lawful and transparent purpose, a documented data flow, an access control, a retention/deletion rule, and a way for an employee or candidate to obtain a meaningful explanation of the process. These questions are operational controls, not merely policy language.
+
+## Bias and validation
+
+Validation must be disaggregated by relevant populations and tested against the actual workflow in which the output will be used. Review false positives and false negatives, missing-data behavior, language and accessibility effects, and changes in performance after model or process updates. A useful result is not sufficient if affected people cannot challenge an error or if the reviewer cannot understand the evidence behind a recommendation.
+
+Keep a decision log for material use cases. Record the version of the system, evaluation sample, known limitations, reviewer decision, override reason, and incident or appeal outcome. Use this record for periodic review and vendor conversations.
+
+## Human oversight and employee communication
+
+Human review should be substantive. Give reviewers authority to reject or override an output, enough context to do so, and a documented escalation path for uncertain cases. Avoid rubber-stamping by sampling decisions, measuring override patterns, and reviewing disagreement cases.
+
+Explain AI-supported processes in plain language to employees and candidates when the process materially affects them. The explanation should cover the purpose, the role of automation, the role of human review, the data categories involved, and how to raise a concern. Do not promise that a human is “in the loop” if the human cannot change the outcome.
+
+## Practical governance checklist
+
+1. Define the HR decision and the acceptable use boundary.
+2. Map data sources, access, retention, transfers, and vendor processing.
+3. Assess bias, validity, accessibility, security, and failure modes before launch.
+4. Assign an accountable owner and an independent reviewer for material decisions.
+5. Pilot with a documented baseline and monitor outcomes after deployment.
+6. Provide notice, explanation, appeal, correction, and incident processes.
+7. Re-review when the model, vendor, data, workforce, or legal context changes.
+
+This guidance is a synthesis of the linked AIHR articles and is not legal advice. Apply the organization’s applicable laws, collective agreements, internal policy, and professional review requirements before deployment.

--- a/skills/hr-ai-governance/examples/aihr-assistant-governance-review.md
+++ b/skills/hr-ai-governance/examples/aihr-assistant-governance-review.md
@@ -1,0 +1,29 @@
+# Governance review for an HR assistant
+
+## Scenario
+
+An HR team wants to introduce an AI assistant that drafts answers to policy questions, summarizes employee-provided information, and suggests next steps to HR staff. The assistant must not make hiring, promotion, compensation, performance, or termination decisions.
+
+## Step 1: Define the boundary
+
+The owner writes a one-sentence purpose statement: “The assistant helps HR staff find and draft responses from approved policy sources.” The register marks the tool as administrative assistance and decision support, not automated decision-making. It lists prohibited inputs and outputs, including requests to rank employees, infer protected characteristics, diagnose health conditions, or recommend employment outcomes.
+
+## Step 2: Map data and controls
+
+The review maps prompts, uploaded documents, generated answers, logs, and vendor telemetry. The team configures approved sources, role-based access, retention limits, redaction for unnecessary identifiers, and a deletion route. The vendor contract and settings are reviewed for training reuse, subprocessors, cross-border transfer, and breach notification.
+
+## Step 3: Design human review
+
+Every answer that could influence an employee receives a named HR reviewer. The interface displays source links and uncertainty notes, and the reviewer must edit or reject unsupported claims. A sample of routine answers is audited weekly. Override reasons and incidents are recorded so that rubber-stamping, recurring misinformation, and policy gaps can be detected.
+
+## Step 4: Pilot and communicate
+
+The team pilots the assistant with synthetic and redacted cases, compares response quality with a documented baseline, and checks performance across languages and accessibility needs. Employees are told what the assistant does, what it does not do, what information should not be entered, and how to request human help or challenge an answer.
+
+## Step 5: Decision record
+
+The final record includes the purpose, prohibited uses, data map, vendor review, pilot results, known limitations, reviewer protocol, monitoring indicators, incident route, owner, approval date, and next review date. The assistant is paused if it begins producing unsupported policy claims, exposes restricted information, or is used as an undisclosed employment decision tool.
+
+## Expected output
+
+The deliverable is a short approved-use policy, a data-flow and vendor checklist, a human-review operating procedure, an employee notice, and a monitoring log. This workflow synthesizes AIHR’s public guidance on AI in HR and data privacy and ethics; it does not replace legal, works-council, security, or privacy review.

--- a/skills/hr-ai-governance/prompts/aihr-governance-review.md
+++ b/skills/hr-ai-governance/prompts/aihr-governance-review.md
@@ -1,0 +1,22 @@
+# AI in HR governance review prompts
+
+## Use-case triage
+
+- "Classify this proposed [HR AI use case] as administrative assistance, decision support, or automated decision-making. Explain the governance consequences and the minimum approval controls."
+- "Create an AI use-case register for [process], including purpose, affected populations, data categories, model output, owner, reviewer, escalation path, and prohibited uses."
+- "Identify where this workflow could turn an advisory model output into an unreviewed employment decision, and redesign the control points."
+- "Build a risk-based review plan for [use case] before pilot, launch, and post-launch monitoring."
+
+## Privacy and security
+
+- "Minimize the data in this [HR AI workflow] while preserving the stated purpose. List fields to remove, generalize, restrict, or retain and explain why."
+- "Map the data flow for [AI vendor and HR process], including prompt inputs, uploaded files, generated outputs, logs, retention, access, and deletion."
+- "Draft plain-language employee notice for [AI-supported process] covering purpose, automation, human review, data categories, and appeal route."
+- "Review this vendor questionnaire for gaps in employee-data processing, access control, retention, deletion, security, and secondary use."
+
+## Bias, validity, and oversight
+
+- "Design a validation plan for [AI use case] that tests false positives, false negatives, missing data, language, accessibility, and outcomes across relevant populations."
+- "Create a human-review protocol for [decision], including reviewer authority, evidence requirements, override reasons, escalation, and audit sampling."
+- "Analyze this model monitoring report for drift, disparate outcomes, override patterns, and incidents. Recommend actions without treating correlation as causation."
+- "Write an incident and appeal workflow for an employee who believes [AI-supported HR decision] is inaccurate or unfair."


### PR DESCRIPTION
## Summary

This PR enriches two existing HR skills with operational guidance, reusable prompts, and end-to-end examples synthesized from public AIHR material already collected by the scraper. It does not create a new skill and does not copy article text verbatim.

### Updated skills

- `hr-ai-adoption`: adds an operating model for use-case selection, staged pilots, role-based enablement, champions, adoption funnels, internal mobility, and sustainment.
- `hr-ai-governance`: adds use-case triage, privacy/data-flow controls, bias and validity checks, human oversight, employee communication, and appeals.

Each skill keeps its `SKILL.md` concise and adds one focused file under `content/`, `prompts/`, and `examples/`. `registry/skills.json` was regenerated with the repository command.

## Sources

- https://www.aihr.com/blog/ai-in-hr/
- https://www.aihr.com/blog/data-privacy-and-ethics-in-ai-for-hr/
- https://www.aihr.com/blog/ai-hr-assistant/
- https://www.aihr.com/blog/ai-for-internal-mobility/
- https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/

## Validation

- `bun run validate` — 146 skills, 0 errors
- `bun run sync` — marketplace and root router already in sync
- `bunx markdownlint` on all changed Markdown — passed
- pre-commit Lefthook — passed

The two existing informational co-selection warnings for `hr-career-development` are unchanged and unrelated to this PR.
