### PR TITLE
fix(skills): synchronize career pathway relationships

### DIFF
--- a/packages/hr-skills-build/eval/golden/planning-scenarios.golden.json
+++ b/packages/hr-skills-build/eval/golden/planning-scenarios.golden.json
@@ -1,6 +1,6 @@
 {
 	"dataset": "planning-scenarios",
-	"generatedAt": "2026-07-29",
+	"generatedAt": "2026-09-07",
 	"results": [
 		{
 			"caseId": "recruiting-interview-questions",
@@ -44,7 +44,7 @@
 				"hr-training-development",
 				"hr-career-development",
 				"hr-leadership-development",
-				"hr-business-partner"
+				"hr-performance-review"
 			],
 			"matchedCapabilities": 2,
 			"totalCapabilities": 2,
@@ -56,7 +56,8 @@
 			"skillIds": [
 				"hr-performance-management",
 				"hr-performance-review",
-				"hr-business-partner"
+				"hr-business-partner",
+				"hr-career-development"
 			],
 			"matchedCapabilities": 2,
 			"totalCapabilities": 2,
@@ -68,7 +69,7 @@
 			"skillIds": [
 				"hr-performance-review",
 				"hr-offboarding",
-				"hr-business-partner",
+				"hr-career-development",
 				"hr-coordination"
 			],
 			"matchedCapabilities": 2,

--- a/packages/hr-skills-build/src/registry/classifier.ts
+++ b/packages/hr-skills-build/src/registry/classifier.ts
@@ -81,10 +81,16 @@ const EXPLICIT: Readonly<Record<string, SkillClassification>> = {
 
 	// Performance / talent / career
 	'hr-performance-management': { category: 'performance-talent', tags: [] },
-	'hr-performance-review': { category: 'performance-talent', tags: [] },
+	'hr-performance-review': {
+		category: 'performance-talent',
+		tags: ['career-pathway'],
+	},
 	'hr-talent-management': { category: 'performance-talent', tags: [] },
 	'hr-succession-planning': { category: 'performance-talent', tags: [] },
-	'hr-career-development': { category: 'performance-talent', tags: [] },
+	'hr-career-development': {
+		category: 'performance-talent',
+		tags: ['career-pathway'],
+	},
 	'hr-competency-management': { category: 'performance-talent', tags: [] },
 	'hr-manager-effectiveness': { category: 'performance-talent', tags: [] },
 	'hr-coaching-mentoring': { category: 'performance-talent', tags: [] },
@@ -100,7 +106,10 @@ const EXPLICIT: Readonly<Record<string, SkillClassification>> = {
 	'hr-retirement-benefits': { category: 'compensation-rewards', tags: [] },
 
 	// Learning / development
-	'hr-training-development': { category: 'learning-development', tags: [] },
+	'hr-training-development': {
+		category: 'learning-development',
+		tags: ['career-pathway'],
+	},
 	'hr-learning-development': { category: 'learning-development', tags: [] },
 	'hr-learning-strategy': { category: 'learning-development', tags: [] },
 	'hr-leadership-development': { category: 'learning-development', tags: [] },

--- a/packages/hr-skills-build/src/registry/registry.ts
+++ b/packages/hr-skills-build/src/registry/registry.ts
@@ -35,6 +35,19 @@ import { SKILLS_DIR } from 'hr-skills-ref/server';
 const HR_PREFIX_REGEX = /^hr-/;
 
 /**
+ * Maintainer-approved relationships that must remain discoverable even when
+ * the deterministic top-five ranker would otherwise trim them. Generated
+ * registry files remain derived artifacts; this map is source data.
+ */
+const RELATED_SKILL_OVERRIDES: Readonly<Record<string, readonly string[]>> = {
+	'hr-career-development': [
+		'hr-performance-review',
+		'hr-training-development',
+		'hr-leadership-development',
+	],
+};
+
+/**
  * Load the committed usage-informed relevance signal table
  * (`registry/relevance-signals.json`), if present and valid — Phase 6.1-B.
  *
@@ -222,10 +235,16 @@ export async function buildRegistry(
 				byDomain.get(entry.classification.category) ?? [],
 			);
 
-			// Optionally blend static ranking with observed co-selection evidence.
-			const relatedSkills = signalIndex
-				? reRankRelatedSkills(entry.id, staticRelated, signalIndex)
-				: staticRelated;
+				// Optionally blend static ranking with observed co-selection evidence.
+				const rankedRelated = signalIndex
+					? reRankRelatedSkills(entry.id, staticRelated, signalIndex)
+					: staticRelated;
+				const relatedSkills = [
+					...new Set([
+						...(RELATED_SKILL_OVERRIDES[entry.id] ?? []),
+						...rankedRelated,
+					]),
+				].slice(0, 5);
 
 			const registryEntry: RegistryEntry = {
 				id: entry.id,

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -917,7 +917,9 @@
       "description": "Help HR teams and managers design career development programs, frameworks, and conversations. Use when asked to create career paths, build individual development plans, design career ladders, run career development conversations, develop career frameworks, or similar career growth tasks.",
       "tier": "full",
       "domain": "performance-talent",
-      "tags": [],
+      "tags": [
+        "career-pathway"
+      ],
       "aliases": [
         "career-development"
       ],
@@ -947,11 +949,11 @@
       },
       "dependencies": [],
       "relatedSkills": [
+        "hr-performance-review",
+        "hr-training-development",
+        "hr-leadership-development",
         "hr-business-partner",
-        "hr-coaching-mentoring",
-        "hr-competency-management",
-        "hr-manager-effectiveness",
-        "hr-leadership-development"
+        "hr-coaching-mentoring"
       ]
     },
     {
@@ -4320,7 +4322,9 @@
       "description": "Help managers, HR professionals, and team leaders write fair, balanced, evidence-based performance reviews, self-assessments, and development plans. Use when asked to write or calibrate an individual performance review, draft manager feedback, evaluate employee performance, write appraisal comments, create a development plan, review employee goals, or any employee performance evaluation task, or write or calibrate individual performance reviews.",
       "tier": "full",
       "domain": "performance-talent",
-      "tags": [],
+      "tags": [
+        "career-pathway"
+      ],
       "aliases": [
         "performance-review"
       ],
@@ -6171,7 +6175,9 @@
       "description": "Help HR managers with learning and development programs. Use when asked to design a training program, create an e-learning course, develop a coaching plan, conduct a needs assessment, write a competency model, design a mentorship program, create a learning plan, or any training and development task, or create a specific training module or course.",
       "tier": "full",
       "domain": "learning-development",
-      "tags": [],
+      "tags": [
+        "career-pathway"
+      ],
       "aliases": [
         "training-development"
       ],


### PR DESCRIPTION
## Summary

- synchronize the maintainer-approved career pathway relationships for `hr-career-development`
- keep `hr-performance-review`, `hr-training-development`, and `hr-leadership-development` discoverable in the generated registry
- regenerate the registry, skill matrix, and planning-scenario golden baseline from the current `dev` branch

## Why

The current relevance signals identified two reciprocal relationships for `hr-career-development` that were not represented in its generated `relatedSkills`. This PR updates source classification and registry generation rather than editing generated JSON by hand.

The golden baseline is regenerated because the approved relationship changes alter deterministic skill selection for three planning scenarios. No skill directories, `SKILL.md` files, web files, or unrelated content are included.

## Validation

- `bun run registry`
- `bun run matrix` — 146 full, 0 partial, 0 bare
- `bun run validate` — 146 skills, 0 errors, 0 warnings
- `bun run evaluate` — no regressions; 100% skill-selection accuracy
- `bun run check`
- `bun run lint:md`
- `bun run test`
- `bun run typecheck`
- `bun run api-docs:check`
- `git diff --check`