### PR TITLE
chore: add AIHR L&D and performance examples

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -12,6 +12,8 @@ jobs:
   knip:
     name: Knip
     runs-on: ubuntu-latest
+    env:
+      KNIP_DISABLE_RAW_TRANSFER: "1"
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: bun ci
 
+      - name: Build skill review dependencies
+        run: bunx turbo run build --filter=hr-skills...
+
       - name: Build hr-skills-ref
         run: bun run build --filter=hr-skills-ref
 
@@ -86,8 +89,8 @@ jobs:
       - name: Generate deterministic report
         if: steps.changed.outputs.count != '0'
         run: |
-          cd packages/hr-skills-build
           echo "${{ steps.changed.outputs.list }}" > /tmp/changed-skills.txt
+          cd packages/hr-skills
           bun run skill-review -- --list-file /tmp/changed-skills.txt > /tmp/skill-review-report.md
           cat /tmp/skill-review-report.md
 

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-20",
+  "generatedAt": "2026-08-23",
   "skillCount": 146,
   "skills": [
     {
@@ -3315,7 +3315,7 @@
       "id": "hr-learning-development",
       "name": "hr-learning-development",
       "version": "1.0.1",
-      "description": "Help HR business partners, L&D managers, and people development leaders understand, design, and run learning and development programs, skills gap analyses, career development frameworks, leadership development tracks, onboarding programs, and learning culture initiatives. Use when asked to design a learning program, run a skills gap analysis for learning program design, build a career development framework, design a leadership development track, build an onboarding program, respond to a capability gap crisis, measure L&D effectiveness, design a learning culture strategy, or any employee learning, skills development, or talent capability task, or design an L&D strategy or program.",
+      "description": "Help HR business partners, L&D managers, and people development leaders design and evaluate learning programs, skills-gap analyses, career frameworks, leadership development and onboarding. Use when building an L&D strategy, diagnosing capability gaps, measuring learning impact, planning reskilling, or supporting employee development decisions.",
       "tier": "full",
       "domain": "learning-development",
       "tags": [],

--- a/skills/hr-learning-development/SKILL.md
+++ b/skills/hr-learning-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hr-learning-development
-description: "Help HR business partners, L&D managers, and people development leaders understand, design, and run learning and development programs, skills gap analyses, career development frameworks, leadership development tracks, onboarding programs, and learning culture initiatives. Use when asked to design a learning program, run a skills gap analysis for learning program design, build a career development framework, design a leadership development track, build an onboarding program, respond to a capability gap crisis, measure L&D effectiveness, design a learning culture strategy, or any employee learning, skills development, or talent capability task, or design an L&D strategy or program."
+description: "Help HR business partners, L&D managers, and people development leaders design and evaluate learning programs, skills-gap analyses, career frameworks, leadership development and onboarding. Use when building an L&D strategy, diagnosing capability gaps, measuring learning impact, planning reskilling, or supporting employee development decisions."
 metadata:
   author: Tuan Duc Tran
   version: "1.0.1"

--- a/skills/hr-learning-development/examples/aihr-ld-capability-review-loop.md
+++ b/skills/hr-learning-development/examples/aihr-ld-capability-review-loop.md
@@ -1,0 +1,29 @@
+# Example: L&D capability review loop
+
+Use this loop to design and evaluate learning work as a capability intervention rather than a catalog of courses. It connects business needs, skill gaps, learning transfer, manager reinforcement, and outcomes.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [Learning and Development](https://www.aihr.com/blog/learning-and-development/) and [Learning and Development Strategies](https://www.aihr.com/blog/learning-and-development-strategies/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce the sources.
+
+## Review loop
+
+| Stage | Question | Evidence or artifact |
+| --- | --- | --- |
+| Business need | Which business priority or operating risk requires new capability? | Priority statement, owner, and success outcome |
+| Capability diagnosis | Which roles, skills, behaviors, or knowledge gaps are material? | Role-based gap assessment and current-state evidence |
+| Design choice | Which mix of formal learning, coaching, practice, and job experience fits the gap? | Options comparison and learning journey |
+| Manager reinforcement | How will managers create opportunities to apply and reinforce learning? | Manager guide, practice plan, and check-in cadence |
+| Transfer | Can employees demonstrate the capability in real work? | Work samples, observation, project application, or assessment |
+| Business impact | Did the intervention improve the intended operational outcome? | Baseline, comparison, and outcome indicators |
+| Review | What should be scaled, adapted, or stopped? | Decision log and next-cycle experiment |
+
+## Measurement rules
+
+Treat completion and participation as delivery signals, not proof of capability. Pair them with behavior-change evidence such as manager observation, quality, speed, confidence in role, project application, internal mobility, or performance improvement. Select business metrics that have a plausible connection to the intervention and define the review period before launch.
+
+Segment by role, level, location, and employee group when privacy and sample-size safeguards support interpretation. If capability is not transferring, investigate workload, role clarity, manager support, tools, and process design before assuming that employees need more content.
+
+## HR practitioner takeaway
+
+Effective L&D is a closed loop between business need, capability diagnosis, applied development, manager reinforcement, and measured outcomes. A larger course catalog is not a substitute for a clearer capability decision.

--- a/skills/hr-performance-management/examples/aihr-continuous-performance-operating-loop.md
+++ b/skills/hr-performance-management/examples/aihr-continuous-performance-operating-loop.md
@@ -1,0 +1,31 @@
+# Example: Continuous performance operating loop
+
+Use this operating loop when moving from infrequent reviews toward regular, useful performance conversations. It keeps goals, feedback, development, manager capability, and organizational priorities connected.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [What Is Continuous Performance Management](https://www.aihr.com/blog/continuous-performance-management/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce the source.
+
+## Operating loop
+
+| Stage | Practice | Control question |
+| --- | --- | --- |
+| Align | Set clear goals connected to team and organizational priorities | Are goals specific, relevant, and still valid as priorities change? |
+| Check in | Hold short, predictable two-way conversations | Are roadblocks, support needs, and progress discussed early enough to act? |
+| Feedback | Give specific, timely feedback tied to observable behavior or outcomes | Can the employee understand what to continue, change, or practice? |
+| Develop | Connect identified skill gaps to development, coaching, and work opportunities | Does development support both employee growth and business capability? |
+| Calibrate | Use shared guidance and calibration to improve consistency and fairness | Are managers applying expectations and evidence comparably? |
+| Pilot | Test the process with a representative team before scaling | What works, what creates fatigue, and what support is missing? |
+| Improve | Gather participant feedback and review outcome signals | Which process, tool, cadence, or training change should happen next? |
+
+## Manager enablement
+
+Explain why regular conversations matter, provide practical guidance, and train managers in coaching, feedback, and goal-setting. Optimize for quality and relevance rather than maximizing the number of requests or meetings. Make expectations explicit and use objective evidence where available, while recognizing that performance conversations remain a human management responsibility.
+
+## Measurement and integration
+
+Track process signals such as check-in completion and goal updates, but pair them with employee usefulness, development progress, performance outcomes, retention, and pulse feedback. Integrate the process with talent management, learning and development, promotion, rewards, and succession planning without turning every conversation into a rating exercise.
+
+## HR practitioner takeaway
+
+Continuous performance management is a supported operating rhythm, not simply more reviews. Start with leadership sponsorship, pilot the process, train managers, use a simple system, and refine it from employee and manager evidence.


### PR DESCRIPTION
## Learning & Development and Performance Management enrichments

This PR adds two reviewed, source-attributed examples to existing skills:

- `hr-learning-development`: L&D capability review loop
- `hr-performance-management`: continuous performance operating loop

The files are original editorial syntheses based on public AIHR articles. They are not verbatim copies, and no new skill directory is created.

The PR includes the minimal existing CI corrections required for Skill Review and Knip to run deterministically on the current repository base.

Validation completed:

- `bun install --frozen-lockfile`
- `bun run check` with `KNIP_DISABLE_RAW_TRANSFER=1`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
