### PR TITLE
chore: add AIHR operations and analytics examples

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -12,6 +12,8 @@ jobs:
   knip:
     name: Knip
     runs-on: ubuntu-latest
+    env:
+      KNIP_DISABLE_RAW_TRANSFER: "1"
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: bun ci
 
+      - name: Build skill review dependencies
+        run: bunx turbo run build --filter=hr-skills...
+
       - name: Build hr-skills-ref
         run: bun run build --filter=hr-skills-ref
 
@@ -86,8 +89,8 @@ jobs:
       - name: Generate deterministic report
         if: steps.changed.outputs.count != '0'
         run: |
-          cd packages/hr-skills-build
           echo "${{ steps.changed.outputs.list }}" > /tmp/changed-skills.txt
+          cd packages/hr-skills
           bun run skill-review -- --list-file /tmp/changed-skills.txt > /tmp/skill-review-report.md
           cat /tmp/skill-review-report.md
 

--- a/skills/hr-analytics/examples/aihr-analytics-maturity-assessment.md
+++ b/skills/hr-analytics/examples/aihr-analytics-maturity-assessment.md
@@ -1,0 +1,37 @@
+# Example: HR analytics maturity assessment
+
+Use this assessment to determine the next realistic analytics capability step. It complements a people-analytics intervention workflow by focusing on maturity, foundations, and sequencing rather than jumping directly to predictive models.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [HR Analytics Maturity](https://www.aihr.com/blog/hr-analytics-maturity/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce the source.
+
+## Four maturity stages
+
+| Stage | Typical capability | Practical next step |
+| --- | --- | --- |
+| 1. Operational reporting | Reliable historical metrics such as headcount, turnover, labor cost, training cost, and absence | Standardize fields, owners, definitions, and recurring reports |
+| 2. Advanced reporting | Frequent dashboards and segmented views that help explain patterns and support decisions | Move from static reporting to business-question-led analysis |
+| 3. Advanced analytics | Statistical analysis combines HR data with operational or financial context to explain drivers and test hypotheses | Centralize governed data and translate findings into actions |
+| 4. Predictive analytics | Forecasts and models inform workforce planning, succession, retention, and risk decisions | Validate model use, assumptions, privacy controls, and decision impact |
+
+## Assessment protocol
+
+Score each statement from 0 to 3: strongly disagree, disagree, agree, or strongly agree. Assess whether the organization has reliable standardized data, recurring reporting ownership, dashboards used by decision-makers, integrated data sources, analytical capability, privacy and access controls, stakeholder demand, and evidence that insights lead to action. Sum the score and use it as an indicative maturity signal, not a substitute for stakeholder judgment.
+
+| Indicative score | Maturity signal |
+| ---: | --- |
+| 0–5 | Operational reporting foundation |
+| 6–11 | Advanced reporting |
+| 12–18 | Advanced analytics |
+| 19+ | Predictive analytics capability |
+
+## Sequencing rules
+
+Do not skip foundational work because predictive analytics sounds more advanced. First stabilize definitions, naming conventions, data quality, ownership, and a small set of useful reports. Then add segmentation and context, followed by integrated statistical analysis, and only then consider predictive use cases with clear decisions, validation, privacy safeguards, and accountable owners.
+
+Assess analytics maturity alongside HR process maturity. Strong tools cannot compensate for inconsistent HR processes, and mature HR processes do not automatically create analytical capability. The highest value comes when both foundations evolve together.
+
+## HR practitioner takeaway
+
+Maturity assessment is a prioritization tool. The correct next step is the one the organization can govern, explain, and use—not necessarily the most sophisticated model available.

--- a/skills/hr-service-delivery/examples/aihr-hr-operations-process-improvement.md
+++ b/skills/hr-service-delivery/examples/aihr-hr-operations-process-improvement.md
@@ -1,0 +1,28 @@
+# Example: HR Operations process-improvement loop
+
+Map HR Operations work to an existing HR service-delivery model rather than treating it as a new standalone skill. Use this loop to improve employee-facing processes while preserving ownership, compliance, service quality, and escalation paths.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [HR Operations](https://www.aihr.com/blog/hr-operations/) and [HR Process Improvement](https://www.aihr.com/blog/hr-process-improvement/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce the sources.
+
+## Operating loop
+
+| Stage | Question | Output |
+| --- | --- | --- |
+| Map | Which employee-lifecycle process is causing delay, error, inconsistent service, or avoidable work? | Current-state workflow, owners, handoffs, and case categories |
+| Standardize | Which policies, definitions, controls, and service levels must be consistent? | Documented procedure, service catalog entry, and SLA by case complexity |
+| Enable | Can self-service, HRIS workflow, or automation remove routine work without hiding exceptions? | Knowledge article, routing rule, automation decision, and fallback path |
+| Govern | Who owns the process, sensitive cases, data access, compliance review, and escalations? | RACI, access controls, audit trail, and escalation matrix |
+| Improve | What does case, employee, and operational data show about recurring issues? | Root-cause backlog and prioritized improvement experiment |
+| Review | Did the change improve quality and experience without increasing risk? | Before/after metrics, stakeholder feedback, and next-cycle decision |
+
+## Service-delivery boundary
+
+HR Operations can span administration, HRIS stewardship, onboarding and offboarding coordination, compliance support, process improvement, and operational analytics. In a service-delivery model, route sensitive legal, medical, or employee-relations cases directly to qualified specialists rather than forcing them through a general Tier 1 queue.
+
+Use different SLAs for different case types. Measure resolution time together with first-contact resolution, reopened cases, CSAT, escalation rate, policy accuracy, and recurring-case volume. A faster response is not a successful improvement if it increases rework or sends employees to the wrong owner.
+
+## HR practitioner takeaway
+
+HR Operations improvement is disciplined service design: document the lifecycle, standardize what should be consistent, automate only well-defined work, preserve specialist escalation, and use operational evidence to fix root causes.


### PR DESCRIPTION
## HR Operations and HR Analytics enrichments

This PR adds two reviewed, source-attributed examples to existing skills:

- `hr-service-delivery`: HR Operations process-improvement loop
- `hr-analytics`: HR analytics maturity assessment

HR Operations is intentionally mapped to the existing `hr-service-delivery` skill because the repository has no `hr-operations` skill and the AIHR source positions HR Operations within HR service delivery. No new skill directory is created.

The analytics example uses a maturity-assessment angle and is intentionally distinct from the people-analytics intervention workflow already proposed in PR #237.

The files are original editorial syntheses based on public AIHR articles. They are not verbatim copies.

Validation completed:

- `bun install --frozen-lockfile`
- `bun run check` with `KNIP_DISABLE_RAW_TRANSFER=1`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
