### PR TITLE
chore: add AIHR TA and rewards examples

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -12,6 +12,8 @@ jobs:
   knip:
     name: Knip
     runs-on: ubuntu-latest
+    env:
+      KNIP_DISABLE_RAW_TRANSFER: "1"
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: bun ci
 
+      - name: Build skill review dependencies
+        run: bunx turbo run build --filter=hr-skills...
+
       - name: Build hr-skills-ref
         run: bun run build --filter=hr-skills-ref
 
@@ -86,8 +89,8 @@ jobs:
       - name: Generate deterministic report
         if: steps.changed.outputs.count != '0'
         run: |
-          cd packages/hr-skills-build
           echo "${{ steps.changed.outputs.list }}" > /tmp/changed-skills.txt
+          cd packages/hr-skills
           bun run skill-review -- --list-file /tmp/changed-skills.txt > /tmp/skill-review-report.md
           cat /tmp/skill-review-report.md
 

--- a/skills/hr-compensation-benefits/examples/aihr-total-rewards-audit-loop.md
+++ b/skills/hr-compensation-benefits/examples/aihr-total-rewards-audit-loop.md
@@ -1,0 +1,32 @@
+# Example: Total rewards audit loop
+
+Use this loop to review compensation and benefits as one employee value proposition while preserving fairness, affordability, employee choice, and clear communication.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [Total Rewards Strategy](https://www.aihr.com/blog/total-rewards-strategy/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce the source.
+
+## Audit and design sequence
+
+| Step | Question | Output |
+| --- | --- | --- |
+| Assess | What compensation, benefits, wellbeing, recognition, and development already exist, and where are the gaps? | Rewards inventory and gap assessment |
+| Listen | What do employees value, misunderstand, or experience as unfair? | Survey, focus-group, stay-interview, and exit-interview themes |
+| Align | How does the rewards strategy support business goals, culture, talent segments, and budget? | Leadership-approved principles and priorities |
+| Balance | Is the package competitive, flexible where appropriate, inclusive, equitable, and financially sustainable? | Design trade-offs and risk register |
+| Communicate | Can employees understand the full value and the rules that govern decisions? | Plain-language total rewards statement, FAQ, and Q&A route |
+| Measure | What cost, people, and experience outcomes should be monitored? | Metric definitions, owners, baseline, and review cadence |
+
+## Five reward dimensions
+
+Review the full system rather than base pay alone: compensation, benefits, wellbeing, recognition, and development. Different employee segments may value different elements, so use employee evidence to inform flexibility while keeping minimum standards, eligibility rules, and decision criteria clear.
+
+Use market information and internal equity analysis together. Document how jobs are evaluated, how ranges and incentives are applied, how exceptions are approved, and how decisions are checked for fairness. Where legal or privacy requirements apply, involve the appropriate specialists and avoid exposing individual-level sensitive data.
+
+## Communication and impact
+
+Explain total rewards in accessible language and provide a durable place for questions and policy updates. Track cost and impact together, such as retention, engagement or eNPS, attraction outcomes, benefit utilization, pay-equity indicators, and development participation. Review outcomes by relevant employee segment and investigate material differences before changing the program.
+
+## HR practitioner takeaway
+
+A total rewards strategy is a managed portfolio, not a list of perks. It should be audited, informed by employees, aligned with leadership and culture, communicated transparently, reviewed for equity, and improved from cost and outcome evidence.

--- a/skills/hr-talent-acquisition/examples/aihr-ta-analytics-operating-loop.md
+++ b/skills/hr-talent-acquisition/examples/aihr-ta-analytics-operating-loop.md
@@ -1,0 +1,31 @@
+# Example: Talent acquisition analytics operating loop
+
+Use this operating loop to turn TA data into hiring decisions. It complements a TA strategy by defining how teams set objectives, collect reliable signals, prioritize improvements, build analytical capability, and monitor results.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [Talent Acquisition Analytics](https://www.aihr.com/blog/talent-acquisition-analytics/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce the source.
+
+## Five-step operating loop
+
+| Step | Question | Practical output |
+| --- | --- | --- |
+| Define | What hiring outcome needs to improve: speed, quality, fairness, cost, or experience? | SMART objective and metric definitions |
+| Collect | Which ATS, assessment, cost, candidate, and demographic signals are reliable and appropriate to use? | Data dictionary, owner, privacy controls, and baseline |
+| Diagnose | Where is the funnel losing candidates or creating delay, cost, bias, or weak downstream outcomes? | Prioritized bottleneck and hypothesis |
+| Improve capability | Can TA interpret the data and work with data, finance, HRIS, and legal partners responsibly? | Capability plan and decision protocol |
+| Monitor | Did the intervention change the intended outcome without damaging quality, fairness, or experience? | Dashboard, review cadence, and next action |
+
+## Metric design
+
+Define event boundaries before comparing roles or periods. Useful signals can include time to fill, time to hire, offer acceptance, stage-level yield, sourcing channel effectiveness, candidate drop-off, candidate feedback, quality of hire, new-hire turnover, cost, and demographic outcomes where lawful and sufficiently protected.
+
+Pair speed and volume measures with quality, candidate experience, early retention, and fairness signals. A shorter hiring cycle is not automatically better if the quality of hire or candidate experience deteriorates. Segment by role family, location, seniority, source, and stage only when the sample and privacy controls support responsible interpretation.
+
+## Improvement protocol
+
+When a metric moves, describe the likely cause before choosing an intervention. For example, a low offer acceptance rate may reflect pay positioning, slow approvals, unclear role expectations, or candidate experience. Test the smallest useful process change, assign an owner, record the baseline and review date, and compare results with the prior period rather than claiming causation from a single movement.
+
+## HR practitioner takeaway
+
+TA analytics is a management loop, not a report. Its value comes from explicit definitions, reliable data, cross-functional interpretation, targeted improvement, and continuous monitoring of both hiring outcomes and unintended effects.


### PR DESCRIPTION
## Talent Acquisition and Compensation & Benefits enrichments

This PR adds two reviewed, source-attributed examples to existing skills:

- `hr-talent-acquisition`: TA analytics operating loop
- `hr-compensation-benefits`: total rewards audit loop

The files are original editorial syntheses based on public AIHR articles. They are not verbatim copies, and no new skill directory is created.

The PR includes the minimal existing CI corrections required for Skill Review and Knip to run deterministically on the current repository base.

Validation completed:

- `bun install --frozen-lockfile`
- `bun run check` with `KNIP_DISABLE_RAW_TRANSFER=1`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
