### PR TITLE
feat(content): add inclusive recruiting guidance

### DIFF
--- a/skills/hr-executive-search/content/confidential-and-inclusive-executive-search.md
+++ b/skills/hr-executive-search/content/confidential-and-inclusive-executive-search.md
@@ -1,0 +1,33 @@
+# Confidential and inclusive executive search
+
+## Purpose
+
+Executive searches combine confidentiality with high-impact decisions about leadership, succession, and organizational direction. A disciplined process protects candidate trust without allowing a small, highly connected decision group to substitute familiarity for evidence.
+
+## Board and search-committee alignment
+
+Before outreach, record the mandate, outcomes, non-negotiable capabilities, learnable capabilities, stakeholder roles, confidentiality boundaries, and the evidence that will be used at each decision point. Separate criteria that are genuinely required for the role from signals that merely resemble the current leadership team's background. A search committee should name who owns the brief, who can change it, who assesses finalists, and who signs the final recommendation.
+
+## Inclusive assessment signals
+
+Use structured questions and comparable evidence across finalists. Review whether the target-company list, referral network, and outreach language reach the relevant talent market rather than relying only on familiar networks. Treat career paths, leadership styles, location history, and communication patterns as context to explore, not automatic proxies for capability. Record legitimate role requirements and the reason for each requirement so the committee can challenge inherited assumptions.
+
+## Confidentiality and candidate experience
+
+Tell candidates what can be shared, with whom, and at which stage. Limit sensitive information to people with a defined role, use a consistent communication cadence, and record opt-out or confidentiality requests. A candidate should not have to trade personal safety or current-employer confidentiality for basic information about the mandate, process, or decision timeline.
+
+## Decision evidence and escalation
+
+At finalist review, separate evidence about leadership outcomes, judgment, stakeholder relationships, and role-specific capability from impressions about style or similarity. Escalate a material disagreement to the agreed committee owner, document the evidence requested, and avoid changing the scorecard after seeing a preferred candidate unless the reason is recorded and applied consistently.
+
+## Practical checklist
+
+- Confirm the role mandate and decision rights before sourcing
+- Test whether the search strategy reaches a sufficiently broad and relevant market
+- Use comparable questions, references, and evidence across finalists
+- Protect confidentiality while communicating process expectations clearly
+- Record changes to criteria, evidence gaps, conflicts, and escalation decisions
+
+## Sources
+
+This guidance synthesizes durable principles from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is an HR-facing editorial synthesis, not legal advice or a substitute for local employment requirements.

--- a/skills/hr-offer-management/content/fair-and-transparent-offer-communication.md
+++ b/skills/hr-offer-management/content/fair-and-transparent-offer-communication.md
@@ -1,0 +1,25 @@
+# Fair and transparent offer communication
+
+## Purpose
+
+Offer fairness is not identical treatment in every circumstance. It is a defensible process in which comparable decisions follow stated principles, legitimate differences are explained, and candidates can understand the total proposition without being pressured to accept uncertainty.
+
+## Evidence before the offer
+
+Before extending an offer, confirm the role level, approved range, internal comparators, total-rewards components, decision owner, and any exception that needs specialist review. Keep the candidate-facing explanation separate from confidential employee data. Share principles and aggregate context without exposing another person's compensation or personal information.
+
+## Candidate-facing clarity
+
+Explain the components that materially affect the decision: base pay, variable pay, equity or long-term incentives where relevant, benefits, flexibility, start date, contingencies, and the point of contact for questions. Use accessible language and allow reasonable time for consideration. If a term is uncertain, identify the decision owner and the date when a reliable answer is expected instead of implying certainty.
+
+## Negotiation guardrails
+
+Prepare the recruiter and hiring manager with the same approval boundaries. A strong process records which terms are flexible, which require escalation, and which cannot be changed. When candidates raise a concern, ask what outcome matters to them and assess whether a non-cash option solves the need without creating an unjustified exception. Do not use urgency, scarcity, or a competing offer to pressure a candidate into a decision.
+
+## Review and learning
+
+Track offer outcomes by role, level, location, source, and relevant candidate-experience signal only where the data can be used responsibly. Review decline reasons, approval delays, exception patterns, and reneges as process evidence. If a pattern suggests unequal access to information, inconsistent flexibility, or a recurring expectation mismatch, the offer owner should open a documented review with compensation, recruiting, and the relevant employee-relations or legal partner.
+
+## Sources
+
+This guidance is an HR-facing synthesis of ethical practice, relationship management, communication, and critical evaluation principles in the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask) and evidence-based people practice described by the [CIPD Profession Map](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/). It does not provide jurisdiction-specific legal advice.

--- a/skills/hr-search-strategy/content/inclusive-search-brief-and-course-correction.md
+++ b/skills/hr-search-strategy/content/inclusive-search-brief-and-course-correction.md
@@ -1,0 +1,34 @@
+# Inclusive search briefs and course correction
+
+## Purpose
+
+A search strategy should make the target market, selection logic, stakeholder expectations, and review points visible before sourcing begins. Inclusion is stronger when it is built into the brief and measurement plan rather than added after a narrow pipeline appears.
+
+## Search-brief fields
+
+Add these fields to the existing brief when they are relevant:
+
+- The business outcome and role mandate
+- Essential capabilities with observable evidence
+- Criteria that are learnable or negotiable
+- Target talent segments and the reason each segment is relevant
+- Channel mix and the access risks each channel may create
+- Candidate-facing positioning that is truthful and accessible
+- Decision owners, approval points, and escalation routes
+- Pipeline-quality measures, review cadence, and a stop or redesign trigger
+
+## Market reach and evidence
+
+Review who is being reached, who is progressing, and where candidates withdraw. Interpret differences with role mix, geography, seniority, channel exposure, sample size, and candidate feedback in view. A small difference is not automatically proof of bias, and a balanced top-line ratio does not prove that the process is inclusive. Use the evidence to identify a question for review, not to assign blame without context.
+
+## Course correction
+
+At an agreed checkpoint, compare the original assumptions with the observed market. If the pipeline is too narrow, first test whether the brief, channel mix, positioning, or screening criteria are excluding relevant capability. Record any change to the profile, the decision owner who approved it, the expected effect, and the date for review. Do not quietly lower a legitimate requirement or add a new preference after seeing a favored candidate.
+
+## Candidate communication
+
+Keep candidates informed about material process changes, expected timing, and who can answer questions. When a search is paused, redirected, or closed, use a clear message that protects confidentiality and does not imply a promise that the organization cannot keep. Candidate feedback is useful evidence about clarity, accessibility, and trust in the process.
+
+## Sources
+
+This guidance synthesizes the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is durable HR practice guidance and does not make a universal legal claim about recruitment outcomes.


### PR DESCRIPTION
## Summary

Adds three single-purpose HR-facing content artifacts to existing skills:

- `hr-executive-search`: confidential and inclusive executive search
- `hr-offer-management`: fair and transparent offer communication
- `hr-search-strategy`: inclusive search briefs and course correction

The changes expand culture, inclusion, stakeholder alignment, candidate trust, decision ownership, and evidence signals without editing `SKILL.md`, creating a new skill, or adding implementation/tutorial material. Sources are cited as editorial synthesis.

## Validation

- `git diff --check`
- `bun run lint:md`
- `bun run validate` (146 skills, 0 errors; existing informational relevance warnings remain documented separately)
- `bun run check`
- `bun run typecheck`
- `bun run test` (442 passed, 0 failed)
- `bun run skill-review -- hr-executive-search hr-offer-management hr-search-strategy`
  - 95.5/100, 94.09/100, 94.66/100
  - security clean

Target branch: `dev`. Generated registry and matrix files were not edited manually.