### PR TITLE
feat(content): add global HR governance guidance

### DIFF
--- a/skills/hr-audit/content/evidence-based-and-rights-aware-hr-audits.md
+++ b/skills/hr-audit/content/evidence-based-and-rights-aware-hr-audits.md
@@ -1,0 +1,25 @@
+# Evidence-based and rights-aware HR audits
+
+## Purpose
+
+An HR audit should improve the reliability and fairness of a process, not turn personal records into an unrestricted investigation. Scope, evidence, confidentiality, and remediation ownership should be explicit before sampling begins.
+
+## Scope and evidence plan
+
+Record the audit objective, population, process owner, relevant period, sample logic, evidence sources, limitations, and decision thresholds. Prefer a defensible sample over an unnecessarily broad collection of personal information. Separate a control failure, an isolated record error, and a question that needs further evidence.
+
+## Worker and stakeholder voice
+
+Where interviews or employee feedback are part of the audit, explain the purpose, participation expectations, confidentiality limits, and route for raising a concern. Include process owners, managers, affected employees, and specialist partners where their experience can explain how a control works in practice. Do not promise absolute confidentiality if the organization cannot provide it.
+
+## Fair interpretation
+
+Review whether a process affects groups differently, but avoid treating a difference as proof of misconduct or discrimination without context. Examine role mix, geography, tenure, work arrangement, access to information, sample size, and alternative explanations. Keep sensitive attributes limited to an approved purpose and protect them from unnecessary circulation.
+
+## Findings and remediation
+
+Each finding should state the evidence, control or experience affected, risk rationale, confidence and limitation, accountable owner, agreed action, escalation route, target review date, and closure evidence. Route potential legal, privacy, safety, accessibility, or employee-relations concerns to the qualified partner defined by the organization. Re-test the control after remediation instead of closing a finding when an action is merely announced.
+
+## Sources
+
+This guidance synthesizes evidence-based practice, ethical decision-making, professional judgment, and business alignment themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not legal, audit, or privacy advice for a specific jurisdiction.

--- a/skills/hr-immigration/content/fair-and-human-centred-global-mobility-governance.md
+++ b/skills/hr-immigration/content/fair-and-human-centred-global-mobility-governance.md
@@ -1,0 +1,25 @@
+# Fair and human-centred global mobility governance
+
+## Purpose
+
+Immigration and mobility work combines time-sensitive case management with decisions that affect an employee's work, family, location, finances, and sense of security. A strong process makes ownership and escalation clear while treating each person as more than a deadline in a tracker.
+
+## Case ownership and decision rights
+
+For each case, record the employee's goal, destination, work arrangement, current status, required decision, accountable HR or mobility owner, external counsel or specialist partner, dependencies, and next reliable update. Separate administrative tracking from legal advice. The case owner should be able to explain who can approve sponsorship, relocation support, exceptions, and urgent escalation.
+
+## Consistent and equitable support
+
+Use stated criteria for sponsorship, relocation support, timing, and exception review. Apply them consistently across comparable cases while allowing documented differences in destination, role, family circumstances, accessibility, or business need. Do not expose another employee's personal or immigration information as a comparison point. If a criterion is unclear or produces a recurring disparity, pause for policy-owner review rather than improvising case by case.
+
+## Communication and worker experience
+
+Communicate what is known, what is pending, who owns the next step, when the next update is expected, and what the employee should do if circumstances change. Avoid promising approval dates that depend on an external authority. Make communications accessible and consider language, time zone, family, disability, financial, and relocation concerns without requesting more personal detail than the process requires.
+
+## Privacy, continuity, and escalation
+
+Limit access to immigration and identity documents to people with a defined role, use an approved retention and transfer process, and record when a document or deadline is missing. Escalate potential status, work-authorisation, tax, payroll, safety, discrimination, privacy, or employee-relations issues to the qualified local specialist. Record the advice received, the decision owner, the employee communication, the contingency plan, and the next review date.
+
+## Sources
+
+This guidance synthesizes technology-and-people, ethical practice, communication, and professional judgment themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not immigration, tax, employment, or legal advice; case-specific requirements must be checked with qualified local specialists.


### PR DESCRIPTION
## Summary

Adds two single-purpose HR-facing content artifacts to existing skills:

- `hr-audit`: evidence-based and rights-aware HR audits
- `hr-immigration`: fair and human-centred global mobility governance

The additions address evidence quality, worker voice, confidentiality, fair interpretation, case ownership, local-specialist escalation, accessible communication, and jurisdiction-safe boundaries. `hr-offboarding` was reviewed earlier and remains unchanged because its existing content and scenario already cover respectful departures, knowledge transfer, exit insight, and team communication. No `SKILL.md`, generated registry, or matrix file was edited.

## Validation

- `git diff --check`
- `bun run lint:md`
- `bun run validate` (146 skills, 0 errors; existing informational relevance warnings remain documented separately)
- `bun run typecheck`
- `bun run test` (442 package tests and 22 web tests passed, 0 failed)
- `bun run skill-review -- hr-audit hr-immigration`
  - 95.5/100 for each skill
  - security clean

Target branch: `dev`. Generated registry and matrix files were not edited manually.