### PR TITLE
feat(content): add technical hiring signals

### DIFF
--- a/skills/hr-cloud/content/production-ownership-and-resilience-signals.md
+++ b/skills/hr-cloud/content/production-ownership-and-resilience-signals.md
@@ -1,0 +1,21 @@
+# Production ownership and resilience signals in cloud hiring
+
+## Purpose
+
+Cloud hiring should evaluate how a candidate operates a dependable service, not how many provider names appear on a résumé. The strongest evidence connects infrastructure choices to user impact, security, cost, recovery, and team ways of working.
+
+## Signals to assess
+
+Look for clear ownership of service boundaries, reliability expectations, access decisions, deployment risk, capacity, observability, and incident response. Ask candidates to explain a production problem in terms of customer impact, diagnosis, communication, mitigation, follow-up, and what changed afterward. Certification or tool familiarity can support the discussion but should not replace evidence of judgment.
+
+## Trade-offs and guardrails
+
+A credible candidate can explain why a design balances availability, latency, cost, security, operational effort, and reversibility for a specific context. They should recognize when a managed service, automation, or platform standard reduces toil and when it introduces dependency or control concerns. HR and hiring managers should listen for explicit assumptions, escalation boundaries, and willingness to involve security, product, developers, and operations partners.
+
+## Sustainable on-call practice
+
+Clarify the actual support model, incident frequency, decision authority, handoff quality, learning process, and compensation or recovery expectations defined by the organization. Treat repeated heroics, unclear ownership, or an always-on expectation as process risks rather than evidence of seniority. Ask how the team protects focus, shares operational knowledge, and improves the system after an incident.
+
+## Source boundaries
+
+The [Kubernetes overview](https://kubernetes.io/docs/concepts/overview/) describes a platform for managing containerized workloads with automation, scaling, and management concerns; it is a technical reference, not a hiring rubric. This content translates durable reliability and ownership ideas into HR-facing evaluation signals. It is not a substitute for a technical panel or organization-specific security and on-call policy.

--- a/skills/hr-devops/content/operational-learning-and-delivery-guardrails.md
+++ b/skills/hr-devops/content/operational-learning-and-delivery-guardrails.md
@@ -1,0 +1,25 @@
+# Operational learning and delivery guardrails in DevOps hiring
+
+## Purpose
+
+DevOps capability is visible in how teams deliver, operate, and learn from software systems. HR should help hiring teams test ownership, collaboration, reliability, and judgment rather than rewarding a long list of tools or uninterrupted availability.
+
+## Delivery signals
+
+Ask how a candidate makes a change safe to release, how quality and security checks fit the delivery path, who can stop or reverse a risky change, and how the team communicates status. Strong answers connect delivery speed with customer impact, service reliability, access control, and a practical fallback. They explain the decision boundary in language that developers, QA, security, product, and operations can share.
+
+## Incident and learning signals
+
+Explore a real incident or service degradation. Listen for the candidate's role, impact assessment, escalation, stakeholder communication, mitigation, evidence preserved, and follow-up improvement. Distinguish learning from blame: a mature response improves detection, runbooks, ownership, or system design without hiding accountability for preventable actions.
+
+## Platform and developer experience
+
+For platform-oriented roles, assess whether the candidate treats internal users as customers. Look for evidence of clear service boundaries, usable self-service, documentation, support, adoption feedback, and measures of toil or reliability. A platform that shifts complexity to application teams is not automatically a successful platform.
+
+## Sustainable operations
+
+Clarify on-call scope, handoffs, workload, incident frequency, recovery time expectations, and how operational work is shared and recognized. Ask what triggers a review of the operating model. Repeated heroics, undocumented knowledge, or vague ownership are signals to investigate rather than badges of commitment.
+
+## Sources
+
+The [Kubernetes overview](https://kubernetes.io/docs/concepts/overview/) provides a current technical reference for orchestration and automated management concepts. The [Node.js About page](https://nodejs.org/en/about) describes the runtime's event-driven, non-blocking model as technical context. This content translates technical concepts into HR-facing workplace signals and is not a technical implementation guide.

--- a/skills/hr-software-architecture/content/architecture-judgment-and-trade-off-signals.md
+++ b/skills/hr-software-architecture/content/architecture-judgment-and-trade-off-signals.md
@@ -1,0 +1,25 @@
+# Architecture judgment and trade-off signals for HR
+
+## Purpose
+
+Architecture hiring should reveal how a candidate makes and communicates consequential system decisions. A polished diagram or confident vocabulary is not enough; hiring teams need evidence of constraints, alternatives, risk ownership, and outcomes.
+
+## Decision evidence
+
+Ask for an architecture decision the candidate influenced. Capture the problem, users, constraints, assumptions, alternatives considered, decision owner, affected teams, migration or rollout path, and evidence that changed the decision. Strong candidates can explain what they deliberately did not optimize and what would cause them to revisit the choice.
+
+## Cross-functional judgment
+
+Listen for collaboration with product, design, security, data, operations, support, and finance partners. Architecture is stronger when the candidate makes boundaries and responsibilities understandable to the people who build, operate, and rely on the system. Look for influence without authority, constructive disagreement, and a record of adapting the design when user or operational evidence changed.
+
+## Reliability, security, and reversibility
+
+Probe how the candidate treats failure, access, data boundaries, observability, operational ownership, and rollback or migration risk. Distinguish a locally elegant solution from one that the organization can support. For senior roles, ask how the candidate leaves behind decision records, enables teams, and reduces dependence on personal expertise.
+
+## Leveling signals
+
+At senior level, expect sound decisions within a defined service or product boundary. At staff or principal level, expect durable patterns across teams, explicit trade-offs, alignment of decision rights, and measurable improvement in reliability, delivery, security, or developer experience. Evaluate the scope and evidence of influence rather than presentation style alone.
+
+## Sources
+
+The [React guide to Thinking in React](https://react.dev/learn/thinking-in-react) illustrates decomposition from user experience into component responsibilities; the [Node.js About page](https://nodejs.org/en/about) provides runtime context; and the [Kubernetes overview](https://kubernetes.io/docs/concepts/overview/) provides context for orchestration and operational trade-offs. These are technical references used to inform HR-facing evaluation language, not architecture tutorials.


### PR DESCRIPTION
## Summary

Adds three single-purpose HR-facing content artifacts to existing skills:

- `hr-cloud`: production ownership and resilience signals
- `hr-devops`: operational learning and delivery guardrails
- `hr-software-architecture`: architecture judgment and trade-off signals

The additions translate official technical references into hiring signals around service ownership, reliability, security, incident learning, delivery guardrails, platform user experience, architecture trade-offs, cross-functional influence, and sustainable on-call practice. They intentionally contain no code, syntax, setup instructions, or implementation tutorial.

`hr-frontend`, `hr-backend`, `hr-system-design`, and `hr-system-integration` were reviewed; their existing focused content was sufficient for this wave, and `hr-system-design` was already covered by Wave 2C. No `SKILL.md`, generated registry, or matrix file was edited.

Sources include official React, Node.js, and Kubernetes documentation.

## Validation

- `git diff --check`
- `bun run lint:md`
- `bun run validate` (146 skills, 0 errors; existing informational relevance warnings remain documented separately)
- `bun run typecheck`
- `bun run test` (442 package tests, 38 reference tests, 7 web tests passed, 0 failed)
- `bun run skill-review -- hr-cloud hr-devops hr-software-architecture hr-frontend hr-backend hr-system-design hr-system-integration`
  - changed skills: 95.5/100, 89.88/100, 95.5/100
  - all security checks clean; hr-devops advisory is non-blocking and reflects pre-existing long description/body and one-example depth

Target branch: `dev`. Generated registry and matrix files were not edited manually.