### PR TITLE
feat(hr-skills-build): define Phase 8.2 platform integration contracts

### DIFF
--- a/.changeset/platform-integration-contracts.md
+++ b/.changeset/platform-integration-contracts.md
@@ -1,0 +1,5 @@
+---
+"hr-skills-build": minor
+---
+
+Added versioned platform-integration contracts for web and external clients, including normalized response envelopes, validation rules, authentication guidance, and rate-limit policies.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -443,12 +443,16 @@ Expose the core registry, planner, runtime, and evaluation capabilities through 
 * Evaluation API
 * Health and version endpoints
 
-#### 8.2 Platform integration
+#### 8.2 Platform integration — in progress
 
 * API contracts for web UI and external clients
 * Auth and rate limiting strategy if public endpoints are introduced
 * Request validation and error normalization
 * Deterministic behavior aligned with the library implementations
+
+The version-one contract, initial access policy, request validation rules, and
+normalized response envelope are documented in
+[`docs/engineering/platform-integration.md`](engineering/platform-integration.md).
 
 #### 8.3 Operational concerns
 

--- a/docs/engineering/api.md
+++ b/docs/engineering/api.md
@@ -1476,6 +1476,21 @@ interface ServiceError {
 
 ---
 
+### `ServiceResponseMeta`
+
+```ts
+import { ServiceResponseMeta } from 'hr-skills-build/server'
+```
+
+```ts
+interface ServiceResponseMeta {
+    apiVersion: 'v1';
+    requestId?: string;
+}
+```
+
+---
+
 ### `ServiceResponseSuccess`
 
 ```ts
@@ -1486,7 +1501,7 @@ import { ServiceResponseSuccess } from 'hr-skills-build/server'
 interface ServiceResponseSuccess<T> {
     success: true;
     data: T;
-    meta?: Record<string, unknown>;
+    meta: ServiceResponseMeta;
 }
 ```
 
@@ -1502,6 +1517,7 @@ import { ServiceResponseFailure } from 'hr-skills-build/server'
 interface ServiceResponseFailure {
     success: false;
     error: ServiceError;
+    meta: ServiceResponseMeta;
 }
 ```
 
@@ -5436,6 +5452,176 @@ filter, or if `limit` is not a positive integer.
 
 ---
 
+### `SERVICE_API_VERSION`
+
+```ts
+import { SERVICE_API_VERSION } from 'hr-skills-build/client'
+```
+
+```ts
+const SERVICE_API_VERSION: "v1"
+```
+
+---
+
+### `ServiceOperation`
+
+```ts
+import { ServiceOperation } from 'hr-skills-build/client'
+```
+
+```ts
+type ServiceOperation = | 'health'
+    | 'version'
+    | 'search'
+    | 'planner'
+    | 'runtime'
+    | 'evaluation'
+```
+
+---
+
+### `ServiceAuthentication`
+
+```ts
+import { ServiceAuthentication } from 'hr-skills-build/client'
+```
+
+```ts
+type ServiceAuthentication = 'none' | 'api-key'
+```
+
+---
+
+### `ServiceRateLimit`
+
+```ts
+import { ServiceRateLimit } from 'hr-skills-build/client'
+```
+
+```ts
+interface ServiceRateLimit {
+    readonly maxRequests: number;
+    readonly windowSeconds: number;
+}
+```
+
+---
+
+### `ServiceContract`
+
+```ts
+import { ServiceContract } from 'hr-skills-build/client'
+```
+
+```ts
+interface ServiceContract {
+    readonly operation: ServiceOperation;
+    readonly method: 'GET' | 'POST';
+    readonly path: `/api/${string}`;
+    readonly authentication: ServiceAuthentication;
+    readonly rateLimit: ServiceRateLimit;
+    readonly deterministic: true;
+}
+```
+
+---
+
+### `SERVICE_CONTRACTS`
+
+```ts
+import { SERVICE_CONTRACTS } from 'hr-skills-build/client'
+```
+
+```ts
+const SERVICE_CONTRACTS: readonly ServiceContract[]
+```
+
+---
+
+### `ServiceErrorContract`
+
+```ts
+import { ServiceErrorContract } from 'hr-skills-build/client'
+```
+
+```ts
+interface ServiceErrorContract {
+    readonly code: ServiceErrorCode;
+    readonly message: string;
+    readonly details?: Record<string, unknown>;
+}
+```
+
+---
+
+### `ServiceSuccessContract`
+
+```ts
+import { ServiceSuccessContract } from 'hr-skills-build/client'
+```
+
+```ts
+interface ServiceSuccessContract<T> {
+    readonly success: true;
+    readonly data: T;
+    readonly meta?: {
+        readonly requestId?: string;
+        readonly apiVersion: typeof SERVICE_API_VERSION;
+    };
+}
+```
+
+---
+
+### `ServiceFailureContract`
+
+```ts
+import { ServiceFailureContract } from 'hr-skills-build/client'
+```
+
+```ts
+interface ServiceFailureContract {
+    readonly success: false;
+    readonly error: ServiceErrorContract;
+    readonly meta?: {
+        readonly requestId?: string;
+        readonly apiVersion: typeof SERVICE_API_VERSION;
+    };
+}
+```
+
+---
+
+### `ServiceEnvelope`
+
+```ts
+import { ServiceEnvelope } from 'hr-skills-build/client'
+```
+
+```ts
+type ServiceEnvelope = | ServiceSuccessContract<T>
+    | ServiceFailureContract
+```
+
+---
+
+### `getServiceContract`
+
+```ts
+import { getServiceContract } from 'hr-skills-build/client'
+```
+
+```ts
+function getServiceContract(operation: ServiceOperation): ServiceContract
+```
+
+#### Parameters
+
+- `operation`
+
+---
+
 ### `SearchRequestSchema`
 
 ```ts
@@ -5518,6 +5704,21 @@ interface ServiceError {
 
 ---
 
+### `ServiceResponseMeta`
+
+```ts
+import { ServiceResponseMeta } from 'hr-skills-build/client'
+```
+
+```ts
+interface ServiceResponseMeta {
+    apiVersion: 'v1';
+    requestId?: string;
+}
+```
+
+---
+
 ### `ServiceResponseSuccess`
 
 ```ts
@@ -5528,7 +5729,7 @@ import { ServiceResponseSuccess } from 'hr-skills-build/client'
 interface ServiceResponseSuccess<T> {
     success: true;
     data: T;
-    meta?: Record<string, unknown>;
+    meta: ServiceResponseMeta;
 }
 ```
 
@@ -5544,6 +5745,7 @@ import { ServiceResponseFailure } from 'hr-skills-build/client'
 interface ServiceResponseFailure {
     success: false;
     error: ServiceError;
+    meta: ServiceResponseMeta;
 }
 ```
 

--- a/docs/engineering/package-architecture.md
+++ b/docs/engineering/package-architecture.md
@@ -42,6 +42,10 @@ import { buildRegistry, buildDocumentationData } from 'hr-skills-build/server';
 
 The generated API reference is maintained by `hr-skills-tsdoc`. When public surfaces change, run `bun run api-docs` and verify with `bun run api-docs:check`.
 
+The versioned service contract is documented in
+[`platform-integration.md`](platform-integration.md). It defines the future
+HTTP adapter boundary without adding hosted routes to the library package.
+
 ## Relationship to the roadmap
 
 Client/server boundary hardening is a completion constraint for the package architecture and Phase 7 web platform. Phase 8.1 now provides versioned-library service functions for registry search, planning, workflow execution, evaluation, health, and version responses. Hosted HTTP contracts, authentication, rate limiting, observability, and deployment remain in the later Phase 8 work.

--- a/docs/engineering/platform-integration.md
+++ b/docs/engineering/platform-integration.md
@@ -1,0 +1,113 @@
+# Platform integration
+
+This document defines the Phase 8.2 contract between the HR Skills service
+layer, the web product, and future external clients.
+
+## Current boundary
+
+The repository currently exposes deterministic library services from
+`hr-skills-build/server`. It does not expose hosted HTTP route handlers yet.
+The contract metadata is therefore a stable implementation guide for future
+adapters, not a claim that these URLs are already deployed.
+
+Browser code should continue to use `hr-skills-build/client`. Server loaders
+and future route handlers should use `hr-skills-build/server`. Neither surface
+may import from the other.
+
+## Versioned operations
+
+The browser-safe `SERVICE_CONTRACTS` export from
+`hr-skills-build/client` defines the reserved version-one operations:
+
+| Operation | Method | Path | Authentication | Limit |
+|---|---|---|---|---|
+| Health | `GET` | `/api/v1/health` | None | 60 requests/minute |
+| Version | `GET` | `/api/v1/version` | None | 60 requests/minute |
+| Search | `POST` | `/api/v1/search` | None | 30 requests/minute |
+| Planner | `POST` | `/api/v1/planner` | None | 20 requests/minute |
+| Runtime | `POST` | `/api/v1/runtime` | API key | 10 requests/minute |
+| Evaluation | `POST` | `/api/v1/evaluation` | API key | 5 requests/minute |
+
+The limits are an initial policy for an adapter. A deployment may lower them
+for abuse prevention, but must not silently raise them without documenting the
+change.
+
+## Response envelope
+
+Every adapter must preserve the discriminated response shape:
+
+```json
+{
+  "success": true,
+  "data": {},
+  "meta": {
+    "apiVersion": "v1",
+    "requestId": "req_123"
+  }
+}
+```
+
+Failures use the same envelope discriminator and a normalized error:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid planner request",
+    "details": {}
+  },
+  "meta": {
+    "apiVersion": "v1",
+    "requestId": "req_123"
+  }
+}
+```
+
+Clients must branch on `success`, not on the presence of `data` or
+`error`. Supported error codes are defined by `ServiceErrorCode` and must
+remain stable within a major API version.
+
+## Authentication and rate limiting
+
+Health, version, search, and planner are read-only or bounded computation
+operations and are initially unauthenticated. They remain rate limited and
+must not expose filesystem paths, secrets, or unbounded registry data.
+
+Runtime and evaluation require an API key at the adapter boundary. API keys
+must be supplied through an authorization mechanism managed by the hosting
+platform, never through query parameters or committed configuration. The
+adapter must identify the caller before applying the per-operation limit and
+return a normalized `SERVICE_UNAVAILABLE` response when its rate-limit store
+is unavailable rather than silently disabling the control.
+
+The initial implementation should use a shared, deployment-backed counter
+with a fixed one-minute window. A later deployment may use a token bucket or
+sliding window if it preserves the documented limits and response behavior.
+
+## Validation and determinism
+
+Adapters must validate request bodies with the exported service schemas before
+calling the server services. Invalid input returns `VALIDATION_ERROR`; missing
+required resources return `BAD_REQUEST` or `NOT_FOUND`; execution failures
+must retain their operation-specific error code.
+
+The adapter must pass the validated input to the existing deterministic
+registry, planner, runtime, and evaluation functions. It must not add ranking,
+planning, retries, timestamps, or random identifiers to service results.
+Request IDs may be added to response metadata for tracing only.
+
+## Compatibility policy
+
+- `v1` response fields are additive-compatible: new optional fields may be
+  added, but existing fields and error codes cannot be removed or renamed.
+- Request fields may be added only as optional fields.
+- A breaking request or response change requires a new API version and a
+  changeset for the affected package.
+- Contract tests must cover web-shaped calls and external-client-shaped calls
+  before a hosted adapter is introduced.
+
+See [`package-architecture.md`](package-architecture.md) for package import
+rules and the service exports in
+`packages/hr-skills-build/src/client/service/contracts.ts` for the
+machine-readable contract.

--- a/packages/hr-skills-build/src/client/service/contracts.ts
+++ b/packages/hr-skills-build/src/client/service/contracts.ts
@@ -1,0 +1,116 @@
+import type { ServiceErrorCode } from './types.js';
+
+export const SERVICE_API_VERSION = 'v1' as const;
+
+export type ServiceOperation =
+	| 'health'
+	| 'version'
+	| 'search'
+	| 'planner'
+	| 'runtime'
+	| 'evaluation';
+
+export type ServiceAuthentication = 'none' | 'api-key';
+
+export interface ServiceRateLimit {
+	readonly maxRequests: number;
+	readonly windowSeconds: number;
+}
+
+export interface ServiceContract {
+	readonly operation: ServiceOperation;
+	readonly method: 'GET' | 'POST';
+	readonly path: `/api/${string}`;
+	readonly authentication: ServiceAuthentication;
+	readonly rateLimit: ServiceRateLimit;
+	readonly deterministic: true;
+}
+
+export const SERVICE_CONTRACTS: readonly ServiceContract[] = [
+	{
+		operation: 'health',
+		method: 'GET',
+		path: '/api/v1/health',
+		authentication: 'none',
+		rateLimit: { maxRequests: 60, windowSeconds: 60 },
+		deterministic: true,
+	},
+	{
+		operation: 'version',
+		method: 'GET',
+		path: '/api/v1/version',
+		authentication: 'none',
+		rateLimit: { maxRequests: 60, windowSeconds: 60 },
+		deterministic: true,
+	},
+	{
+		operation: 'search',
+		method: 'POST',
+		path: '/api/v1/search',
+		authentication: 'none',
+		rateLimit: { maxRequests: 30, windowSeconds: 60 },
+		deterministic: true,
+	},
+	{
+		operation: 'planner',
+		method: 'POST',
+		path: '/api/v1/planner',
+		authentication: 'none',
+		rateLimit: { maxRequests: 20, windowSeconds: 60 },
+		deterministic: true,
+	},
+	{
+		operation: 'runtime',
+		method: 'POST',
+		path: '/api/v1/runtime',
+		authentication: 'api-key',
+		rateLimit: { maxRequests: 10, windowSeconds: 60 },
+		deterministic: true,
+	},
+	{
+		operation: 'evaluation',
+		method: 'POST',
+		path: '/api/v1/evaluation',
+		authentication: 'api-key',
+		rateLimit: { maxRequests: 5, windowSeconds: 60 },
+		deterministic: true,
+	},
+] as const;
+
+export interface ServiceErrorContract {
+	readonly code: ServiceErrorCode;
+	readonly message: string;
+	readonly details?: Record<string, unknown>;
+}
+
+export interface ServiceSuccessContract<T> {
+	readonly success: true;
+	readonly data: T;
+	readonly meta?: {
+		readonly requestId?: string;
+		readonly apiVersion: typeof SERVICE_API_VERSION;
+	};
+}
+
+export interface ServiceFailureContract {
+	readonly success: false;
+	readonly error: ServiceErrorContract;
+	readonly meta?: {
+		readonly requestId?: string;
+		readonly apiVersion: typeof SERVICE_API_VERSION;
+	};
+}
+
+export type ServiceEnvelope<T> = ServiceSuccessContract<T> | ServiceFailureContract;
+
+export function getServiceContract(operation: ServiceOperation): ServiceContract {
+	const contract = SERVICE_CONTRACTS.find(
+		(candidate) => candidate.operation === operation,
+	);
+
+	if (!contract) {
+		throw new Error(`Unknown service operation: ${operation}`);
+	}
+
+	return contract;
+}

--- a/packages/hr-skills-build/src/client/service/index.client.ts
+++ b/packages/hr-skills-build/src/client/service/index.client.ts
@@ -1,2 +1,3 @@
+export * from './contracts.js';
 export * from './schemas.js';
 export type * from './types.js';

--- a/packages/hr-skills-build/src/client/service/schemas.ts
+++ b/packages/hr-skills-build/src/client/service/schemas.ts
@@ -18,8 +18,8 @@ export const SearchRequestSchema = v.pipe(
 				]),
 			),
 		),
-		limit: v.optional(v.number()),
-		maxResults: v.optional(v.number()),
+		limit: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+		maxResults: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
 		fuzzy: v.optional(v.boolean()),
 	}),
 	v.transform(

--- a/packages/hr-skills-build/src/client/service/types.ts
+++ b/packages/hr-skills-build/src/client/service/types.ts
@@ -20,15 +20,21 @@ export interface ServiceError {
 	details?: Record<string, unknown>;
 }
 
+export interface ServiceResponseMeta {
+	apiVersion: 'v1';
+	requestId?: string;
+}
+
 export interface ServiceResponseSuccess<T> {
 	success: true;
 	data: T;
-	meta?: Record<string, unknown>;
+	meta: ServiceResponseMeta;
 }
 
 export interface ServiceResponseFailure {
 	success: false;
 	error: ServiceError;
+	meta: ServiceResponseMeta;
 }
 
 export type ServiceResponse<T> = ServiceResponseSuccess<T> | ServiceResponseFailure;

--- a/packages/hr-skills-build/src/server/service/service.ts
+++ b/packages/hr-skills-build/src/server/service/service.ts
@@ -27,6 +27,11 @@ import type {
 import { validateExecutionPlan } from '../validation/validate-planner.js';
 
 const START_TIME = Date.now();
+const API_VERSION = 'v1' as const;
+
+function describeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
 
 export function successResponse<T>(
 	data: T,
@@ -35,7 +40,10 @@ export function successResponse<T>(
 	return {
 		success: true,
 		data,
-		...(meta ? { meta } : {}),
+		meta: {
+			...meta,
+			apiVersion: API_VERSION,
+		},
 	};
 }
 
@@ -50,6 +58,9 @@ export function failureResponse(
 			code,
 			message,
 			...(details ? { details } : {}),
+		},
+		meta: {
+			apiVersion: API_VERSION,
 		},
 	};
 }
@@ -132,8 +143,7 @@ export function searchRegistryService(
 		const searchResult = searchSkills(query, registry);
 		return successResponse(searchResult);
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		return failureResponse('BAD_REQUEST', message);
+		return failureResponse('BAD_REQUEST', describeError(err));
 	}
 }
 
@@ -180,8 +190,10 @@ export async function executeWorkflowService(
 		const result = await executeWorkflow(plan, executor, options.options);
 		return successResponse(result);
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		return failureResponse('RUNTIME_FAILED', `Execution failed: ${message}`);
+		return failureResponse(
+			'RUNTIME_FAILED',
+			`Execution failed: ${describeError(err)}`,
+		);
 	}
 }
 
@@ -206,10 +218,9 @@ export async function runEvaluationService(
 		const report = await runEvaluation(dataset, registry, golden);
 		return successResponse(report);
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
 		return failureResponse(
 			'INTERNAL_ERROR',
-			`Evaluation execution failed: ${message}`,
+			`Evaluation execution failed: ${describeError(err)}`,
 		);
 	}
 }

--- a/packages/hr-skills-build/src/server/service/types.ts
+++ b/packages/hr-skills-build/src/server/service/types.ts
@@ -20,15 +20,21 @@ export interface ServiceError {
 	details?: Record<string, unknown>;
 }
 
+export interface ServiceResponseMeta {
+	apiVersion: 'v1';
+	requestId?: string;
+}
+
 export interface ServiceResponseSuccess<T> {
 	success: true;
 	data: T;
-	meta?: Record<string, unknown>;
+	meta: ServiceResponseMeta;
 }
 
 export interface ServiceResponseFailure {
 	success: false;
 	error: ServiceError;
+	meta: ServiceResponseMeta;
 }
 
 export type ServiceResponse<T> = ServiceResponseSuccess<T> | ServiceResponseFailure;

--- a/packages/hr-skills-build/test/service/contracts.test.ts
+++ b/packages/hr-skills-build/test/service/contracts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	getServiceContract,
+	SERVICE_API_VERSION,
+	SERVICE_CONTRACTS,
+} from '../../src/client/service/contracts.js';
+
+describe('Phase 8.2 service contracts', () => {
+	it('defines every version-one operation with a stable route and policy', () => {
+		expect(SERVICE_API_VERSION).toBe('v1');
+		expect(SERVICE_CONTRACTS).toHaveLength(6);
+		expect(SERVICE_CONTRACTS.every((contract) => contract.deterministic)).toBe(true);
+		expect(SERVICE_CONTRACTS.map((contract) => contract.path)).toEqual([
+			'/api/v1/health',
+			'/api/v1/version',
+			'/api/v1/search',
+			'/api/v1/planner',
+			'/api/v1/runtime',
+			'/api/v1/evaluation',
+		]);
+	});
+
+	it('requires API keys for bounded execution operations', () => {
+		expect(getServiceContract('runtime').authentication).toBe('api-key');
+		expect(getServiceContract('evaluation').authentication).toBe('api-key');
+		expect(getServiceContract('search').authentication).toBe('none');
+	});
+
+	it('throws for unknown operations instead of returning a silent fallback', () => {
+		expect(() => getServiceContract('unknown' as never)).toThrow(
+			'Unknown service operation: unknown',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Implements the Phase 8.2 platform integration contract for the service layer.

- Adds versioned `v1` operation metadata for web and external clients.
- Adds stable success/error response envelopes with API version metadata.
- Tightens request validation for search limits and documents normalized errors.
- Documents authentication, rate limiting, determinism, and compatibility policy.
- Adds contract tests and a `hr-skills-build` changeset.

## Validation

- `bun test packages/hr-skills-build/test/service`
- `bun run typecheck`
- `bun run validate`
- `bun run api-docs:check`
- `bun run lint:md`
- `bun run lint:links`

Closes #227
