### PR TITLE
feat(packages): add operational service primitives

### DIFF
--- a/.changeset/operational-concerns.md
+++ b/.changeset/operational-concerns.md
@@ -1,0 +1,5 @@
+---
+"hr-skills-build": minor
+---
+
+Added cache, structured observability, readiness checks, and operational guidance for service deployments.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -431,7 +431,7 @@ Phase 7 provides a public web product and browser-safe library integration, but 
 
 ### Phase 8 — API & Services
 
-**Status: In progress.** Phase 8.1 is implemented as a versioned-library service layer. Hosted HTTP contracts and operational concerns remain in 8.2 and 8.3.
+**Status: In progress.** Phase 8.1 and 8.2 are implemented as versioned-library service and platform-integration layers. Operational concerns remain in 8.3.
 
 Expose the core registry, planner, runtime, and evaluation capabilities through stable service interfaces.
 
@@ -443,7 +443,7 @@ Expose the core registry, planner, runtime, and evaluation capabilities through 
 * Evaluation API
 * Health and version endpoints
 
-#### 8.2 Platform integration — in progress
+#### 8.2 Platform integration — completed
 
 * API contracts for web UI and external clients
 * Auth and rate limiting strategy if public endpoints are introduced
@@ -454,12 +454,16 @@ The version-one contract, initial access policy, request validation rules, and
 normalized response envelope are documented in
 [`docs/engineering/platform-integration.md`](engineering/platform-integration.md).
 
-#### 8.3 Operational concerns
+#### 8.3 Operational concerns — in progress
 
 * Caching strategy for registry and evaluation artifacts
 * Observability and structured logs
 * Backward-compatible versioning for public endpoints
 * Deployment guidance for self-hosted and managed environments
+
+The operational cache, observability, readiness, compatibility, and deployment
+guidance is documented in
+[`docs/engineering/operations.md`](engineering/operations.md).
 
 ---
 

--- a/docs/engineering/api.md
+++ b/docs/engineering/api.md
@@ -359,6 +359,259 @@ All committed golden fixtures, sorted by dataset name.
 
 ---
 
+### `VersionedCache`
+
+```ts
+import { VersionedCache } from 'hr-skills-build/server'
+```
+
+```ts
+interface VersionedCache<T> {
+    get(key: string, version: string): T | undefined;
+    set(key: string, version: string, value: T): void;
+    invalidate(key: string): boolean;
+    clear(): void;
+    readonly size: number;
+}
+```
+
+---
+
+### `createVersionedCache`
+
+```ts
+import { createVersionedCache } from 'hr-skills-build/server'
+```
+
+```ts
+function createVersionedCache(): VersionedCache<T>
+```
+
+---
+
+### `createRegistryCache`
+
+```ts
+import { createRegistryCache } from 'hr-skills-build/server'
+```
+
+```ts
+function createRegistryCache(): VersionedCache<T>
+```
+
+---
+
+### `createEvaluationCache`
+
+```ts
+import { createEvaluationCache } from 'hr-skills-build/server'
+```
+
+```ts
+function createEvaluationCache(): VersionedCache<T>
+```
+
+---
+
+### `ServiceLogLevel`
+
+```ts
+import { ServiceLogLevel } from 'hr-skills-build/server'
+```
+
+```ts
+type ServiceLogLevel = 'info' | 'warn' | 'error'
+```
+
+---
+
+### `ServiceLogEvent`
+
+```ts
+import { ServiceLogEvent } from 'hr-skills-build/server'
+```
+
+```ts
+interface ServiceLogEvent {
+    readonly level: ServiceLogLevel;
+    readonly event: string;
+    readonly timestamp: string;
+    readonly operation?: string;
+    readonly requestId?: string;
+    readonly durationMs?: number;
+    readonly details?: Record<string, unknown>;
+}
+```
+
+---
+
+### `ServiceLogSink`
+
+```ts
+import { ServiceLogSink } from 'hr-skills-build/server'
+```
+
+```ts
+function ServiceLogSink(event: ServiceLogEvent): void
+```
+
+#### Parameters
+
+- `event`
+
+---
+
+### `StructuredServiceLogger`
+
+```ts
+import { StructuredServiceLogger } from 'hr-skills-build/server'
+```
+
+```ts
+interface StructuredServiceLogger {
+    log(
+        level: ServiceLogLevel,
+        event: string,
+        context?: Omit<ServiceLogEvent, 'level' | 'event' | 'timestamp'>,
+    ): void;
+    info(
+        event: string,
+        context?: Omit<ServiceLogEvent, 'level' | 'event' | 'timestamp'>,
+    ): void;
+    warn(
+        event: string,
+        context?: Omit<ServiceLogEvent, 'level' | 'event' | 'timestamp'>,
+    ): void;
+    error(
+        event: string,
+        context?: Omit<ServiceLogEvent, 'level' | 'event' | 'timestamp'>,
+    ): void;
+}
+```
+
+---
+
+### `createStructuredLogger`
+
+```ts
+import { createStructuredLogger } from 'hr-skills-build/server'
+```
+
+```ts
+function createStructuredLogger(sink: ServiceLogSink, now?: () => string): StructuredServiceLogger
+```
+
+#### Parameters
+
+- `sink`
+- `now` (optional)
+
+---
+
+### `ServiceMetricSnapshot`
+
+```ts
+import { ServiceMetricSnapshot } from 'hr-skills-build/server'
+```
+
+```ts
+interface ServiceMetricSnapshot {
+    readonly counters: Readonly<Record<string, number>>;
+}
+```
+
+---
+
+### `ServiceMetrics`
+
+```ts
+import { ServiceMetrics } from 'hr-skills-build/server'
+```
+
+```ts
+interface ServiceMetrics {
+    increment(name: string, value?: number): void;
+    snapshot(): ServiceMetricSnapshot;
+    reset(): void;
+}
+```
+
+---
+
+### `createServiceMetrics`
+
+```ts
+import { createServiceMetrics } from 'hr-skills-build/server'
+```
+
+```ts
+function createServiceMetrics(): ServiceMetrics
+```
+
+---
+
+### `ReadinessCheck`
+
+```ts
+import { ReadinessCheck } from 'hr-skills-build/server'
+```
+
+```ts
+interface ReadinessCheck {
+    readonly name: string;
+    readonly status: 'ready' | 'not_ready';
+    readonly message?: string;
+}
+```
+
+---
+
+### `ReadinessStatus`
+
+```ts
+import { ReadinessStatus } from 'hr-skills-build/server'
+```
+
+```ts
+interface ReadinessStatus {
+    readonly status: 'ready' | 'not_ready';
+    readonly checks: readonly ReadinessCheck[];
+}
+```
+
+---
+
+### `ReadinessDependency`
+
+```ts
+import { ReadinessDependency } from 'hr-skills-build/server'
+```
+
+```ts
+interface ReadinessDependency {
+    readonly name: string;
+    readonly check: () => boolean | Promise<boolean>;
+}
+```
+
+---
+
+### `getReadinessService`
+
+```ts
+import { getReadinessService } from 'hr-skills-build/server'
+```
+
+```ts
+function getReadinessService(dependencies: readonly ReadinessDependency[]): Promise<ServiceResponse<ReadinessStatus>>
+```
+
+#### Parameters
+
+- `dependencies`
+
+---
+
 ### `analyzeIntent`
 
 ```ts
@@ -5600,8 +5853,7 @@ import { ServiceEnvelope } from 'hr-skills-build/client'
 ```
 
 ```ts
-type ServiceEnvelope = | ServiceSuccessContract<T>
-    | ServiceFailureContract
+type ServiceEnvelope = ServiceSuccessContract<T> | ServiceFailureContract
 ```
 
 ---

--- a/docs/engineering/operations.md
+++ b/docs/engineering/operations.md
@@ -1,0 +1,83 @@
+# Operational concerns
+
+This document defines the operational behavior for Phase 8.3. The current
+repository provides library-level operational primitives; deployment adapters
+remain responsible for connecting them to a cache, log collector, metrics
+backend, and hosting platform.
+
+## Artifact caching
+
+Registry and evaluation artifacts use separate versioned caches from
+`hr-skills-build/server`:
+
+- Registry entries are keyed by the committed registry version, normally
+  `registry.generatedAt` plus the registry schema version.
+- Evaluation reports are keyed by the dataset name, dataset version, golden
+  fixture version, and registry version.
+- A version mismatch is a cache miss. The old value is never returned for a
+  newer source version.
+- Deployments must invalidate both caches when the registry schema or
+  evaluation fixture format changes.
+
+The cache primitives do not add time-based expiry. Deployments may add a TTL
+for resource protection, but version checks remain mandatory so identical
+inputs continue to produce deterministic results.
+
+## Logging and metrics
+
+`createStructuredLogger()` emits JSON-compatible events with a stable event
+name, level, timestamp, operation, request ID, duration, and optional details.
+Production adapters should send these events to their structured log backend
+and must redact API keys, skill content, prompts, and personal data.
+
+`createServiceMetrics()` provides counters for request totals, validation
+failures, service failures, cache hits, cache misses, and readiness failures.
+Adapters should publish snapshots to their metrics system and include the
+operation and API version in metric dimensions.
+
+## Readiness and failure recovery
+
+`getReadinessService()` checks deployment dependencies such as registry loading,
+cache availability, and required configuration. A failed dependency returns
+`SERVICE_UNAVAILABLE` with the failing checks and API version in the response
+metadata. Health is a liveness signal; readiness is the signal used by a load
+balancer before sending traffic.
+
+Adapters should remove an instance from rotation when readiness fails, retry
+transient dependency recovery with bounded backoff, and preserve the last
+known-good immutable registry artifact when a refresh fails. They must not
+silently serve a newer partial registry.
+
+## Version compatibility
+
+Public routes use the `/api/v1/` prefix. Within `v1`:
+
+- Existing response fields and error codes are never removed or renamed.
+- New response fields must be optional.
+- New request fields must be optional and ignored by older consumers.
+- Breaking changes require a new route version, migration notes, tests, and a
+  changeset for the affected package.
+- The service API version in every response must match the route version.
+
+## Deployment guidance
+
+### Self-hosted
+
+Run the service adapter beside the Bun/Node server package. Store API keys and
+cache credentials in the deployment secret manager, terminate TLS at the
+trusted edge, and use a shared cache when multiple instances serve traffic.
+Use the readiness check for process supervision and graceful rollout.
+
+### Managed
+
+Use the platform's secret store, request tracing, rate-limit store, and
+deployment health checks. Pin the package version and registry artifact
+together, deploy immutable builds, and retain structured logs and metrics for
+the configured retention period. Do not rely on local filesystem state for
+cross-instance cache or recovery behavior.
+
+## Operational test matrix
+
+Adapters must test cache version changes, cold starts, stale artifacts,
+dependency failure, log redaction, metric increments, readiness transitions,
+and old-client compatibility with additive response fields.

--- a/packages/hr-skills-build/src/server/index.ts
+++ b/packages/hr-skills-build/src/server/index.ts
@@ -6,6 +6,7 @@
  */
 export * from './docs/index.js';
 export * from './evaluation/index.js';
+export * from './operations/index.js';
 export * from './planner/index.js';
 export * from './registry/index.js';
 export * from './runtime/index.js';

--- a/packages/hr-skills-build/src/server/operations/cache.ts
+++ b/packages/hr-skills-build/src/server/operations/cache.ts
@@ -1,0 +1,43 @@
+export interface VersionedCache<T> {
+	get(key: string, version: string): T | undefined;
+	set(key: string, version: string, value: T): void;
+	invalidate(key: string): boolean;
+	clear(): void;
+	readonly size: number;
+}
+
+interface CacheEntry<T> {
+	readonly version: string;
+	readonly value: T;
+}
+
+export function createVersionedCache<T>(): VersionedCache<T> {
+	const entries = new Map<string, CacheEntry<T>>();
+
+	return {
+		get(key, version) {
+			const entry = entries.get(key);
+			return entry?.version === version ? entry.value : undefined;
+		},
+		set(key, version, value) {
+			entries.set(key, { version, value });
+		},
+		invalidate(key) {
+			return entries.delete(key);
+		},
+		clear() {
+			entries.clear();
+		},
+		get size() {
+			return entries.size;
+		},
+	};
+}
+
+export function createRegistryCache<T>(): VersionedCache<T> {
+	return createVersionedCache<T>();
+}
+
+export function createEvaluationCache<T>(): VersionedCache<T> {
+	return createVersionedCache<T>();
+}

--- a/packages/hr-skills-build/src/server/operations/index.ts
+++ b/packages/hr-skills-build/src/server/operations/index.ts
@@ -1,0 +1,3 @@
+export * from './cache.js';
+export * from './observability.js';
+export * from './readiness.js';

--- a/packages/hr-skills-build/src/server/operations/observability.ts
+++ b/packages/hr-skills-build/src/server/operations/observability.ts
@@ -1,0 +1,79 @@
+export type ServiceLogLevel = 'info' | 'warn' | 'error';
+
+export interface ServiceLogEvent {
+	readonly level: ServiceLogLevel;
+	readonly event: string;
+	readonly timestamp: string;
+	readonly operation?: string;
+	readonly requestId?: string;
+	readonly durationMs?: number;
+	readonly details?: Record<string, unknown>;
+}
+
+export type ServiceLogSink = (event: ServiceLogEvent) => void;
+
+export interface StructuredServiceLogger {
+	log(
+		level: ServiceLogLevel,
+		event: string,
+		context?: Omit<ServiceLogEvent, 'level' | 'event' | 'timestamp'>,
+	): void;
+	info(
+		event: string,
+		context?: Omit<ServiceLogEvent, 'level' | 'event' | 'timestamp'>,
+	): void;
+	warn(
+		event: string,
+		context?: Omit<ServiceLogEvent, 'level' | 'event' | 'timestamp'>,
+	): void;
+	error(
+		event: string,
+		context?: Omit<ServiceLogEvent, 'level' | 'event' | 'timestamp'>,
+	): void;
+}
+
+export function createStructuredLogger(
+	sink: ServiceLogSink,
+	now: () => string = () => new Date().toISOString(),
+): StructuredServiceLogger {
+	function log(
+		level: ServiceLogLevel,
+		event: string,
+		context: Omit<ServiceLogEvent, 'level' | 'event' | 'timestamp'> = {},
+	): void {
+		sink({ level, event, timestamp: now(), ...context });
+	}
+
+	return {
+		log,
+		info: (event, context) => log('info', event, context),
+		warn: (event, context) => log('warn', event, context),
+		error: (event, context) => log('error', event, context),
+	};
+}
+
+export interface ServiceMetricSnapshot {
+	readonly counters: Readonly<Record<string, number>>;
+}
+
+export interface ServiceMetrics {
+	increment(name: string, value?: number): void;
+	snapshot(): ServiceMetricSnapshot;
+	reset(): void;
+}
+
+export function createServiceMetrics(): ServiceMetrics {
+	const counters = new Map<string, number>();
+
+	return {
+		increment(name, value = 1) {
+			counters.set(name, (counters.get(name) ?? 0) + value);
+		},
+		snapshot() {
+			return { counters: Object.fromEntries(counters) };
+		},
+		reset() {
+			counters.clear();
+		},
+	};
+}

--- a/packages/hr-skills-build/src/server/operations/readiness.ts
+++ b/packages/hr-skills-build/src/server/operations/readiness.ts
@@ -1,0 +1,53 @@
+import { failureResponse, successResponse } from '../service/service.js';
+import type { ServiceResponse } from '../service/types.js';
+
+export interface ReadinessCheck {
+	readonly name: string;
+	readonly status: 'ready' | 'not_ready';
+	readonly message?: string;
+}
+
+export interface ReadinessStatus {
+	readonly status: 'ready' | 'not_ready';
+	readonly checks: readonly ReadinessCheck[];
+}
+
+export interface ReadinessDependency {
+	readonly name: string;
+	readonly check: () => boolean | Promise<boolean>;
+}
+
+export async function getReadinessService(
+	dependencies: readonly ReadinessDependency[],
+): Promise<ServiceResponse<ReadinessStatus>> {
+	const checks: ReadinessCheck[] = [];
+
+	for (const dependency of dependencies) {
+		try {
+			const ready = await dependency.check();
+			checks.push({
+				name: dependency.name,
+				status: ready ? 'ready' : 'not_ready',
+				...(ready ? {} : { message: 'Dependency is not ready' }),
+			});
+		} catch (error) {
+			checks.push({
+				name: dependency.name,
+				status: 'not_ready',
+				message: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	const ready = checks.every((check) => check.status === 'ready');
+	const status: ReadinessStatus = {
+		status: ready ? 'ready' : 'not_ready',
+		checks,
+	};
+
+	return ready
+		? successResponse(status)
+		: failureResponse('SERVICE_UNAVAILABLE', 'Service is not ready', {
+				checks,
+			});
+}

--- a/packages/hr-skills-build/test/service/operations.test.ts
+++ b/packages/hr-skills-build/test/service/operations.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test';
+import type { ServiceLogEvent } from '../../src/server/operations/index.js';
+import {
+	createEvaluationCache,
+	createRegistryCache,
+	createServiceMetrics,
+	createStructuredLogger,
+	getReadinessService,
+} from '../../src/server/operations/index.js';
+
+describe('Phase 8.3 operational concerns', () => {
+	it('invalidates cached artifacts when their source version changes', () => {
+		const cache = createRegistryCache<{ skills: number }>();
+		cache.set('registry', 'generated-at-1', { skills: 146 });
+
+		expect(cache.get('registry', 'generated-at-1')).toEqual({ skills: 146 });
+		expect(cache.get('registry', 'generated-at-2')).toBeUndefined();
+		expect(cache.size).toBe(1);
+		cache.invalidate('registry');
+		expect(cache.size).toBe(0);
+	});
+
+	it('keeps evaluation artifacts in a separate cache', () => {
+		const registryCache = createRegistryCache<string>();
+		const evaluationCache = createEvaluationCache<string>();
+		registryCache.set('artifact', 'v1', 'registry');
+		evaluationCache.set('artifact', 'v1', 'evaluation');
+
+		expect(registryCache.get('artifact', 'v1')).toBe('registry');
+		expect(evaluationCache.get('artifact', 'v1')).toBe('evaluation');
+	});
+
+	it('emits structured logs and deterministic metric snapshots', () => {
+		const events: ServiceLogEvent[] = [];
+		const logger = createStructuredLogger(
+			(event) => events.push(event),
+			() => '2026-09-10T00:00:00.000Z',
+		);
+		const metrics = createServiceMetrics();
+
+		logger.info('service.request.completed', {
+			operation: 'search',
+			durationMs: 12,
+		});
+		metrics.increment('service.requests');
+		metrics.increment('service.requests', 2);
+
+		expect(events[0]).toMatchObject({
+			level: 'info',
+			event: 'service.request.completed',
+			timestamp: '2026-09-10T00:00:00.000Z',
+			operation: 'search',
+			durationMs: 12,
+		});
+		expect(metrics.snapshot()).toEqual({
+			counters: { 'service.requests': 3 },
+		});
+	});
+
+	it('returns a normalized unavailable response for failed readiness checks', async () => {
+		const response = await getReadinessService([
+			{ name: 'registry', check: () => true },
+			{ name: 'cache', check: () => false },
+		]);
+
+		expect(response.success).toBe(false);
+		if (!response.success) {
+			expect(response.error.code).toBe('SERVICE_UNAVAILABLE');
+			expect(response.meta.apiVersion).toBe('v1');
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- add versioned registry and evaluation caches
- add structured logging, metrics, and readiness primitives
- document compatibility and self-hosted/managed deployment guidance
- update generated API docs and roadmap for Phase 8.3

Closes #228

## Validation
- bun run build
- bun run typecheck
- bun run validate
- bun run api-docs:check
- bun run lint:md
- bun run lint:links
- bun test packages/hr-skills-build/test/service
- jscpd operational sources