### PR TITLE
chore: add AIHR DEIB and onboarding examples

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -12,6 +12,8 @@ jobs:
   knip:
     name: Knip
     runs-on: ubuntu-latest
+    env:
+      KNIP_DISABLE_RAW_TRANSFER: "1"
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: bun ci
 
+      - name: Build skill review dependencies
+        run: bunx turbo run build --filter=hr-skills...
+
       - name: Build hr-skills-ref
         run: bun run build --filter=hr-skills-ref
 
@@ -86,8 +89,8 @@ jobs:
       - name: Generate deterministic report
         if: steps.changed.outputs.count != '0'
         run: |
-          cd packages/hr-skills-build
           echo "${{ steps.changed.outputs.list }}" > /tmp/changed-skills.txt
+          cd packages/hr-skills
           bun run skill-review -- --list-file /tmp/changed-skills.txt > /tmp/skill-review-report.md
           cat /tmp/skill-review-report.md
 

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-20",
+  "generatedAt": "2026-08-23",
   "skillCount": 146,
   "skills": [
     {
@@ -2024,7 +2024,7 @@
       "id": "hr-employee-experience",
       "name": "hr-employee-experience",
       "version": "1.0.1",
-      "description": "Help HR business partners, employee experience managers, and people leaders understand, design, and run employee experience strategies, journey mapping, engagement programs, culture diagnostics, onboarding and offboarding experience design, workplace environment initiatives, and recognition and belonging programs. Use when asked to design an employee experience strategy, map the employee journey, run an engagement diagnostic, design a culture program, improve the onboarding experience, build a recognition program, design a belonging and inclusion experience, respond to an engagement crisis, measure employee experience health, or any employee experience, engagement, or culture design task, or design the end-to-end employee experience.",
+      "description": "Help HR business partners, employee experience managers, and people leaders design and evaluate employee experience, journey mapping, engagement, culture, onboarding and belonging programs. Use when diagnosing experience risks, improving lifecycle moments, building recognition or inclusion practices, responding to engagement crises, or measuring employee experience health.",
       "tier": "full",
       "domain": "culture-experience",
       "tags": [],

--- a/skills/hr-diversity-inclusion/examples/aihr-deib-operating-scorecard.md
+++ b/skills/hr-diversity-inclusion/examples/aihr-deib-operating-scorecard.md
@@ -1,0 +1,30 @@
+# Example: DEIB operating scorecard
+
+Use this scorecard to move DEIB work from isolated initiatives toward accountable changes in systems, employee experience, and leadership behavior.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [Diversity, Equity, Inclusion and Belonging At Work: A 2026 Guide](https://www.aihr.com/blog/diversity-equity-inclusion-belonging-deib/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce the source.
+
+## Operating scorecard
+
+| Area | Diagnostic question | Evidence or action |
+| --- | --- | --- |
+| Representation | Who is present, progressing, and absent at each stage? | Consistently defined representation data by level and lifecycle stage |
+| Equity | Do policies, decisions, resources, and outcomes differ unfairly across groups? | Review of hiring, promotion, pay, development, and access patterns |
+| Inclusion | What employer behaviors and systems make participation possible? | Policy audit, inclusive process review, and employee feedback |
+| Belonging | Do employees feel respected, heard, valued, and safe to contribute? | Belonging and psychological-safety listening signals |
+| Systems | Where can bias persist even when individual intentions are positive? | Process controls, decision criteria, and accountability owners |
+| Leadership | What do leaders model, resource, measure, and address? | Visible commitments, manager expectations, and progress reviews |
+| Coverage | Which groups or worker arrangements are missing from the design? | Check of frontline, remote, contingent, and intersecting identities |
+| Learning | What behavior or capability must change, and how will it be reinforced? | Practice-based learning, manager support, and follow-up evidence |
+
+## Inclusion-to-belonging logic
+
+Treat inclusion as the actions and conditions the organization creates, and belonging as the employee experience that results. A welcoming policy or program is not sufficient evidence of belonging; listen for whether people feel respected, represented, supported, and able to contribute without fear of retribution.
+
+Measure both leading and outcome signals. Leading signals can include participation in listening, policy completion, manager actions, and process coverage. Outcome signals can include belonging, psychological safety, access to development, representation at progression points, retention, and employee feedback. Interpret results by group and lifecycle stage, protect confidentiality, and pair quantitative patterns with qualitative context.
+
+## HR practitioner takeaway
+
+Durable DEIB progress requires changes to systems and everyday management practices, not only awareness events. Assign owners, publish measurable commitments, review trade-offs, and use employee evidence to improve the design continuously.

--- a/skills/hr-employee-experience/SKILL.md
+++ b/skills/hr-employee-experience/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hr-employee-experience
-description: "Help HR business partners, employee experience managers, and people leaders understand, design, and run employee experience strategies, journey mapping, engagement programs, culture diagnostics, onboarding and offboarding experience design, workplace environment initiatives, and recognition and belonging programs. Use when asked to design an employee experience strategy, map the employee journey, run an engagement diagnostic, design a culture program, improve the onboarding experience, build a recognition program, design a belonging and inclusion experience, respond to an engagement crisis, measure employee experience health, or any employee experience, engagement, or culture design task, or design the end-to-end employee experience."
+description: "Help HR business partners, employee experience managers, and people leaders design and evaluate employee experience, journey mapping, engagement, culture, onboarding and belonging programs. Use when diagnosing experience risks, improving lifecycle moments, building recognition or inclusion practices, responding to engagement crises, or measuring employee experience health."
 metadata:
   author: Tuan Duc Tran
   version: "1.0.1"

--- a/skills/hr-employee-experience/examples/aihr-experience-value-driver-diagnostic.md
+++ b/skills/hr-employee-experience/examples/aihr-experience-value-driver-diagnostic.md
@@ -1,0 +1,27 @@
+# Example: Employee experience value-driver diagnostic
+
+Use this diagnostic before launching an employee experience program. It helps identify whether the problem is caused by strategy, structure, skills, systems of work, stakeholders, or leadership rather than assuming that a new survey or perk will solve it.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [The Future of Employee Experience](https://www.aihr.com/blog/future-of-employee-experience/), accessed from the public WordPress API on 2026-08-22. It is an editorial synthesis and does not reproduce the source.
+
+## Five-driver diagnostic
+
+| Driver | Diagnostic question | Evidence to review |
+| --- | --- | --- |
+| Strategy | Is the intended employee experience explicit and connected to business priorities? | Experience promise, priorities, measures, and investment choices |
+| Structure | Do ownership, decision rights, and operating routines support the intended experience? | Governance, handoffs, manager responsibilities, and escalation paths |
+| Skills | Do employees and managers have the capability to create the experience in daily work? | Role expectations, manager capability, training, and support demand |
+| Systems of work | Do tools, policies, processes, and work design make the desired experience possible? | Journey maps, friction points, access, workload, and process data |
+| Stakeholders | Are employees, managers, HR, IT, leaders, and other partners included in design and feedback? | Listening evidence, co-design participation, and segment coverage |
+
+## Applying the diagnostic
+
+Start with the employee journey and identify moments of truth rather than beginning with a program catalog. For each pain point, collect quantitative signals such as retention, absence, mobility, service demand, or survey trends alongside qualitative listening from interviews, focus groups, stay conversations, and team retrospectives.
+
+Rank interventions by employee impact, feasibility, risk, and ownership. Define the behavior or operational outcome expected from each intervention, then review whether the change is visible in day-to-day work. Keep a short review cadence after launch so that program activity is not mistaken for improved experience.
+
+## HR practitioner takeaway
+
+Employee experience is an operating design problem as well as a sentiment problem. The diagnostic is useful when it turns a broad concern into a small number of observable conditions, accountable owners, and measurable improvements.

--- a/skills/hr-onboarding/examples/aihr-onboarding-readiness-gates.md
+++ b/skills/hr-onboarding/examples/aihr-onboarding-readiness-gates.md
@@ -1,0 +1,33 @@
+# Example: Onboarding readiness gates
+
+Use these gates to design a consistent onboarding experience from offer acceptance through the first year. The goal is to connect administrative readiness with role clarity, relationships, belonging, and growing independence.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [Employee Onboarding: The Complete Process, Stages & Free Checklists](https://www.aihr.com/blog/employee-onboarding/) and [18 Must-Have Onboarding Documents](https://www.aihr.com/blog/onboarding-documents/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce either source.
+
+## Readiness gates
+
+| Stage | Readiness question | Minimum evidence |
+| --- | --- | --- |
+| Preboarding | Can the new hire arrive informed, welcomed, and able to start? | Welcome details, documents, equipment, system access, manager contact, and first goals |
+| First day | Can the new hire understand the organization, role, team, and support route? | Orientation agenda, working access, introductions, key policies, and buddy/contact |
+| First week | Can the new hire navigate tools, routines, relationships, and immediate priorities? | Stakeholder meetings, manager check-in, tool walkthrough, resource map, and questions log |
+| First 30 days | Is the employee learning the role and receiving useful feedback? | Role-specific learning, early deliverables, check-in, and support adjustments |
+| First 60 days | Is the employee taking on meaningful work with growing confidence? | Progress review, development needs, feedback, and revised priorities |
+| First 90 days | Is the employee moving from learning toward independent contribution? | Measurable outcomes, manager assessment, employee reflection, and remaining gaps |
+| First year | Can the organization close formal onboarding and connect it to development? | Role clarity, performance and growth discussion, onboarding feedback, and process improvements |
+
+## Document and ownership controls
+
+Assign an owner and due date to every artifact. Coordinate HR, the manager, IT, payroll, security, and the onboarding buddy so that access, policy acknowledgement, equipment, introductions, and role expectations do not depend on one person remembering each step. Protect personal data and provide only the access required for the role.
+
+Design for office, hybrid, and remote employees without treating remote workers as an exception. Include a 30-60-90 day plan, predictable manager check-ins, opportunities to build relationships, and clear escalation routes. Continue support after the formal first-week orientation; onboarding is an integration arc, not a single event.
+
+## Measurement loop
+
+Track completion and time-to-access, but also ask whether the employee understands success criteria, has the tools and knowledge to perform, feels welcomed and supported, and is progressing toward independent contribution. Review these signals at 30, 60, and 90 days and use employee and manager feedback to improve the next onboarding cycle.
+
+## HR practitioner takeaway
+
+A reliable onboarding program is a cross-functional service with explicit handoffs, staged outcomes, and continuous feedback. Administrative completion is necessary, but role clarity, connection, support, and time to contribution determine whether the experience is working.


### PR DESCRIPTION
## DEIB, employee experience, and onboarding enrichments

This PR adds three reviewed, source-attributed examples to existing skills:

- `hr-diversity-inclusion`: DEIB operating scorecard
- `hr-employee-experience`: employee experience value-driver diagnostic
- `hr-onboarding`: onboarding readiness gates

The files are original editorial syntheses based on public AIHR articles. They are not verbatim copies, and no new skill directory is created.

The PR includes the minimal existing CI corrections required for Skill Review and Knip to run deterministically on the current repository base.

Validation completed:

- `bun install --frozen-lockfile`
- `bun run check` with `KNIP_DISABLE_RAW_TRANSFER=1`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
