### PR TITLE
feat(content): add fair workforce planning guidance

### DIFF
--- a/skills/hr-people-budgeting/content/people-budgeting-and-workforce-impact.md
+++ b/skills/hr-people-budgeting/content/people-budgeting-and-workforce-impact.md
@@ -1,0 +1,25 @@
+# People budgeting and workforce impact
+
+## Purpose
+
+A people budget is a resource-allocation decision, not only a cost forecast. It should make visible how headcount, compensation, benefits, capability investment, and operating constraints affect different groups of employees and the business outcomes they support.
+
+## Make trade-offs visible
+
+For each material change, record the intended outcome, affected roles or locations, time horizon, assumptions, decision owner, and the alternative that was not funded. Separate fixed commitments from discretionary choices. A hiring pause, benefit change, or learning reduction can shift workload, retention risk, access to development, or service quality even when the financial variance appears favorable.
+
+## Evidence and limitations
+
+Use budget-to-actual, vacancy and backfill timing, workload or service indicators, attrition patterns, capability risk, and employee-experience evidence where appropriate. Reconcile definitions with Finance and People Analytics before comparing groups. State when a sample is small, a cost is allocated rather than directly observed, or an outcome cannot be attributed to one budget decision.
+
+## Fair allocation questions
+
+Ask whether employees in comparable roles have comparable access to essential support, whether shared costs are allocated transparently, and whether a proposed saving transfers cost or workload to a less visible group. Treat demographic or sensitive workforce data as governed evidence, not a shortcut for deciding whose investment is expendable. Involve the relevant privacy, employee-relations, or legal partner when the analysis could affect individual rights or protected information.
+
+## Decision and review loop
+
+The accountable budget owner should document the decision, approval boundary, assumptions changed, affected groups, mitigation, and review date. Reopen the decision when a leading indicator moves materially, a key assumption becomes unreliable, or employee and service impact differs from the expected trade-off. A clear record lets HR and Finance challenge the model without turning the discussion into an argument about isolated percentages.
+
+## Sources
+
+This guidance synthesizes business alignment, evidence-based practice, ethics, and professional judgment themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not financial, legal, or tax advice.

--- a/skills/hr-time-attendance/content/fair-time-records-and-exception-governance.md
+++ b/skills/hr-time-attendance/content/fair-time-records-and-exception-governance.md
@@ -1,0 +1,25 @@
+# Fair time records and exception governance
+
+## Purpose
+
+Time and attendance controls should produce reliable records while preserving a fair way to explain exceptions. A policy that treats every absence, edit, or late arrival as the same can hide transport disruption, disability-related needs, caregiving responsibilities, scheduling errors, or manager inconsistency.
+
+## Design the control around the work
+
+Document which time must be recorded, who reviews it, what evidence is acceptable, and how employees can correct an error. Keep the rule understandable for the workers who use it. If a system applies rounding, geofencing, automated points, or manager approval, record the business purpose, the affected worker groups, the exception path, and the person accountable for reviewing adverse patterns.
+
+## Exception and edit governance
+
+A legitimate exception should have a reason category, reviewer, date, affected record, and outcome. The reviewer should distinguish a data correction from a policy exception and avoid requiring unnecessary personal detail. Repeated exceptions may indicate a scheduling, accessibility, training, or system-design problem; they should not automatically become a discipline pattern without context and a consistent review process.
+
+## Worker communication and voice
+
+Before a material change, explain what is changing, why the organization needs the record, how the data will be used, who can access it, and how to ask questions or challenge an error. Provide a route for confidential concerns and make the process accessible across shifts, locations, languages, and work arrangements. Do not promise a universal outcome where local rules, collective agreements, or individual circumstances may change the correct handling.
+
+## Monitoring and escalation
+
+Review approval delays, manual edits, exception rates, missed breaks or rest concerns, disputed records, and differences by location or shift. Treat a pattern as a question for investigation rather than proof of misconduct or bias. Escalate when records may affect pay, safety, employee relations, accessibility, privacy, or a collective agreement. The accountable HR or payroll owner should record the evidence reviewed, the decision, the escalation route, and the next review date.
+
+## Sources
+
+This guidance synthesizes ethical practice, communication, evidence, and professional judgment themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). Local wage-and-hour, privacy, accessibility, and collective-agreement requirements must be checked separately.

--- a/skills/hr-workforce-scheduling/content/fair-and-predictable-scheduling.md
+++ b/skills/hr-workforce-scheduling/content/fair-and-predictable-scheduling.md
@@ -1,0 +1,25 @@
+# Fair and predictable scheduling
+
+## Purpose
+
+A schedule is both an operating plan and an employee-experience decision. Good scheduling balances coverage, cost, continuity, rest, predictability, accessibility, and the ability of workers to influence changes that affect their lives.
+
+## Make the trade-off explicit
+
+Before publishing a schedule, record the coverage need, planning horizon, assumptions, constraints, and decision owner. Identify which shifts are hard to fill, how undesirable work will be distributed, and what minimum flexibility or rest protection the organization intends to preserve. Do not hide a coverage shortfall by relying on repeated short-notice changes or unpaid availability.
+
+## Worker input and accessibility
+
+Offer a consistent way for workers to state availability, constraints, swap requests, and accessibility needs without forcing unnecessary medical disclosure. Consider whether the schedule reaches workers across locations, shifts, languages, and employment arrangements. Managers should explain how requests are weighed when coverage, fairness, and individual needs conflict, and record the reason for a material exception.
+
+## Evidence for review
+
+Monitor schedule publication timing, last-minute changes, open shifts, swaps, overtime, absence, rest-period concerns, employee feedback, and continuity or service outcomes. Compare patterns by site, shift, role, and contract type only where the data is appropriate and responsibly governed. A high fill rate is not sufficient evidence of a good schedule if fatigue, inequitable undesirable-shift allocation, or avoidable turnover is increasing.
+
+## Escalation and course correction
+
+Name who can approve an exception, who handles an unfilled shift, and who reviews safety, accessibility, employee-relations, or local rule concerns. Reopen the scheduling model when demand assumptions change, a rest or safety concern appears, short-notice changes become recurrent, or a group carries a disproportionate share of undesirable work. Record the decision, mitigation, affected workers, and review date.
+
+## Sources
+
+This guidance synthesizes professional judgment, employee voice, evidence-based practice, and ethical decision-making themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). Scheduling law, rest requirements, accessibility duties, and collective agreements vary by jurisdiction and must be checked locally.


### PR DESCRIPTION
## Summary

Adds three single-purpose HR-facing content artifacts to existing skills:

- `hr-people-budgeting`: people budgeting and workforce impact
- `hr-time-attendance`: fair time records and exception governance
- `hr-workforce-scheduling`: fair and predictable scheduling

The additions address the repository-native culture/behaviour and technology/people review queues through worker impact, fairness, accessibility, evidence limits, exception governance, and escalation ownership. `hr-offboarding` was reviewed and left unchanged because its current content and scenario already cover respectful departures, employee voice, knowledge transfer, and team communication. No `SKILL.md` or generated artifact was edited.

## Validation

- `git diff --check`
- `bun run lint:md`
- `bun run validate` (146 skills, 0 errors; existing informational relevance warnings remain documented separately)
- `bun run typecheck`
- `bun run test` (442 passed, 0 failed)
- `bun run skill-review -- hr-people-budgeting hr-time-attendance hr-workforce-scheduling`
  - 93.68/100, 95.5/100, 95.5/100
  - security clean

Target branch: `dev`. Generated registry and matrix files were not edited manually.