### PR TITLE
chore: add AIHR strategy and workforce examples

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -12,6 +12,8 @@ jobs:
   knip:
     name: Knip
     runs-on: ubuntu-latest
+    env:
+      KNIP_DISABLE_RAW_TRANSFER: "1"
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: bun ci
 
+      - name: Build skill review dependencies
+        run: bunx turbo run build --filter=hr-skills...
+
       - name: Build hr-skills-ref
         run: bun run build --filter=hr-skills-ref
 
@@ -86,8 +89,8 @@ jobs:
       - name: Generate deterministic report
         if: steps.changed.outputs.count != '0'
         run: |
-          cd packages/hr-skills-build
           echo "${{ steps.changed.outputs.list }}" > /tmp/changed-skills.txt
+          cd packages/hr-skills
           bun run skill-review -- --list-file /tmp/changed-skills.txt > /tmp/skill-review-report.md
           cat /tmp/skill-review-report.md
 

--- a/skills/hr-operating-model/examples/aihr-strategic-hr-alignment-loop.md
+++ b/skills/hr-operating-model/examples/aihr-strategic-hr-alignment-loop.md
@@ -1,0 +1,27 @@
+# Example: Strategic HR alignment loop
+
+Map broad Strategic HR work to the existing `hr-operating-model` skill when the practical question is how the HR function, governance, capabilities, and investments deliver business strategy. Do not create a separate Strategic HR skill for this use case.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [Aligning HR Strategy With Business Strategy](https://www.aihr.com/blog/aligning-hr-strategy-with-business-strategy/) and [HR Strategy Examples](https://www.aihr.com/blog/hr-strategy-examples/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce the sources.
+
+## Alignment loop
+
+| Stage | Question | Output |
+| --- | --- | --- |
+| Understand | What are the business value drivers, strategic priorities, market forces, and success criteria? | Strategy brief and external-context assumptions |
+| Translate | What workforce, capability, leadership, culture, and operating-model implications follow? | HR contribution hypotheses and capability implications |
+| Align | Which HR priorities and initiatives directly support the must-win business outcomes? | Prioritized HR strategy and explicit non-priorities |
+| Connect | Can the operating model, roles, governance, capabilities, and investment portfolio deliver the priorities? | RACI, capability plan, investment trade-offs, and delivery roadmap |
+| Reiterate | What evidence shows progress, and what has changed in the business or workforce context? | HR scorecard, review cadence, and strategy refresh decisions |
+
+## Delivery controls
+
+Write each priority as a contribution statement: the business outcome, the HR action, the owner, the milestone, and the evidence that would show progress. Use a balanced scorecard that includes value and cost measures rather than activity counts alone. Check whether the current HR operating model can execute the strategy; clarify boundaries across HRBPs, Centers of Excellence, and Shared Services before adding initiatives or headcount.
+
+Make trade-offs explicit. A credible HR strategy states what HR will focus on and what it will not do within the current capacity and budget. Revisit assumptions when business priorities change instead of continuing to execute an outdated plan.
+
+## HR practitioner takeaway
+
+Strategic HR is not a list of programs. It is a traceable chain from business direction to HR contribution, operating-model capability, investment choice, and measurable impact.

--- a/skills/hr-strategic-workforce-planning/examples/aihr-strategic-workforce-planning-review-cycle.md
+++ b/skills/hr-strategic-workforce-planning/examples/aihr-strategic-workforce-planning-review-cycle.md
@@ -1,0 +1,29 @@
+# Example: Strategic workforce planning review cycle
+
+Use this review cycle to connect a multi-year business direction to workforce size, shape, cost, capability, and agility. It complements a scenario loop by focusing on executive alignment, critical-role prioritization, and recurring review.
+
+## Source and editorial scope
+
+This is an original synthesis based on AIHR's [Strategic Workforce Planning](https://www.aihr.com/blog/strategic-workforce-planning/), accessed from the public WordPress API on 2026-08-22. It preserves attribution and does not reproduce the source.
+
+## Review cycle
+
+| Stage | Question | Output |
+| --- | --- | --- |
+| Set direction | What business strategy, market conditions, products, and competitive moves shape the next three to five years? | Business direction and planning assumptions |
+| Focus | Which roles and capabilities are critical to the strategy and deserve disproportionate attention? | Critical-role and capability segments |
+| Diagnose current state | What is the current workforce formation, capability, location, cost, risk, and mobility profile? | Current-state workforce baseline |
+| Define future state | What workforce size, shape, cost, location, and agility will the strategy require? | Future workforce requirements |
+| Close gaps | Should each material gap be addressed by build, buy, borrow, automate, redeploy, or redesign? | Prioritized action portfolio |
+| Fund and sequence | Which actions fit financial planning cycles and have the greatest strategic criticality and feasibility? | Phased workforce roadmap and owners |
+| Monitor | Which leading indicators show that assumptions or workforce risks are changing? | Dashboard, review cadence, and trigger thresholds |
+
+## Planning discipline
+
+Strategic workforce planning is led jointly by business and HR leaders. Start from business strategy rather than from an existing headcount request, and distinguish long-range capability decisions from operational staffing. Combine quantitative workforce data with manager and functional-leader input; numbers alone can miss emerging skills, work redesign, or feasibility constraints.
+
+Prioritize critical roles and capabilities rather than attempting to model every position with equal depth. Document assumptions, distinguish projections from commitments, and revisit the plan when business strategy or market conditions change. A workforce plan should inform talent acquisition, L&D, succession, and cost decisions without automatically turning every projection into an immediate hiring request.
+
+## HR practitioner takeaway
+
+A strategic workforce plan is a living decision system: it translates direction into future workforce requirements, chooses how to close the most important gaps, sequences investment, and monitors leading indicators before risks become urgent.


### PR DESCRIPTION
## Strategic HR and Workforce Planning enrichments

This PR adds two reviewed, source-attributed examples to existing skills:

- `hr-operating-model`: Strategic HR alignment loop
- `hr-strategic-workforce-planning`: strategic workforce planning review cycle

Strategic HR is intentionally mapped to the existing `hr-operating-model` skill because the repository has no standalone Strategic HR skill and the content focuses on HR operating-model delivery, governance, capabilities, and investment alignment.

The workforce planning example is intentionally distinct from the existing scenario-loop and market-expansion examples: it focuses on executive alignment, critical-role prioritization, workforce size/shape/cost/agility, and recurring review.

The files are original editorial syntheses based on public AIHR articles. They are not verbatim copies, and no new skill directory is created.

Validation completed:

- `bun install --frozen-lockfile`
- `bun run check` with `KNIP_DISABLE_RAW_TRANSFER=1`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
