### PR TITLE
chore: add AIHR HR Tech examples

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -12,6 +12,8 @@ jobs:
   knip:
     name: Knip
     runs-on: ubuntu-latest
+    env:
+      KNIP_DISABLE_RAW_TRANSFER: "1"
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: bun ci
 
+      - name: Build skill review dependencies
+        run: bunx turbo run build --filter=hr-skills...
+
       - name: Build hr-skills-ref
         run: bun run build --filter=hr-skills-ref
 
@@ -86,8 +89,8 @@ jobs:
       - name: Generate deterministic report
         if: steps.changed.outputs.count != '0'
         run: |
-          cd packages/hr-skills-build
           echo "${{ steps.changed.outputs.list }}" > /tmp/changed-skills.txt
+          cd packages/hr-skills
           bun run skill-review -- --list-file /tmp/changed-skills.txt > /tmp/skill-review-report.md
           cat /tmp/skill-review-report.md
 

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-20",
+  "generatedAt": "2026-08-23",
   "skillCount": 146,
   "skills": [
     {
@@ -2765,7 +2765,7 @@
       "id": "hr-hris",
       "name": "hr-hris",
       "version": "1.0.1",
-      "description": "Help HR managers, HR operations teams, and recruiters understand HRIS (Human Resource Information Systems), including HRIS platforms, implementation and migration, system integrations, employee data management, HR automation, and HRIS-related hiring. Use when asked to explain HRIS, choose an HRIS platform, implement or migrate an HRIS, screen HRIS analysts or managers, understand HR system integrations, configure HRIS to automate HR workflows, evaluate HRIS vendors, or any HR technology and systems task.",
+      "description": "Help HR managers, HR operations teams, and recruiters evaluate HRIS platforms, implementations, migrations, integrations, data governance and automation. Use when selecting or configuring HRIS, screening people-systems talent, assessing vendors, planning integrations, or improving HR technology workflows.",
       "tier": "full",
       "domain": "hr-technology-ai",
       "tags": [],

--- a/skills/hr-hris/SKILL.md
+++ b/skills/hr-hris/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hr-hris
-description: "Help HR managers, HR operations teams, and recruiters understand HRIS (Human Resource Information Systems), including HRIS platforms, implementation and migration, system integrations, employee data management, HR automation, and HRIS-related hiring. Use when asked to explain HRIS, choose an HRIS platform, implement or migrate an HRIS, screen HRIS analysts or managers, understand HR system integrations, configure HRIS to automate HR workflows, evaluate HRIS vendors, or any HR technology and systems task."
+description: "Help HR managers, HR operations teams, and recruiters evaluate HRIS platforms, implementations, migrations, integrations, data governance and automation. Use when selecting or configuring HRIS, screening people-systems talent, assessing vendors, planning integrations, or improving HR technology workflows."
 metadata:
   author: Tuan Duc Tran
   version: "1.0.1"

--- a/skills/hr-hris/examples/aihr-hris-implementation-gates.md
+++ b/skills/hr-hris/examples/aihr-hris-implementation-gates.md
@@ -1,0 +1,28 @@
+# Example: HRIS implementation gates
+
+Use these gates to keep an HRIS implementation focused on business requirements, data integrity, adoption, and sustainable operations. The phases are sequential enough to expose missing decisions early, but they should be revisited when scope, regulations, or the organization changes.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [How to Implement an HRIS in 6 Steps](https://www.aihr.com/blog/how-to-implement-an-hris-in-6-steps/), accessed from the public WordPress API on 2026-08-22. The source describes six high-level phases: search, planning and alignment, definition and design, configuration and testing, training and configuration, and deployment and sustainability.
+
+## Six implementation gates
+
+| Gate | Questions to answer | Evidence before moving on |
+| --- | --- | --- |
+| Search | What outcomes, users, processes, and constraints define the need? | Requirements, scope boundary, stakeholder list, and selection criteria |
+| Plan and align | Who owns decisions, budget, risks, and communications? | Governance model, milestones, escalation path, and change plan |
+| Define and design | What should the future process and data model look like? | Process maps, role model, data dictionary, integrations, and acceptance criteria |
+| Configure and test | Does the configured system behave correctly with representative data? | Test cases, migration reconciliation, integration tests, security checks, and defect log |
+| Train and prepare | Can each user group complete its tasks and understand the change? | Role-based training, support model, communications, and readiness evidence |
+| Deploy and sustain | Can the organization operate, measure, and improve the system after launch? | Cutover plan, rollback decision, ownership, monitoring, issue triage, and post-launch review |
+
+## Migration and rollout controls
+
+Before importing employee data, define the authoritative source for each field, normalize values, remove duplicates, preserve a reconciliation record, and test a representative sample. Treat payroll, benefits, identity, and access integrations as separate risk areas rather than assuming that a successful core import proves the entire rollout is safe.
+
+During rollout, publish the support route and a clear escalation owner. Measure adoption by user group, process completion, defect volume, and support demand rather than relying only on attendance at training. Record decisions and exceptions so future administrators can distinguish intended configuration from workarounds.
+
+## HR practitioner takeaway
+
+An HRIS implementation is complete only when the organization can operate the new process reliably, protect employee data, support users, and demonstrate that the system meets its agreed outcomes. A vendor demo or a technically successful deployment is evidence of progress, not evidence of adoption or business value.

--- a/skills/hr-technology/examples/aihr-technology-strategy-scorecard.md
+++ b/skills/hr-technology/examples/aihr-technology-strategy-scorecard.md
@@ -1,0 +1,33 @@
+# Example: HR technology strategy scorecard
+
+Use this scorecard when an HR technology roadmap needs to connect business outcomes, user adoption, integration, governance, and long-term scalability. The objective is not to purchase the largest number of tools; it is to create a coherent operating model that solves prioritized problems and can be measured after implementation.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [HR Technology Strategy: How HR Leaders Can Succeed](https://www.aihr.com/blog/hr-technology-strategy/), accessed from the public WordPress API on 2026-08-22. It preserves the source attribution but does not reproduce the article.
+
+## Strategy scorecard
+
+| Dimension | Decision question | Evidence to collect | Minimum output |
+| --- | --- | --- | --- |
+| Business alignment | Which people or business outcome should improve? | Baseline KPI, owner, target date, affected population | A measurable objective |
+| Process fit | Which workflow is failing or consuming avoidable effort? | Process map, pain points, exception volume, current controls | Prioritized problem statement |
+| User experience | Can employees, managers, and HR complete the task reliably? | User interviews, accessibility needs, task completion feedback | Adoption and usability requirements |
+| Architecture | How will the proposed system coexist with the current stack? | System of record, integration points, data ownership, failure handling | Integration and data-flow outline |
+| Governance | Who may view, change, export, and retain the data? | Data classification, access roles, audit needs, privacy obligations | Control requirements and review owner |
+| Economics | What is the total cost and how will value be measured? | License, implementation, training, support, migration, avoided cost | Business case with assumptions |
+| Scalability | What changes as headcount, countries, or transaction volume grow? | Growth scenarios, localization, vendor limits, support capacity | Exit and scale criteria |
+
+## Practical sequence
+
+1. Audit the current HR processes and technology before writing vendor requirements.
+2. Agree on a small set of SMART outcomes with HR, IT, finance, and executive sponsors.
+3. Separate must-have controls and capabilities from useful but deferrable features.
+4. Compare vendors against the same weighted scorecard and test realistic user journeys during demos.
+5. Confirm integration, security, privacy, accessibility, support, and data-export requirements in writing.
+6. Pilot the highest-risk workflow with representative users, measure adoption and service quality, and revise the roadmap from evidence.
+7. Review the stack periodically so duplicated tools, new risks, and changing business needs are handled deliberately.
+
+## HR practitioner takeaway
+
+A good HR technology strategy is a governed portfolio of capabilities, not a list of vendor logos. A decision is ready for approval when its intended outcome, user impact, integration boundary, data controls, total cost, and post-launch measurement plan are explicit.


### PR DESCRIPTION
## HR Tech enrichment from AIHR

This PR adds two reviewed, source-attributed examples to existing skills:

- `skills/hr-technology/examples/aihr-technology-strategy-scorecard.md`
- `skills/hr-hris/examples/aihr-hris-implementation-gates.md`

Both files are original editorial syntheses based on public AIHR articles. They are not verbatim copies, and no new skill directory is created.

The PR also carries the minimal CI corrections required while the earlier source branch remains unmerged: Skill Review now invokes the package script from the correct directory after building its dependency, and Knip uses its documented raw-transfer opt-out. These changes are limited to the existing workflows and make the required checks deterministic.

Validation completed:

- `bun install --frozen-lockfile`
- `bun run check` with `KNIP_DISABLE_RAW_TRANSFER=1`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
