### PR TITLE
feat(skills): enrich AI adoption and governance

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Generate deterministic report
         if: steps.changed.outputs.count != '0'
         run: |
-          cd packages/hr-skills-build
+          cd packages/hr-skills
           echo "${{ steps.changed.outputs.list }}" > /tmp/changed-skills.txt
           bun run skill-review -- --list-file /tmp/changed-skills.txt > /tmp/skill-review-report.md
           cat /tmp/skill-review-report.md

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Build hr-skills-ref
         run: bun run build --filter=hr-skills-ref
 
+      - name: Build hr-skills-build
+        run: bun run build --filter=hr-skills-build
+
       - name: Determine changed skills
         id: changed
         run: |

--- a/docs/engineering/skill-matrix.md
+++ b/docs/engineering/skill-matrix.md
@@ -1,6 +1,6 @@
 # HR Skills — Skill Matrix
 
-> Auto-generated on 2026-08-20 by `bun run matrix`. Do not edit manually.
+> Auto-generated on 2026-09-06 by `bun run matrix`. Do not edit manually.
 
 ## Summary
 
@@ -18,11 +18,11 @@
 | `hr-accessibility-accommodation` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
 | `hr-agentic-ai` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
 | `hr-ai` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
-| `hr-ai-adoption` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
+| `hr-ai-adoption` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.1 |
 | `hr-ai-change-management` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
 | `hr-ai-ethics` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
 | `hr-ai-evaluation` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
-| `hr-ai-governance` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
+| `hr-ai-governance` | 🟢 Full | ✅ | ✅ | ✅ | 2 | 1.0.1 |
 | `hr-ai-privacy` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
 | `hr-analytics` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |
 | `hr-ar-vr` | 🟢 Full | ✅ | ✅ | ✅ | 1 | 1.0.1 |

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-20",
+  "generatedAt": "2026-09-06",
   "skillCount": 146,
   "skills": [
     {

--- a/skills/hr-ai-adoption/content/aihr-adoption-operating-model.md
+++ b/skills/hr-ai-adoption/content/aihr-adoption-operating-model.md
@@ -1,0 +1,40 @@
+# AIHR evidence: an operating model for AI adoption in HR
+
+AIHR’s public articles describe AI adoption as a workflow and capability change, not simply a software launch. Relevant examples include [AI for internal mobility](https://www.aihr.com/blog/ai-for-internal-mobility/), [AI in HR](https://www.aihr.com/blog/ai-in-hr/), and [AI HR assistant](https://www.aihr.com/blog/ai-hr-assistant/). The practical implication is to connect each AI use case to a user problem, a safe operating boundary, enablement, and evidence of changed work.
+
+## Start from work, not features
+
+Map the current HR workflow before choosing the adoption intervention. Identify the repetitive step, decision bottleneck, quality problem, or employee experience gap the tool is meant to improve. Define what a good outcome looks like in the existing process, then select a small use case where users can see value without changing every process at once.
+
+For internal mobility, for example, adoption should be framed around making skills, opportunities, and development conversations more visible. A tool that recommends opportunities still needs trusted skills data, manager participation, employee agency, and a clear route to challenge or correct a recommendation.
+
+## Sequence the rollout
+
+Use a staged rollout: prepare the operating boundary, pilot with representative users, measure the workflow outcome, improve the experience, and then expand. Select pilot groups for learning value rather than enthusiasm alone. Include skeptical users and the contexts in which the process is difficult, while avoiding an initial scope so broad that the team cannot distinguish product problems from change-management problems.
+
+A pilot should define baseline performance, training and support, feedback channels, prohibited uses, and a stop condition. The next stage should depend on evidence of useful and safe behavior, not merely the number of accounts provisioned or people who attended training.
+
+## Enablement and trust
+
+AIHR’s AI-in-HR framing supports role-specific enablement. HR practitioners need practice with representative cases, guidance on verification and confidential data, examples of acceptable and unacceptable use, and a way to ask for help. Managers need language for role changes and job-security concerns. Employees need to understand where AI supports a service and where a human remains accountable.
+
+Peer champions can translate general training into local workflows, but they should not become informal policy owners. Give champions a bounded remit, escalation route, reusable examples, and a feedback mechanism. Publish improvements made from feedback so users can see that adoption is a two-way process.
+
+## Measure sustained adoption
+
+Measure a funnel rather than a single usage number: awareness, first successful use, repeated use in a target workflow, quality and time outcome, user confidence, and safe-use adherence. Segment results by role, team, use case, and level of support. A falling usage rate may indicate weak relevance, poor data, unclear policy, or lack of manager reinforcement; it should trigger investigation rather than an automatic mandate.
+
+Pair quantitative signals with workflow observation and user interviews. Track rework, escalation, correction, and abandonment, because high activity can coexist with low value. For a people-facing use case, include employee experience and fairness signals alongside productivity measures.
+
+## Adoption review questions
+
+| Review area | Questions |
+| --- | --- |
+| Relevance | Which specific HR task becomes easier, safer, faster, or more useful? |
+| Readiness | Do users have the data, skills, permissions, and time required to use the tool well? |
+| Trust | Can users verify, correct, and escalate an output? |
+| Enablement | Are examples and support tailored to the role and workflow? |
+| Outcomes | What changed in quality, cycle time, employee experience, or capability? |
+| Sustainability | What will maintain good use after launch support is reduced? |
+
+This document synthesizes the linked public AIHR material. It is operational guidance, not a promise that any specific AI product will produce a particular result.

--- a/skills/hr-ai-adoption/examples/aihr-assistant-rollout.md
+++ b/skills/hr-ai-adoption/examples/aihr-assistant-rollout.md
@@ -1,0 +1,25 @@
+# Staged rollout for an HR assistant
+
+## Scenario
+
+An HR operations team wants to introduce an AI assistant for policy search and first-draft employee responses. The objective is to reduce repetitive lookup work while preserving human accountability for sensitive cases.
+
+## Prepare
+
+The team maps the current workflow and chooses two low-risk tasks: finding approved policy passages and drafting a response that a named HR specialist must review. It defines prohibited uses, approved sources, confidential-data rules, baseline response time, quality criteria, and a route for employees to request human assistance.
+
+## Pilot
+
+The pilot includes HR operations, one HR business partner, and a skeptical representative from a high-volume service team. Each participant practices with realistic redacted cases. A champion collects friction and examples, but cannot approve policy changes or expand the use case. The product owner reviews errors weekly and pauses the pilot if the assistant invents policy, exposes restricted information, or is used to decide an employment outcome.
+
+## Measure
+
+The team tracks first successful use, repeated use in the target workflow, reviewer correction rate, rework, response time, escalation, confidence, and safe-use adherence. Interviews explain why users abandon the tool or bypass review. Adoption is considered healthy only when the workflow outcome improves without a rise in unsupported answers or hidden policy decisions.
+
+## Expand or redesign
+
+After 30 days, the team compares results with the baseline and publishes improvements made from feedback. Expansion requires stable quality, a workable review load, clear employee communication, and an owner for ongoing monitoring. If usage is low because the approved knowledge base is incomplete, the team improves the source and enablement before mandating use.
+
+## Expected output
+
+The final package contains a use-case canvas, pilot charter, role-based practice set, manager and employee communications, champion remit, dashboard definition, weekly review log, and an expand/pause/redesign decision record. The workflow is informed by [AIHR’s AI HR assistant article](https://www.aihr.com/blog/ai-hr-assistant/) and [AI in HR overview](https://www.aihr.com/blog/ai-in-hr/).

--- a/skills/hr-ai-adoption/prompts/aihr-adoption-planning.md
+++ b/skills/hr-ai-adoption/prompts/aihr-adoption-planning.md
@@ -1,0 +1,22 @@
+# AI adoption planning prompts
+
+## Use-case and rollout design
+
+- "Map the current [HR workflow] and identify the smallest AI use case that could improve [quality, cycle time, employee experience, or capability] without hiding the accountable human."
+- "Design a staged rollout for [AI tool] across [population]. Define pilot selection, baseline measures, enablement, support, feedback, stop conditions, and expansion criteria."
+- "Compare the adoption risks of introducing [chatbot, copilot, analytics, or internal-mobility tool] in [HR process] and recommend controls for each stage."
+- "Create a use-case canvas for [AI initiative] covering user problem, desired outcome, data readiness, prohibited uses, reviewer, escalation, and evidence of value."
+
+## Enablement and trust
+
+- "Create role-specific practice exercises for [HR role] using [AI tool], including verification steps, confidential-data boundaries, acceptable-use examples, and escalation."
+- "Draft manager talking points for [AI rollout] that address job changes honestly, explain accountability, and avoid promising that automation will have no workforce impact."
+- "Design a peer-champion program for [population] with a bounded remit, support materials, feedback route, and handoff to the accountable product or HR owner."
+- "Write an employee FAQ for [AI-supported HR service] explaining purpose, human involvement, data boundaries, correction, and how to request human help."
+
+## Measurement and sustainment
+
+- "Build an adoption funnel for [AI use case] from awareness to repeated safe use and measurable workflow outcome. Define leading and lagging indicators."
+- "Design a baseline and pilot evaluation for [HR process] that measures quality, rework, cycle time, confidence, fairness, and safe-use adherence."
+- "Analyze these usage and outcome signals for [AI tool]. Distinguish low relevance, poor enablement, data issues, policy friction, and manager reinforcement problems."
+- "Create a 30/60/90-day sustainment plan for [AI rollout], including feedback reviews, product improvements, champion support, and a decision to expand, pause, or redesign."

--- a/skills/hr-ai-governance/content/aihr-evidence-and-governance.md
+++ b/skills/hr-ai-governance/content/aihr-evidence-and-governance.md
@@ -1,0 +1,39 @@
+# AIHR evidence: governance for AI in HR
+
+AIHR’s public material treats AI in HR as a portfolio of use cases rather than a single deployment. The governance question is therefore not only whether a tool is accurate, but also whether the use case is proportionate, explainable, secure, and reviewable throughout the employee lifecycle. See [AI in HR](https://www.aihr.com/blog/ai-in-hr/) and [Data Privacy and Ethics in AI for HR](https://www.aihr.com/blog/data-privacy-and-ethics-in-ai-for-hr/).
+
+## Use-case classification
+
+Start by classifying the proposed use case before selecting a vendor or model. Separate administrative assistance, decision support, and automated decision-making. The closer a system is to hiring, promotion, performance, compensation, termination, or access to sensitive employee information, the stronger the evidence, approval, monitoring, and human-review requirements should be.
+
+Document the intended decision, affected people, data inputs, model output, responsible owner, human reviewer, escalation route, retention period, and fallback process. Do not allow a model output to become a hidden policy simply because it is convenient to consume.
+
+## Privacy and data minimization
+
+AIHR’s privacy-and-ethics framing supports a data-minimization approach: use only the attributes needed for the stated HR purpose, remove direct identifiers where they are not necessary, restrict access by role, and define retention before collecting data. Treat prompts, uploaded documents, generated outputs, logs, and vendor telemetry as potential employee-data surfaces.
+
+A governance review should ask whether the organization has a lawful and transparent purpose, a documented data flow, an access control, a retention/deletion rule, and a way for an employee or candidate to obtain a meaningful explanation of the process. These questions are operational controls, not merely policy language.
+
+## Bias and validation
+
+Validation must be disaggregated by relevant populations and tested against the actual workflow in which the output will be used. Review false positives and false negatives, missing-data behavior, language and accessibility effects, and changes in performance after model or process updates. A useful result is not sufficient if affected people cannot challenge an error or if the reviewer cannot understand the evidence behind a recommendation.
+
+Keep a decision log for material use cases. Record the version of the system, evaluation sample, known limitations, reviewer decision, override reason, and incident or appeal outcome. Use this record for periodic review and vendor conversations.
+
+## Human oversight and employee communication
+
+Human review should be substantive. Give reviewers authority to reject or override an output, enough context to do so, and a documented escalation path for uncertain cases. Avoid rubber-stamping by sampling decisions, measuring override patterns, and reviewing disagreement cases.
+
+Explain AI-supported processes in plain language to employees and candidates when the process materially affects them. The explanation should cover the purpose, the role of automation, the role of human review, the data categories involved, and how to raise a concern. Do not promise that a human is “in the loop” if the human cannot change the outcome.
+
+## Practical governance checklist
+
+1. Define the HR decision and the acceptable use boundary.
+2. Map data sources, access, retention, transfers, and vendor processing.
+3. Assess bias, validity, accessibility, security, and failure modes before launch.
+4. Assign an accountable owner and an independent reviewer for material decisions.
+5. Pilot with a documented baseline and monitor outcomes after deployment.
+6. Provide notice, explanation, appeal, correction, and incident processes.
+7. Re-review when the model, vendor, data, workforce, or legal context changes.
+
+This guidance is a synthesis of the linked AIHR articles and is not legal advice. Apply the organization’s applicable laws, collective agreements, internal policy, and professional review requirements before deployment.

--- a/skills/hr-ai-governance/examples/aihr-assistant-governance-review.md
+++ b/skills/hr-ai-governance/examples/aihr-assistant-governance-review.md
@@ -1,0 +1,29 @@
+# Governance review for an HR assistant
+
+## Scenario
+
+An HR team wants to introduce an AI assistant that drafts answers to policy questions, summarizes employee-provided information, and suggests next steps to HR staff. The assistant must not make hiring, promotion, compensation, performance, or termination decisions.
+
+## Step 1: Define the boundary
+
+The owner writes a one-sentence purpose statement: “The assistant helps HR staff find and draft responses from approved policy sources.” The register marks the tool as administrative assistance and decision support, not automated decision-making. It lists prohibited inputs and outputs, including requests to rank employees, infer protected characteristics, diagnose health conditions, or recommend employment outcomes.
+
+## Step 2: Map data and controls
+
+The review maps prompts, uploaded documents, generated answers, logs, and vendor telemetry. The team configures approved sources, role-based access, retention limits, redaction for unnecessary identifiers, and a deletion route. The vendor contract and settings are reviewed for training reuse, subprocessors, cross-border transfer, and breach notification.
+
+## Step 3: Design human review
+
+Every answer that could influence an employee receives a named HR reviewer. The interface displays source links and uncertainty notes, and the reviewer must edit or reject unsupported claims. A sample of routine answers is audited weekly. Override reasons and incidents are recorded so that rubber-stamping, recurring misinformation, and policy gaps can be detected.
+
+## Step 4: Pilot and communicate
+
+The team pilots the assistant with synthetic and redacted cases, compares response quality with a documented baseline, and checks performance across languages and accessibility needs. Employees are told what the assistant does, what it does not do, what information should not be entered, and how to request human help or challenge an answer.
+
+## Step 5: Decision record
+
+The final record includes the purpose, prohibited uses, data map, vendor review, pilot results, known limitations, reviewer protocol, monitoring indicators, incident route, owner, approval date, and next review date. The assistant is paused if it begins producing unsupported policy claims, exposes restricted information, or is used as an undisclosed employment decision tool.
+
+## Expected output
+
+The deliverable is a short approved-use policy, a data-flow and vendor checklist, a human-review operating procedure, an employee notice, and a monitoring log. This workflow synthesizes AIHR’s public guidance on AI in HR and data privacy and ethics; it does not replace legal, works-council, security, or privacy review.

--- a/skills/hr-ai-governance/prompts/aihr-governance-review.md
+++ b/skills/hr-ai-governance/prompts/aihr-governance-review.md
@@ -1,0 +1,22 @@
+# AI in HR governance review prompts
+
+## Use-case triage
+
+- "Classify this proposed [HR AI use case] as administrative assistance, decision support, or automated decision-making. Explain the governance consequences and the minimum approval controls."
+- "Create an AI use-case register for [process], including purpose, affected populations, data categories, model output, owner, reviewer, escalation path, and prohibited uses."
+- "Identify where this workflow could turn an advisory model output into an unreviewed employment decision, and redesign the control points."
+- "Build a risk-based review plan for [use case] before pilot, launch, and post-launch monitoring."
+
+## Privacy and security
+
+- "Minimize the data in this [HR AI workflow] while preserving the stated purpose. List fields to remove, generalize, restrict, or retain and explain why."
+- "Map the data flow for [AI vendor and HR process], including prompt inputs, uploaded files, generated outputs, logs, retention, access, and deletion."
+- "Draft plain-language employee notice for [AI-supported process] covering purpose, automation, human review, data categories, and appeal route."
+- "Review this vendor questionnaire for gaps in employee-data processing, access control, retention, deletion, security, and secondary use."
+
+## Bias, validity, and oversight
+
+- "Design a validation plan for [AI use case] that tests false positives, false negatives, missing data, language, accessibility, and outcomes across relevant populations."
+- "Create a human-review protocol for [decision], including reviewer authority, evidence requirements, override reasons, escalation, and audit sampling."
+- "Analyze this model monitoring report for drift, disparate outcomes, override patterns, and incidents. Recommend actions without treating correlation as causation."
+- "Write an incident and appeal workflow for an employee who believes [AI-supported HR decision] is inaccurate or unfair."


### PR DESCRIPTION
## Summary

This PR adds missing HR-facing companion content for the existing `hr-ai-adoption` and `hr-ai-governance` skills.

The changes were selected after reviewing closed, unmerged PR #236. That PR was explicitly closed as out of scope; its useful skill companion artifacts were not present on the current `dev` branch. This PR ports only those missing `content`, `examples`, and `prompts` files. It does not recreate the prior web changes, dependency changes, or direct edits to `SKILL.md`.

## Added content

- `hr-ai-adoption/content/aihr-adoption-operating-model.md`
- `hr-ai-adoption/examples/aihr-assistant-rollout.md`
- `hr-ai-adoption/prompts/aihr-adoption-planning.md`
- `hr-ai-governance/content/aihr-evidence-and-governance.md`
- `hr-ai-governance/examples/aihr-assistant-governance-review.md`
- `hr-ai-governance/prompts/aihr-governance-review.md`

The generated registry and skill matrix were regenerated by repository scripts. No new skill directory is created.

## Validation

- `bun run registry`
- `bun run matrix`
- `bun run validate`: 146 skills, 0 errors; two existing informational relevance warnings remain for `hr-career-development`.
- `bun run check`
- `bun run lint:md`
- `bun run test`
- `bun run typecheck`
- `git diff --check`

The PR is based on the current `dev` branch and does not reproduce any already-merged or unrelated closed PR changes.
