### PR TITLE
feat(content): add accountable HR technology guidance

### DIFF
--- a/skills/hr-ai-governance/content/accountable-ai-controls-for-hr.md
+++ b/skills/hr-ai-governance/content/accountable-ai-controls-for-hr.md
@@ -1,0 +1,21 @@
+# Accountable AI controls for HR
+
+## Purpose
+
+An HR AI governance process should connect a use case to an accountable owner, the people affected, the evidence required, and a safe route to pause or retire the system. A policy that only names fairness as a value does not tell HR what to do when evidence is incomplete or the tool behaves unexpectedly.
+
+## Pre-adoption record
+
+Before approval, record the intended decision or workflow, purpose, affected candidates or workers, data categories, source systems, vendor role, human decision-maker, alternatives considered, accessibility needs, and local specialist reviews required. Distinguish assistance from delegation: the person who makes the employment decision remains accountable for explaining the decision and handling a challenge.
+
+## Evaluation and monitoring
+
+Define success measures, known limitations, subgroup or scenario checks, human-review quality, complaint signals, and the evidence owner before the pilot starts. Use a baseline where possible and state when sample size, data quality, or missing context limits the conclusion. Re-test after material model, data, workflow, vendor, or workforce changes rather than treating approval as permanent.
+
+## Escalation and sunset
+
+Set pause triggers for unexplained performance changes, accessibility barriers, privacy concerns, unreliable outputs, material complaints, or a mismatch between the approved and actual use. Name who can pause the workflow, who informs affected people, who preserves evidence, and who decides whether remediation is sufficient. A retirement plan should cover access removal, retention or deletion decisions, human replacement steps, vendor notification, and lessons learned.
+
+## Source boundaries
+
+The [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework) provides a voluntary risk-management reference for trustworthy AI. The [ICO guidance on monitoring workers](https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/employment/monitoring-workers/) is UK-specific and illustrates the need to define purpose, necessity, proportionality, transparency, and safeguards when monitoring people. This content is HR governance guidance, not legal advice.

--- a/skills/hr-digital-hr/content/digital-hr-operating-model-and-adoption-evidence.md
+++ b/skills/hr-digital-hr/content/digital-hr-operating-model-and-adoption-evidence.md
@@ -1,0 +1,25 @@
+# Digital HR operating model and adoption evidence
+
+## Purpose
+
+Digital HR transformation changes work for HR teams, managers, employees, candidates, and service partners. A roadmap should explain who owns the new process, what capability is changing, how people will be supported, and what evidence will decide whether the transformation continues.
+
+## From maturity to operating model
+
+For each priority journey, define the desired user outcome, process owner, service boundary, decision rights, data steward, support route, capability-building need, and dependencies. Maturity language is useful only when it changes a decision about sequencing, controls, investment, or readiness. Avoid treating a more automated state as automatically better.
+
+## Inclusive change and access
+
+Map who may lose access, context, or confidence when a process becomes digital. Test alternatives for workers with different schedules, locations, languages, connectivity, digital confidence, or accessibility needs. Explain what the system does, what it does not do, and how a person can reach human support or challenge an error.
+
+## Evidence and course correction
+
+Track adoption, completion, abandonment, repeat contacts, support demand, data-quality issues, time saved or shifted, user comprehension, and the intended employee or business outcome. Separate implementation activity from outcome evidence. A successful launch is not proof of value, and high usage is not proof that a process is fair or usable. Set review thresholds, an accountable owner, and a date for deciding whether to redesign, extend support, or stop.
+
+## Capability and sustainability
+
+Assign ownership for process standards, data quality, vendor relationships, access, incident response, training, and retirement. Review the operating model after a reorganisation, vendor change, material workflow change, or repeated user harm. Preserve a human fallback and a transition plan so the organization does not become dependent on a system that no longer meets its purpose.
+
+## Sources
+
+This guidance synthesizes the [CIPD Technology and People knowledge area](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/), the [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework) where AI is part of the transformation, and professional practice in the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not legal, accessibility, privacy, or technology implementation advice.

--- a/skills/hr-technology/content/employee-centred-hr-technology-governance.md
+++ b/skills/hr-technology/content/employee-centred-hr-technology-governance.md
@@ -1,0 +1,25 @@
+# Employee-centred HR technology governance
+
+## Purpose
+
+HR technology succeeds when it improves a real people or business outcome and can be operated responsibly after implementation. Selection and delivery should therefore test process quality, user experience, data stewardship, accountability, and adoption evidence alongside functional fit.
+
+## Decision record
+
+For each material technology decision, record the problem to solve, affected user groups, process owner, required capability, data categories, access boundaries, integration dependencies, service owner, change impact, total cost assumptions, and review date. Keep vendor promises separate from evidence observed in a pilot, reference call, or production measure.
+
+## Design with affected users
+
+Involve HR practitioners, managers, employees, candidates, accessibility specialists, privacy or security partners, and service or support teams in proportion to the risk. Test the experience across roles, locations, work arrangements, language needs, and assistive technology where relevant. A self-service workflow that reduces HR tickets but increases confusion or exclusion is not a successful outcome.
+
+## Adoption and service evidence
+
+Track adoption by intended user group, completion and abandonment, support demand, data-quality defects, processing time, user feedback, and the business or employee outcome the system was meant to improve. Interpret differences with role mix, access, sample size, and process changes in view. Assign an owner to each measure and state what evidence would trigger redesign, additional support, or a pause.
+
+## Governance over time
+
+Set clear incident, privacy, security, accessibility, vendor, and service-level escalation routes. Revisit the decision when the process, vendor, data flow, user population, or risk changes. A roadmap should include decommissioning, data retention, migration, continuity, and capability transfer rather than assuming every system remains suitable indefinitely.
+
+## Sources
+
+This guidance synthesizes the technology-and-people perspective in the [CIPD Technology and People knowledge area](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/technology-people/) and professional judgment and ethical practice themes in the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not procurement, security, privacy, or legal advice.


### PR DESCRIPTION
## Summary

Adds three single-purpose HR-facing content artifacts to existing skills:

- `hr-ai-governance`: accountable AI controls for HR
- `hr-technology`: employee-centred HR technology governance
- `hr-digital-hr`: digital HR operating model and adoption evidence

The additions address purpose and affected people, data categories, human accountability, evidence limits, accessibility, adoption measures, escalation, re-testing, pause triggers, and system retirement. `hr-ai-evaluation`, `hr-ai-privacy`, and `hr-data` were reviewed and left unchanged because their existing content already covers the primary evaluation, privacy, and technical-hiring scopes. No `SKILL.md`, generated registry, or matrix file was edited.

Sources include CIPD Technology and People, NIST AI RMF, ICO worker-monitoring guidance with its UK-specific boundary, and SHRM BASK.

## Validation

- `git diff --check`
- `bun run lint:md`
- `bun run validate` (146 skills, 0 errors; existing informational relevance warnings remain documented separately)
- `bun run typecheck`
- `bun run test` (442 package tests, 38 reference tests, and 7 web tests passed, 0 failed)
- `bun run skill-review -- hr-ai-governance hr-technology hr-digital-hr`
  - 95.5/100, 100/100, 93.52/100
  - security clean

Target branch: `dev`. Generated registry and matrix files were not edited manually.