### PR TITLE
feat(content): add technology workplace signals

### DIFF
--- a/skills/hr-embedded/content/embedded-workplace-signals-and-safety.md
+++ b/skills/hr-embedded/content/embedded-workplace-signals-and-safety.md
@@ -1,0 +1,25 @@
+# Embedded workplace signals and safety
+
+## Purpose
+
+Embedded engineering connects software decisions to hardware behaviour, product reliability, and sometimes safety-critical outcomes. HR and recruiting teams should evaluate how candidates work within those constraints without reducing the assessment to a list of languages, processors, or tools.
+
+## Evidence to look for
+
+Strong evidence includes ownership of a shipped product, reasoning about resource and timing constraints, disciplined verification, documentation that another team could use, and learning from hardware or field failures. Ask what the candidate personally decided, what they inherited, which trade-offs they accepted, and how they communicated uncertainty to hardware, systems, quality, manufacturing, product, and support partners.
+
+## Safety and regulated context
+
+For regulated or safety-relevant products, clarify the role's actual accountability for requirements, traceability, verification, release evidence, incident response, and change control. Do not infer regulated-product competence from an industry label alone. Confirm the candidate's contribution and the level of review they operated under. Where the role is not safety-critical, avoid importing requirements that narrow the market without improving the outcome.
+
+## Reliability and maintainability
+
+A production-ready candidate can discuss how reliability is monitored after release, how defects are triaged, how field feedback reaches engineering, and who owns the decision to pause, patch, replace, or retire a product. Look for an appreciation that maintainability, documentation, test evidence, and supportability are workplace responsibilities shared across functions.
+
+## Fair assessment design
+
+Use comparable scenario prompts and allow candidates to explain unfamiliar hardware context. Score systems reasoning, risk judgment, communication, and learning agility separately from exact platform experience unless the platform is a genuine role requirement. Provide a clear boundary between an interview exercise and unpaid production work.
+
+## Sources
+
+This guidance synthesizes the technology-and-people perspective in the [CIPD Technology and People knowledge area](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and ethical, professional, and evidence-based practice themes in the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It does not replace sector-specific quality, safety, or regulatory review.

--- a/skills/hr-iot/content/iot-workplace-capability-and-risk.md
+++ b/skills/hr-iot/content/iot-workplace-capability-and-risk.md
@@ -1,0 +1,25 @@
+# IoT workplace capability and risk
+
+## Purpose
+
+IoT work joins physical devices, connectivity, data, and operational services. Hiring should therefore assess how a person makes trade-offs across the system and with the people who use, support, maintain, and are affected by connected products.
+
+## Capability signals beyond the stack
+
+Look for clear ownership of a product outcome, not only familiarity with a device or protocol. Strong candidates can explain how they worked with hardware, firmware, cloud, security, operations, product, support, and field teams; how they handled incomplete information; and how they learned from incidents or device behaviour after release.
+
+## Data, privacy, and safety boundaries
+
+Ask how the candidate identifies what data a device collects, who needs it, how long it should be retained, and what happens when a device is shared, lost, replaced, or retired. The role may involve sensitive locations, usage patterns, or safety-relevant decisions. Assessment should look for proportionate access, clear accountability, user communication, and escalation when a product decision could create harm or loss of trust.
+
+## Fleet and lifecycle evidence
+
+Distinguish a prototype contribution from responsibility for a live fleet. Useful evidence includes staged rollout decisions, monitoring ownership, rollback or recovery planning, support handoffs, incident learning, device retirement, and communication with affected users. Ask what changed after field evidence contradicted the original assumption.
+
+## Fair and realistic role design
+
+Do not require deep mastery of every layer when the role has a clear primary boundary. State the expected device, connectivity, cloud, edge, or operational responsibility, then name the collaboration required across the boundary. A realistic brief helps adjacent specialists contribute without treating breadth as a proxy for seniority.
+
+## Sources
+
+This guidance synthesizes the technology-and-people perspective in the [CIPD Technology and People knowledge area](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/technology-people/) and professional judgment and ethical practice themes in the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is HR-facing hiring guidance, not a device-security or privacy certification.

--- a/skills/hr-system-design/content/system-design-workplace-capability.md
+++ b/skills/hr-system-design/content/system-design-workplace-capability.md
@@ -1,0 +1,29 @@
+# System design as workplace capability
+
+## Purpose
+
+A system design interview should reveal how a candidate frames a problem, makes trade-offs, communicates uncertainty, and takes responsibility for a service over time. The final diagram is only one piece of evidence.
+
+## Capability dimensions
+
+Evaluate the candidate's ability to clarify users and outcomes, identify constraints, choose an appropriate level of complexity, reason about failure and recovery, and explain which decisions are reversible. Also assess how they collaborate with product, design, security, data, support, and operations partners. A senior signal is not simply naming more components; it is making a coherent decision that other people can operate and challenge.
+
+## Reliability and operational ownership
+
+Ask who would monitor the service, respond when assumptions fail, communicate with affected users, and decide whether to degrade, pause, or restore an experience. Look for evidence of capacity thinking, observability, privacy and security boundaries, dependency management, and an explicit plan for learning after launch. The candidate should be able to state what the design does not guarantee.
+
+## Fair and calibrated assessment
+
+Use the same starting context, time boundary, and core rubric for comparable candidates. Separate design reasoning, reliability judgment, communication, collaboration, and domain-specific knowledge so one confident presentation style does not dominate the decision. Calibrate interviewers with examples of strong, adequate, and weak evidence before the loop and record disagreements instead of silently averaging them away.
+
+## Seniority and role fit
+
+Scale ambiguity and decision scope to the role. A staff-level assessment may examine cross-team consequences, migration or platform strategy, and long-term ownership; a less senior assessment can focus on clear problem framing, sensible trade-offs, and willingness to seek guidance. Do not turn optional familiarity with a named architecture into a universal hiring requirement.
+
+## Technical reference points for non-technical reviewers
+
+The [Node.js project overview](https://nodejs.org/en/about) and [Kubernetes concepts overview](https://kubernetes.io/docs/concepts/overview/) illustrate why runtime, platform, deployment, reliability, and operational responsibility are distinct concerns. Use such references to clarify interview vocabulary, not to test syntax or require a tutorial response from HR participants.
+
+## Sources
+
+This guidance is an HR-facing synthesis of the [CIPD Technology and People knowledge area](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/), the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask), and the cited official technical overviews. It is not a programming lesson.


### PR DESCRIPTION
## Summary

Adds three single-purpose HR-facing content artifacts to existing skills:

- `hr-iot`: IoT workplace capability and risk
- `hr-embedded`: embedded workplace signals and safety
- `hr-system-design`: system design as workplace capability

The additions translate technical scope into observable workplace signals: cross-functional ownership, lifecycle evidence, privacy and safety boundaries, reliability, communication, calibration, and fair assessment. `hr-ar-vr` and `hr-blockchain` were reviewed and left unchanged because their existing content already covers the distinctive human-impact and risk signals for their scopes. No `SKILL.md`, generated registry, or matrix file was edited.

## Validation

- `git diff --check`
- `bun run lint:md`
- `bun run validate` (146 skills, 0 errors; existing informational relevance warnings remain documented separately)
- `bun run typecheck`
- `bun run test` (442 passed, 0 failed)
- `bun run skill-review -- hr-iot hr-embedded hr-system-design`
  - 95.5/100 for each skill
  - security clean

Target branch: `dev`. Generated registry and matrix files were not edited manually.