### PR TITLE
feat(content): add workforce decision governance

### DIFF
--- a/skills/hr-demand-planning/content/inclusive-demand-assumptions-and-prioritization.md
+++ b/skills/hr-demand-planning/content/inclusive-demand-assumptions-and-prioritization.md
@@ -1,0 +1,21 @@
+# Inclusive demand assumptions and prioritization
+
+## Purpose
+
+Demand planning is stronger when business leaders can distinguish a justified workforce need from a preference, and when prioritization does not hide the people and service consequences of deferring work.
+
+## Test the demand signal
+
+For each request, record the business outcome, work volume or risk, role and capability needed, timing, location, employment model, alternatives considered, budget status, owner, and evidence limit. Challenge whether the request reflects net-new work, backfill, workload redistribution, a process problem, or an aspirational target.
+
+## Prioritize with consequences visible
+
+Use criteria such as customer or employee impact, revenue or compliance criticality, safety, capability scarcity, time sensitivity, reversibility, and recruiting capacity. Make the effect of acceleration or deferment visible for workload, service levels, accessibility, employee experience, and existing team sustainability. Do not let a single productivity ratio decide a people-impacting trade-off.
+
+## Review and communicate
+
+Define who approves the prioritization, who can challenge an assumption, and when the demand plan is revisited. Communicate the decision, evidence, alternatives, mitigation, and next review date to business leaders and affected HR partners. A credible no or not-yet decision explains what would change the answer.
+
+## Sources
+
+This guidance synthesizes business alignment, evidence-based practice, communication, and ethics themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not a headcount approval or legal policy.

--- a/skills/hr-strategic-workforce-planning/content/workforce-change-and-decision-governance.md
+++ b/skills/hr-strategic-workforce-planning/content/workforce-change-and-decision-governance.md
@@ -1,0 +1,21 @@
+# Workforce change and decision governance
+
+## Purpose
+
+A strategic workforce plan becomes credible when leaders can see who owns each decision, which people may be affected, what evidence supports the choice, and how the organization will learn before the next planning cycle.
+
+## Make the human impact explicit
+
+For each priority capability or structural change, record the roles and groups affected, the expected work change, possible build, buy, borrow, or automate paths, transition support, and the business outcome at risk. Include employee voice, manager capacity, accessibility, location, and cultural context where they could change the feasibility or fairness of the plan.
+
+## Evidence and assumptions
+
+Separate strategic facts, working assumptions, signals, and judgments. State the source, date, owner, confidence, and limitation for important inputs such as capability supply, attrition, productivity, hiring lead time, or automation potential. Do not present a long-range workforce scenario as a precise prediction.
+
+## Decision rights and review triggers
+
+Name the executive sponsor, functional owner, finance partner, people partner, and decision forum for each material action. Define triggers for review, such as a strategy change, material variance, critical capability loss, employee-impact signal, or an assumption that no longer holds. Record the decision, alternatives considered, mitigation, and next review date.
+
+## Sources
+
+This guidance synthesizes strategic alignment, evidence-based practice, ethics, and professional judgment themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not a restructuring, employment, or legal playbook.

--- a/skills/hr-workforce-economics/content/capability-preserving-workforce-cost-decisions.md
+++ b/skills/hr-workforce-economics/content/capability-preserving-workforce-cost-decisions.md
@@ -1,0 +1,21 @@
+# Capability-preserving workforce cost decisions
+
+## Purpose
+
+Workforce economics should help leaders improve the economics of capability, not reduce people to a short-term expense line. A sound model makes delayed costs, employee impact, service risk, and recovery options visible alongside savings.
+
+## Define the decision and counterfactual
+
+Record the business problem, outcome, affected work, time horizon, baseline, alternatives, decision owner, and assumptions. Compare the proposed action with a credible counterfactual, such as maintaining the current model, delaying the decision, redesigning work, developing internal capability, or using temporary capacity.
+
+## Include hidden and shifted costs
+
+Consider ramp time, manager capacity, knowledge loss, transition support, quality, safety, service continuity, employee relations, accessibility, and the cost of reversing the decision. Make clear when a cost is estimated, allocated, or not measurable. A lower payroll number is not proof of value if workload or risk has moved to employees, customers, or a later period.
+
+## Review for fairness and sustainability
+
+Ask whether comparable groups face comparable impact, whether the decision reduces access to development or support, and whether the evidence reflects the people who perform the work. Use workforce and employee-experience evidence proportionately and protect sensitive information. Set a review date and triggers for reopening the model when assumptions or outcomes move materially.
+
+## Sources
+
+This guidance synthesizes business alignment, evidence-based practice, ethics, and professional judgment themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not financial, employment, or legal advice.

--- a/skills/hr-workforce-planning/content/fair-workforce-redeployment-and-skills-governance.md
+++ b/skills/hr-workforce-planning/content/fair-workforce-redeployment-and-skills-governance.md
@@ -1,0 +1,25 @@
+# Fair workforce redeployment and skills governance
+
+## Purpose
+
+Workforce planning should not treat people as interchangeable capacity units. When priorities shift, the plan should show how capability will be built, bought, borrowed, redeployed, or reduced, and how affected employees will receive a fair and understandable process.
+
+## Define the capability gap
+
+Describe the future work, observable capability, time horizon, current evidence, and business consequence before selecting a solution. Distinguish a missing skill from a capacity, process, manager, technology, or role-design problem. Use employee and manager input to test whether the proposed capability definition matches work as performed.
+
+## Compare closure options
+
+For each gap, compare development, internal mobility, hiring, contingent support, redesign, automation, and deferment. Record time to value, cost, dependencies, access requirements, quality and safety risks, workload effect, and reversibility. Do not assume that hiring is neutral or that automation removes work without shifting oversight, support, or accountability elsewhere.
+
+## Fair transition evidence
+
+Use consistent criteria for role matching, development access, readiness, and support. Explain how decisions will be made and provide a route for questions or review. Check whether the plan creates unequal access to opportunity or places transition cost on a less visible group. Treat demographic and sensitive workforce data as governed evidence, not as a shortcut for deciding who is expendable.
+
+## Review and accountability
+
+Assign an owner for the capability model, employee communication, progress evidence, and escalation. Review mobility, development participation, workload, retention, time to proficiency, and business outcomes with their limitations stated. Revisit the plan when the work, strategy, or employee impact differs from the approved assumptions.
+
+## Sources
+
+This guidance synthesizes the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/), the [World Economic Forum Future of Jobs 2025 Skills Outlook](https://www.weforum.org/publications/the-future-of-jobs-report-2025/in-full/3-skills-outlook/), and professional practice in the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not legal advice for redeployment, redundancy, or selection decisions.

--- a/skills/hr-workforce-scenario-planning/content/workforce-scenario-change-and-worker-impact.md
+++ b/skills/hr-workforce-scenario-planning/content/workforce-scenario-change-and-worker-impact.md
@@ -1,0 +1,21 @@
+# Workforce scenario change and worker impact
+
+## Purpose
+
+Scenario planning should prepare leaders to make difficult workforce choices without false certainty. Each scenario needs both an operating response and a view of how the response changes work, opportunity, workload, and employee experience.
+
+## Add a people-impact layer
+
+For each scenario, describe the affected roles and groups, work that may stop, start, or move, capability and manager demands, access or accessibility concerns, employee communication needs, and likely short-term and long-term consequences. Distinguish reversible actions from choices that could permanently change capability or trust.
+
+## Triggers and guardrails
+
+Pair each trigger with a decision owner, evidence source, confidence or limitation, action boundary, and review date. Define guardrails for safety, service continuity, legal or policy review, workload, employee voice, and equitable access. A trigger should start a disciplined review, not automatically authorize a high-impact action.
+
+## Learn and adapt
+
+Track whether the scenario assumptions, workforce actions, and employee or business outcomes match. Use manager and employee feedback alongside headcount, cost, capacity, attrition, service, and capability measures. Record what was learned, what changed, and which assumptions remain uncertain before refreshing the scenario set.
+
+## Sources
+
+This guidance synthesizes evidence-based practice, change, ethics, employee voice, and business alignment themes from the [CIPD Profession Map core knowledge](https://www.cipd.org/en/the-people-profession/the-profession-map/explore-the-profession-map/core-knowledge/) and the [SHRM Body of Applied Skills and Knowledge](https://www.shrm.org/credentials/certification/exam-preparation/bask). It is not legal or restructuring advice.


### PR DESCRIPTION
## Summary

Adds five single-purpose HR-facing content artifacts to existing skills:

- `hr-strategic-workforce-planning`: workforce change and decision governance
- `hr-workforce-planning`: fair workforce redeployment and skills governance
- `hr-workforce-economics`: capability-preserving workforce cost decisions
- `hr-demand-planning`: inclusive demand assumptions and prioritization
- `hr-workforce-scenario-planning`: workforce scenario change and worker impact

The additions address evidence provenance, assumptions, worker and manager impact, fair redeployment, transition support, uncertainty, reversibility, service continuity, and decision ownership. No `SKILL.md`, generated registry, or matrix file was edited.

## Validation

- `git diff --check`
- `bun run lint:md`
- `bun run validate` (146 skills, 0 errors; existing informational relevance warnings remain documented separately)
- `bun run typecheck`
- `bun run test` (442 package tests, 38 reference tests, 7 web tests passed, 0 failed)
- `bun run skill-review -- hr-strategic-workforce-planning hr-workforce-planning hr-workforce-economics hr-demand-planning hr-workforce-scenario-planning`
  - 97.76/100, 100/100, 94.66/100, 95.5/100, 92.76/100
  - security clean

Target branch: `dev`. Generated registry and matrix files were not edited manually.