### PR TITLE
feat(content): add trustworthy HR operations guidance

### DIFF
--- a/skills/hr-recruitment-operations/content/candidate-trust-and-fair-recruiting-operations.md
+++ b/skills/hr-recruitment-operations/content/candidate-trust-and-fair-recruiting-operations.md
@@ -1,0 +1,25 @@
+# Candidate trust and fair recruiting operations
+
+## Purpose
+
+Recruitment operations can make a hiring process feel predictable and respectful or opaque and arbitrary. Workflow efficiency should be balanced with candidate communication, consistent treatment, privacy, accessibility, and evidence that the process is selecting for the approved role requirements.
+
+## Operational decision record
+
+For each material workflow, record the purpose, candidate and stakeholder groups affected, process owner, data fields, automation boundary, service expectation, exception path, and escalation owner. Distinguish a workflow rule from a hiring judgment. A system should route and remind people without silently making a consequential decision that nobody can explain.
+
+## Candidate-facing safeguards
+
+Define when candidates receive status updates, scheduling alternatives, accessibility support, consent or privacy information, and a reliable contact route. Use disposition reasons that describe the process outcome without unnecessary sensitive detail. When an exception is approved, record the operational reason and apply the same principle to comparable cases.
+
+## Evidence and interpretation
+
+Review stage conversion, time in stage, candidate withdrawals, rescheduling, response delay, offer delay, complaints, accessibility requests, data-quality defects, and recruiter workload together. Interpret differences by role, seniority, location, channel, and sample size. A faster funnel or higher conversion rate is not automatically better if qualified candidates are being screened out, communication quality is falling, or a group has less access to the process.
+
+## Course correction
+
+At a fixed review cadence, compare actual workflow behaviour with the approved process and candidate feedback. Assign an owner and date to each change. Pause an automation or routing rule when its outcome is unexplained, data quality is unreliable, a privacy or accessibility concern appears, or the workflow no longer matches the role decision. Document the evidence and the human fallback.
+
+## Sources
+
+This guidance synthesizes evidence-based practice, communication, ethics, and technology-and-people themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not legal or privacy advice for a specific recruitment process.

--- a/skills/hr-service-delivery/content/trustworthy-and-accessible-hr-service-delivery.md
+++ b/skills/hr-service-delivery/content/trustworthy-and-accessible-hr-service-delivery.md
@@ -1,0 +1,25 @@
+# Trustworthy and accessible HR service delivery
+
+## Purpose
+
+HR service delivery is a people-facing control system. It should resolve routine requests efficiently while protecting sensitive cases, providing a usable route to human help, and learning from the reasons employees need support.
+
+## Design for access and trust
+
+For each service, record the intended user groups, service owner, channel, language and accessibility needs, data collected, expected response, and escalation route. Offer a human path when self-service cannot safely handle the question. Tell employees what information is needed, who can see it, how it will be used, and what to do if the answer does not fit their circumstances.
+
+## Route by risk and complexity
+
+Do not send medical, harassment, safeguarding, legal, immigration, or other sensitive cases through a general queue without a defined specialist route. Document the reason for escalation, the minimum information required, the receiving owner, and the service expectation. A fast handoff that loses context or exposes personal information is not a successful service outcome.
+
+## Evidence beyond speed
+
+Review resolution quality, reopened cases, repeat contact, escalation, accessibility barriers, employee comprehension, unanswered questions, and policy accuracy alongside volume, response time, and satisfaction. Interpret differences by case mix, channel, language, location, and user group. A high self-service rate can conceal exclusion or unresolved complexity if employees stop asking for help.
+
+## Review and accountability
+
+Assign owners for knowledge content, policy changes, case-data quality, specialist escalation, and service recovery. Revisit the model when recurring cases reveal a broken upstream process, when a policy changes, or when a user group experiences avoidable friction. Record the evidence, decision, mitigation, and next review date.
+
+## Sources
+
+This guidance synthesizes technology-and-people, communication, ethics, and evidence-based practice themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not legal, privacy, accessibility, or employee-relations advice for a specific case.

--- a/skills/hr-vendor-management/content/vendor-service-and-worker-impact-governance.md
+++ b/skills/hr-vendor-management/content/vendor-service-and-worker-impact-governance.md
@@ -1,0 +1,25 @@
+# Vendor service and worker-impact governance
+
+## Purpose
+
+An HR vendor can shape how employees, candidates, managers, and HR teams experience a critical process. Vendor governance should therefore assess service outcomes and people impact, not only price, features, and contract completion.
+
+## Define the service and affected people
+
+Before selection or renewal, record the user groups, process outcome, service owner, critical moments, data categories, access boundaries, dependencies, support model, and failure consequences. Define what the vendor must make visible to HR and affected users, including service interruptions, material changes, data incidents, and unresolved cases.
+
+## Evidence for evaluation
+
+Use demonstrations, references, pilot evidence, accessibility checks, support scenarios, incident history, data-flow review, and user feedback. Separate vendor claims from observed evidence and state where the sample or reference context is limited. A low unit cost is not a saving if it transfers manual work, delay, privacy risk, or inaccessible service to employees or HR teams.
+
+## Ongoing controls
+
+Name the business owner, technical or security partner, privacy owner, procurement contact, and escalation route. Review service quality, complaint and support patterns, accessibility barriers, data-quality defects, incident response, and outcomes for affected users at an agreed cadence. Set thresholds for remediation, executive escalation, contingency activation, or pause.
+
+## Transition and exit
+
+Plan how users will be informed, supported, and protected during a vendor failure, material change, renewal dispute, or exit. Confirm data portability, retention or deletion decisions, continuity ownership, alternative service capacity, and communication responsibilities before the transition starts. Close the loop with evidence that the old access, data flows, and employee-facing instructions were actually retired or replaced.
+
+## Sources
+
+This guidance synthesizes technology-and-people, ethics, business alignment, and professional judgment themes from the [CIPD Technology and People knowledge area](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/technology-people/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not procurement, privacy, security, or legal advice.


### PR DESCRIPTION
## Summary

Adds three single-purpose HR-facing content artifacts to existing skills:

- `hr-service-delivery`: trustworthy and accessible HR service delivery
- `hr-vendor-management`: vendor service and worker-impact governance
- `hr-recruitment-operations`: candidate trust and fair recruiting operations

The additions address access, sensitive-case routing, service evidence beyond speed, vendor accountability, transition safeguards, candidate communication, workflow exceptions, privacy, and human fallback. `hr-payroll` was reviewed and left unchanged because its current content and scenario already cover payroll trust, root-cause analysis, validation, stabilization, and employee communication; its time-sensitive material is deferred to a separate freshness review. No `SKILL.md`, generated registry, or matrix file was edited.

## Validation

- `git diff --check`
- `bun run lint:md`
- `bun run validate` (146 skills, 0 errors; existing informational relevance warnings remain documented separately)
- `bun run typecheck`
- `bun run test` (442 package tests, 38 reference tests, 7 web tests passed, 0 failed)
- `bun run skill-review -- hr-service-delivery hr-vendor-management hr-recruitment-operations`
  - 100/100, 93.65/100, 94.9/100
  - security clean

Target branch: `dev`. Generated registry and matrix files were not edited manually.