### PR TITLE
fix(packages): align Phase 8 service contracts

### DIFF
--- a/.changeset/phase-8-readiness-contract.md
+++ b/.changeset/phase-8-readiness-contract.md
@@ -1,0 +1,5 @@
+---
+"hr-skills-build": minor
+---
+
+Added the version-one readiness contract and aligned client response envelopes with the required API metadata.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -431,7 +431,7 @@ Phase 7 provides a public web product and browser-safe library integration, but 
 
 ### Phase 8 — API & Services
 
-**Status: In progress.** Phase 8.1 and 8.2 are implemented as versioned-library service and platform-integration layers. Operational concerns remain in 8.3.
+**Status: In progress.** Phase 8.1–8.3 are implemented as versioned-library service, platform-integration, and operational layers. A hosted HTTP adapter remains deployment-specific and is not included in the library packages.
 
 Expose the core registry, planner, runtime, and evaluation capabilities through stable service interfaces.
 
@@ -454,7 +454,7 @@ The version-one contract, initial access policy, request validation rules, and
 normalized response envelope are documented in
 [`docs/engineering/platform-integration.md`](engineering/platform-integration.md).
 
-#### 8.3 Operational concerns — in progress
+#### 8.3 Operational concerns — completed
 
 * Caching strategy for registry and evaluation artifacts
 * Observability and structured logs

--- a/docs/engineering/api.md
+++ b/docs/engineering/api.md
@@ -1823,6 +1823,7 @@ interface VersionInfo {
     phase: string;
     apiVersions: {
         health: string;
+        readiness: string;
         version: string;
         search: string;
         planner: string;
@@ -5725,6 +5726,7 @@ import { ServiceOperation } from 'hr-skills-build/client'
 
 ```ts
 type ServiceOperation = | 'health'
+    | 'readiness'
     | 'version'
     | 'search'
     | 'planner'
@@ -5818,7 +5820,7 @@ import { ServiceSuccessContract } from 'hr-skills-build/client'
 interface ServiceSuccessContract<T> {
     readonly success: true;
     readonly data: T;
-    readonly meta?: {
+    readonly meta: {
         readonly requestId?: string;
         readonly apiVersion: typeof SERVICE_API_VERSION;
     };
@@ -5837,7 +5839,7 @@ import { ServiceFailureContract } from 'hr-skills-build/client'
 interface ServiceFailureContract {
     readonly success: false;
     readonly error: ServiceErrorContract;
-    readonly meta?: {
+    readonly meta: {
         readonly requestId?: string;
         readonly apiVersion: typeof SERVICE_API_VERSION;
     };

--- a/docs/engineering/operations.md
+++ b/docs/engineering/operations.md
@@ -43,6 +43,9 @@ cache availability, and required configuration. A failed dependency returns
 metadata. Health is a liveness signal; readiness is the signal used by a load
 balancer before sending traffic.
 
+HTTP adapters should expose this check through the reserved `GET /api/v1/ready`
+contract and keep it unauthenticated but rate limited.
+
 Adapters should remove an instance from rotation when readiness fails, retry
 transient dependency recovery with bounded backoff, and preserve the last
 known-good immutable registry artifact when a refresh fails. They must not

--- a/docs/engineering/package-architecture.md
+++ b/docs/engineering/package-architecture.md
@@ -48,4 +48,4 @@ HTTP adapter boundary without adding hosted routes to the library package.
 
 ## Relationship to the roadmap
 
-Client/server boundary hardening is a completion constraint for the package architecture and Phase 7 web platform. Phase 8.1 now provides versioned-library service functions for registry search, planning, workflow execution, evaluation, health, and version responses. Hosted HTTP contracts, authentication, rate limiting, observability, and deployment remain in the later Phase 8 work.
+Client/server boundary hardening is a completion constraint for the package architecture and Phase 7 web platform. Phase 8.1 now provides versioned-library service functions for registry search, planning, workflow execution, evaluation, health, and version responses. Phase 8.2 and 8.3 define the versioned HTTP contract, access policy, observability, readiness, and deployment guidance; a hosted HTTP adapter remains deployment-specific and is not included in these library packages.

--- a/docs/engineering/platform-integration.md
+++ b/docs/engineering/platform-integration.md
@@ -22,6 +22,7 @@ The browser-safe `SERVICE_CONTRACTS` export from
 | Operation | Method | Path | Authentication | Limit |
 |---|---|---|---|---|
 | Health | `GET` | `/api/v1/health` | None | 60 requests/minute |
+| Readiness | `GET` | `/api/v1/ready` | None | 60 requests/minute |
 | Version | `GET` | `/api/v1/version` | None | 60 requests/minute |
 | Search | `POST` | `/api/v1/search` | None | 30 requests/minute |
 | Planner | `POST` | `/api/v1/planner` | None | 20 requests/minute |

--- a/packages/hr-skills-build/src/client/service/contracts.ts
+++ b/packages/hr-skills-build/src/client/service/contracts.ts
@@ -4,6 +4,7 @@ export const SERVICE_API_VERSION = 'v1' as const;
 
 export type ServiceOperation =
 	| 'health'
+	| 'readiness'
 	| 'version'
 	| 'search'
 	| 'planner'
@@ -31,6 +32,14 @@ export const SERVICE_CONTRACTS: readonly ServiceContract[] = [
 		operation: 'health',
 		method: 'GET',
 		path: '/api/v1/health',
+		authentication: 'none',
+		rateLimit: { maxRequests: 60, windowSeconds: 60 },
+		deterministic: true,
+	},
+	{
+		operation: 'readiness',
+		method: 'GET',
+		path: '/api/v1/ready',
 		authentication: 'none',
 		rateLimit: { maxRequests: 60, windowSeconds: 60 },
 		deterministic: true,
@@ -86,7 +95,7 @@ export interface ServiceErrorContract {
 export interface ServiceSuccessContract<T> {
 	readonly success: true;
 	readonly data: T;
-	readonly meta?: {
+	readonly meta: {
 		readonly requestId?: string;
 		readonly apiVersion: typeof SERVICE_API_VERSION;
 	};
@@ -95,7 +104,7 @@ export interface ServiceSuccessContract<T> {
 export interface ServiceFailureContract {
 	readonly success: false;
 	readonly error: ServiceErrorContract;
-	readonly meta?: {
+	readonly meta: {
 		readonly requestId?: string;
 		readonly apiVersion: typeof SERVICE_API_VERSION;
 	};

--- a/packages/hr-skills-build/src/server/service/service.ts
+++ b/packages/hr-skills-build/src/server/service/service.ts
@@ -110,6 +110,7 @@ export function getVersionService(): ServiceResponse<VersionInfo> {
 		phase: 'Phase 8.1 — Service layer',
 		apiVersions: {
 			health: 'v1',
+			readiness: 'v1',
 			version: 'v1',
 			search: 'v1',
 			planner: 'v1',

--- a/packages/hr-skills-build/src/server/service/types.ts
+++ b/packages/hr-skills-build/src/server/service/types.ts
@@ -57,6 +57,7 @@ export interface VersionInfo {
 	phase: string;
 	apiVersions: {
 		health: string;
+		readiness: string;
 		version: string;
 		search: string;
 		planner: string;

--- a/packages/hr-skills-build/test/service/contracts.test.ts
+++ b/packages/hr-skills-build/test/service/contracts.test.ts
@@ -8,10 +8,11 @@ import {
 describe('Phase 8.2 service contracts', () => {
 	it('defines every version-one operation with a stable route and policy', () => {
 		expect(SERVICE_API_VERSION).toBe('v1');
-		expect(SERVICE_CONTRACTS).toHaveLength(6);
+		expect(SERVICE_CONTRACTS).toHaveLength(7);
 		expect(SERVICE_CONTRACTS.every((contract) => contract.deterministic)).toBe(true);
 		expect(SERVICE_CONTRACTS.map((contract) => contract.path)).toEqual([
 			'/api/v1/health',
+			'/api/v1/ready',
 			'/api/v1/version',
 			'/api/v1/search',
 			'/api/v1/planner',
@@ -24,6 +25,7 @@ describe('Phase 8.2 service contracts', () => {
 		expect(getServiceContract('runtime').authentication).toBe('api-key');
 		expect(getServiceContract('evaluation').authentication).toBe('api-key');
 		expect(getServiceContract('search').authentication).toBe('none');
+		expect(getServiceContract('readiness').authentication).toBe('none');
 	});
 
 	it('throws for unknown operations instead of returning a silent fallback', () => {

--- a/packages/hr-skills-build/test/service/service.test.ts
+++ b/packages/hr-skills-build/test/service/service.test.ts
@@ -69,6 +69,7 @@ describe('Service Layer — Phase 8.1', () => {
 				expect(res.data.name).toBe('hr-skills-service');
 				expect(res.data.phase).toContain('Phase 8.1');
 				expect(res.data.apiVersions.health).toBe('v1');
+				expect(res.data.apiVersions.readiness).toBe('v1');
 			}
 		});
 	});
@@ -136,13 +137,12 @@ describe('Service Layer — Phase 8.1', () => {
 	});
 
 	describe('executeWorkflowService', () => {
-		it('fails on null or invalid plan structure', () => {
-			executeWorkflowService(null as unknown as ExecutionPlan).then((res) => {
-				expect(res.success).toBe(false);
-				if (!res.success) {
-					expect(res.error.code).toBe('BAD_REQUEST');
-				}
-			});
+		it('fails on null or invalid plan structure', async () => {
+			const res = await executeWorkflowService(null as unknown as ExecutionPlan);
+			expect(res.success).toBe(false);
+			if (!res.success) {
+				expect(res.error.code).toBe('BAD_REQUEST');
+			}
 		});
 
 		it('executes workflow plan successfully', async () => {


### PR DESCRIPTION
## Summary
- add the reserved v1 readiness contract at `/api/v1/ready`
- require API metadata in client response contracts
- fix the async Phase 8.1 regression test so invalid plans are awaited
- clarify roadmap and package architecture boundaries for deployment-specific HTTP adapters

## Validation
- Phase 8 service tests
- typecheck
- API docs generation/check
- Markdown/link checks
- Biome and pre-push Knip