### PR TITLE
test(repo): cover playground server and web e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,39 @@
+name: End-to-end
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  e2e:
+    name: Playwright (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [chromium, mobile-chromium]
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.13.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run end-to-end tests
+        run: bun run test:e2e -- -- --project=${{ matrix.project }}

--- a/README.md
+++ b/README.md
@@ -170,9 +170,14 @@ Quality commands:
 ```bash
 bun run lint
 bun run lint:md
+bun run test:e2e
 bun run typecheck
 bun run check
 ```
+
+The `playground/next-app` and `playground/vite-app` projects provide browser
+smoke tests for the explicit `hr-skills-build/client` and
+`hr-skills-build/server` package surfaces.
 
 Release commands:
 

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -162,6 +162,8 @@ maintainer's responsibility when reviewing the release PR.
       `test.yml`, on both `ubuntu-latest` and `windows-latest`)
 - [ ] `bun run lint`, `bun run lint:md`, and `bun run lint:links` pass
       (`lint.yml`)
+- [ ] `bun run test:e2e` passes for Chromium and mobile Chromium
+      (`e2e.yml`)
 - [ ] `bun run knip` reports no unused files or dependencies (`knip.yml`)
 - [ ] Every pending `.changeset/*.md` file is consumed and reflected in the
       generated `CHANGELOG.md` diff

--- a/playground/next-app/app/page.tsx
+++ b/playground/next-app/app/page.tsx
@@ -1,19 +1,12 @@
+import { getReadinessService, getVersionService } from 'hr-skills-build/server';
 import { ClientWidget } from './client-widget';
 
-// Note: a Server Component calling a full fs-backed export like
-// `buildRegistry()` from 'hr-skills-build/server' hits an unrelated,
-// pre-existing issue: `hr-skills-ref` resolves `ROOT_DIR` from `process.cwd()`
-// at module load time, which Next's webpack server bundling does not evaluate
-// correctly for an externalized workspace package symlinked outside
-// `next-app/`. Nothing here works around it — there is deliberately no
-// `next.config.ts`, because the server path is out of scope for this
-// playground. That's a Next.js/ESM interop wrinkle
-// in `hr-skills-ref`, not something the client/server split changed — the fs
-// path is already covered by `bun test` / `bun run validate` in
-// `packages/hr-skills-build`. What this playground exists to prove is the
-// part that's actually new and risky: that `hr-skills-build/client` bundles
-// cleanly for the browser. See `client-widget.tsx`.
-export default function Page() {
+export default async function Page() {
+	const version = getVersionService();
+	const readiness = await getReadinessService([
+		{ name: 'playground', check: () => true },
+	]);
+
 	return (
 		<main style={{ fontFamily: 'monospace', padding: 24 }}>
 			<h1>hr-skills-build playground (Next.js)</h1>
@@ -21,6 +14,18 @@ export default function Page() {
 			<section>
 				<h2>Client: parseSkillFrontmatter() via hr-skills-build/client</h2>
 				<ClientWidget />
+			</section>
+
+			<section>
+				<h2>Server: version and readiness via hr-skills-build/server</h2>
+				<pre
+					style={{
+						whiteSpace: 'pre-wrap',
+						maxWidth: '100%',
+						overflowX: 'auto',
+					}}>
+					{JSON.stringify({ version, readiness }, null, 2)}
+				</pre>
 			</section>
 		</main>
 	);


### PR DESCRIPTION
## Summary
- exercise `hr-skills-build/server` version and readiness services in the Next playground
- keep the Vite and Next playgrounds as client/server smoke coverage
- add a dedicated Playwright CI workflow for desktop and mobile Chromium
- document E2E and playground validation in the README and release checklist

## Validation
- workspace build
- workspace tests
- typecheck
- Biome, Markdown, links, and Knip
- both playground builds

Local Playwright execution is blocked by the macOS 12 browser support limitation; CI installs Chromium on Ubuntu.